### PR TITLE
Add a default check flag option to mesh-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES
 * Add a `health-sync` subcommand to sync ECS health checks into Consul [[GH-33](https://github.com/hashicorp/consul-ecs/pull/33)]
+* Add the `-health-sync-containers` flag to `mesh-init` [[GH-36](https://github.com/hashicorp/consul-ecs/pull/36)]
 
 ## 0.2.0-beta2 (September 30, 2021)
 IMPROVEMENTS

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -19,23 +19,23 @@ import (
 )
 
 const (
-	flagContainerNames = "container-names"
+	flagHealthSyncContainers = "health-sync-containers"
 	// pollingInterval is how often we poll the container health endpoint.
 	// The rate limit is about 40 per second, so 1 second polling seems reasonable.
 	pollInterval = 1 * time.Second
 )
 
 type Command struct {
-	UI                 cli.Ui
-	flagContainerNames string
-	log                hclog.Logger
-	flagSet            *flag.FlagSet
-	once               sync.Once
+	UI                       cli.Ui
+	flagHealthSyncContainers string
+	log                      hclog.Logger
+	flagSet                  *flag.FlagSet
+	once                     sync.Once
 }
 
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
-	c.flagSet.StringVar(&c.flagContainerNames, flagContainerNames, "", "Comma-separated list of container names for which to sync health status into Consul")
+	c.flagSet.StringVar(&c.flagHealthSyncContainers, flagHealthSyncContainers, "", "Comma-separated list of container names for which to sync health status into Consul")
 	c.log = hclog.New(nil)
 }
 
@@ -47,8 +47,8 @@ func (c *Command) Run(args []string) int {
 
 	// We expect this command to be invoked with a list of containers
 	// so error out if the list is empty.
-	if len(c.flagContainerNames) == 0 {
-		c.UI.Error(fmt.Sprintf("-%v doesn't have a value. exiting", flagContainerNames))
+	if len(c.flagHealthSyncContainers) == 0 {
+		c.UI.Error(fmt.Sprintf("-%v doesn't have a value. exiting", flagHealthSyncContainers))
 		return 1
 	}
 
@@ -83,7 +83,7 @@ func (c *Command) realRun(ctx context.Context, consulClient *api.Client) error {
 	serviceName := taskMeta.Family
 
 	currentStatuses := make(map[string]string)
-	parsedContainerNames := strings.Split(c.flagContainerNames, ",")
+	parsedContainerNames := strings.Split(c.flagHealthSyncContainers, ",")
 
 	for {
 		select {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -26,7 +26,7 @@ func TestRunWithoutContainerNames(t *testing.T) {
 	}
 	code := cmd.Run(nil)
 	require.Equal(t, 1, code)
-	require.Equal(t, "-container-names doesn't have a value. exiting\n", ui.ErrorWriter.String())
+	require.Equal(t, "-health-sync-containers doesn't have a value. exiting\n", ui.ErrorWriter.String())
 }
 
 func TestEcsHealthToConsulHealth(t *testing.T) {
@@ -222,9 +222,9 @@ func TestRunWithContainerNames(t *testing.T) {
 			ui := cli.NewMockUi()
 			log := hclog.New(nil)
 			cmd := Command{
-				UI:                 ui,
-				log:                log,
-				flagContainerNames: strings.Join(expectSyncContainers, ","),
+				UI:                       ui,
+				log:                      log,
+				flagHealthSyncContainers: strings.Join(expectSyncContainers, ","),
 			}
 
 			// Start the command.

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -222,8 +222,7 @@ func TestConstructChecks(t *testing.T) {
 
 	argChecks := api.AgentServiceChecks{
 		&api.AgentServiceCheck{
-			// Check id should be "api-<type>" for assertions.
-			CheckID:  "api-http",
+			CheckID:  "check-1",
 			Name:     "HTTP on port 8080",
 			HTTP:     "http://localhost:8080",
 			Interval: "20s",
@@ -233,7 +232,7 @@ func TestConstructChecks(t *testing.T) {
 			Notes:    "unittest http check",
 		},
 		&api.AgentServiceCheck{
-			CheckID:  "api-tcp",
+			CheckID:  "check-2",
 			Name:     "TCP on port 8080",
 			TCP:      "localhost:8080",
 			Interval: "10s",
@@ -241,7 +240,7 @@ func TestConstructChecks(t *testing.T) {
 			Notes:    "unittest tcp check",
 		},
 		&api.AgentServiceCheck{
-			CheckID:    "api-grpc",
+			CheckID:    "check-3",
 			Name:       "GRPC on port 8081",
 			GRPC:       "localhost:8081",
 			GRPCUseTLS: false,


### PR DESCRIPTION
## Changes proposed in this PR:
- This will be used for constructing TTL checks [that the upcoming health-sync subcommand can use](https://github.com/hashicorp/consul-ecs/pull/33).

## How I've tested this PR:
1. Unit tests
2. Combined with https://github.com/hashicorp/consul-ecs/pull/33 on the [health-sync-e2e](https://github.com/hashicorp/consul-ecs/tree/health-sync-e2e) branch. The resulting docker image works for the fargate example along with the tests on [the use-ecs-checks-with-patches branch in terraform-aws-consul-ecs](https://github.com/hashicorp/terraform-aws-consul-ecs/compare/use-ecs-checks-with-patches)

## How I expect reviewers to test this PR:


## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added