### PR TITLE
Add user agent handler

### DIFF
--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -5,8 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"runtime"
 	"os"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/hashicorp/consul-ecs/version"
 )
 
 const ecsMetadataURIEnvVar = "ECS_CONTAINER_METADATA_URI_V4"
@@ -44,4 +48,15 @@ func ECSTaskMetadata() (ECSTaskMeta, error) {
 		return metadataResp, fmt.Errorf("unmarshalling metadata uri response: %s", err)
 	}
 	return metadataResp, nil
+}
+
+func UserAgentHandler(caller string) request.NamedHandler {
+	return request.NamedHandler{
+		Name: "UserAgentHandler",
+		Fn: func(r *request.Request) {
+			userAgent := r.HTTPRequest.Header.Get("User-Agent")
+			r.HTTPRequest.Header.Set("User-Agent",
+				fmt.Sprintf("consul-ecs-%s/%s (%s) %s", caller, version.Version, runtime.GOOS, userAgent))
+		},
+	}
 }

--- a/subcommand/discover-servers/command.go
+++ b/subcommand/discover-servers/command.go
@@ -79,6 +79,7 @@ func (c *Command) realRun(log hclog.Logger) error {
 	if err != nil {
 		return err
 	}
+	clientSession.Handlers.Build.PushBackNamed(awsutil.UserAgentHandler("discover"))
 	c.ecsClient = ecs.New(clientSession)
 
 	var taskARNs *ecs.ListTasksOutput


### PR DESCRIPTION
## Testing

Ran locally as container with hardcoded region & cluster
![image](https://user-images.githubusercontent.com/34254888/124796050-93a7a480-df05-11eb-824a-d0dfe1188ad2.png)

CloudTrail logs show `useragent` on calls to ECS
![image](https://user-images.githubusercontent.com/34254888/124796199-bf2a8f00-df05-11eb-9c34-d45c910c7b46.png)
