### PR TITLE
ci: dockerfile download arm instead of armv6 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux && \
     apkArch="$(apk --print-arch)" && \
     case "${apkArch}" in \
     aarch64) ARCH='arm64' ;; \
-    armhf) ARCH='armhfv6' ;; \
+    armhf) ARCH='arm' ;; \
     x86) ARCH='386' ;; \
     x86_64) ARCH='amd64' ;; \
     *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/${NAME}/${VERSION}/)" && exit 1 ;; \


### PR DESCRIPTION
With the fix in https://github.com/golang/go/pull/34030, we have removed the armv5 and armv6 images in favor of arm/arm64 images for release. The dockerfile should download the "arm" named binary rather than `armhfv6` one from now on. 