### PR TITLE
Fix windows line ending issue in mesh-task

### DIFF
--- a/terraform/modules/mesh-task/main.tf
+++ b/terraform/modules/mesh-task/main.tf
@@ -118,14 +118,14 @@ resource "aws_ecs_task_definition" "this" {
             ]
             logConfiguration = var.log_configuration
             entryPoint       = ["/bin/sh", "-ec"]
-            command = [
+            command = [replace(
               templatefile(
                 "${path.module}/templates/consul_client_command.tpl",
                 {
                   dev_server_enabled = var.dev_server_enabled
                   retry_join         = var.retry_join
                 }
-              )
+              ), "\r", "")
             ]
             mountPoints = [
               local.consul_data_mount


### PR DESCRIPTION
Running `terraform apply` from a Windows machine results in CRLF chars being added to the `command` of the consul-client container. Wrapping the command value in `replace()`, similar to what's done within the [server module](https://github.com/hashicorp/consul-ecs/blob/main/terraform/modules/server/main.tf#L62), prevents these from ending up in the resulting task definition.

### Testing

Before change:
![image](https://user-images.githubusercontent.com/34254888/119033054-a2d89000-b961-11eb-9842-732f38ce35be.png)

After change:
![image](https://user-images.githubusercontent.com/34254888/119033195-cac7f380-b961-11eb-8943-bdb51de6dc80.png)
