### PR TITLE
Make `NAME` the /consul volume owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ FEATURES
 ## 0.2.0-beta2 (September 30, 2021)
 IMPROVEMENTS
 * Clean up ACL tokens for services/task families that are deleted. [[GH-30](https://github.com/hashicorp/consul-ecs/pull/30)]
+* Change the owner of `/consul` in the Docker image  to `consul-ecs`. This
+  allows `mesh-init` to run as `consul-ecs` rather than `root`.
+  [[GH-37](https://github.com/hashicorp/consul-ecs/pull/37)]
 
 FEATURES
 * mesh-init: Add `-checks` option to register service health checks.

--- a/build-support/docker/Dev.dockerfile
+++ b/build-support/docker/Dev.dockerfile
@@ -1,3 +1,14 @@
 FROM hashicorp/consul-ecs:latest
 
 COPY pkg/bin/linux_amd64/consul-ecs /bin
+
+# TODO remove this after the next release
+# Changing the owner of /consul to NAME allows mesh-init to run as NAME rather
+# than root. See
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html
+# for more information
+ARG NAME=consul-ecs
+USER root
+RUN chown ${NAME}:${NAME} /consul
+VOLUME [ "/consul" ]
+USER ${NAME}

--- a/build-support/docker/Release.dockerfile
+++ b/build-support/docker/Release.dockerfile
@@ -25,6 +25,13 @@ ENV HASHICORP_RELEASES=https://releases.hashicorp.com
 RUN addgroup ${NAME} && \
     adduser -S -G ${NAME} ${NAME}
 
+# Changing the owner of /consul to NAME allows mesh-init to run as NAME rather
+# than root. See
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html
+# for more information
+RUN chown ${NAME}:${NAME} /consul
+VOLUME [ "/consul" ]
+
 # Set up certificates, base tools, and software.
 RUN set -eux && \
     apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils iptables && \


### PR DESCRIPTION
## Changes proposed in this PR:
- Make [`NAME`](https://github.com/hashicorp/consul-ecs/pull/37/files#diff-6893ac12af1d710fd632a552b4730959c03f4c65951aa1f24abefed1d2ed8dbbR30) the `/consul` volume owner. This [follows the documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html), allowing the `mesh-init` subcommand to run as `NAME` instead of `root`.

## How I've tested this PR:
**The release dockerfile changes**:
1. `docker build --build-arg "VERSION=0.2.0-beta2" -f build-support/docker/Release.dockerfile .`
2. `docker tag SOURCE_IMAGE erichaberkorn/consul-ecs:latest`
3. `docker push erichaberkorn/consul-ecs:latest`
4. I [changed terraform-aws-consul-ecs](https://github.com/hashicorp/terraform-aws-consul-ecs/compare/try-out-non-root-mesh-init) to ensure it continues to work. This included switching the user mesh-init runs as from `root` to `consul-ecs` and [swapping out the docker image](https://github.com/hashicorp/terraform-aws-consul-ecs/commit/590fb3181f9804dc64128b7fb79e4f2e434df8c7#diff-fad89c2c5f7dc0bd52d5c74b8d24da4fd285f1ce705648aded16944b8090a606R57). The tests keep passing after the change and the fargate example still works.

**The dev dockerfile changes**:
I ensured the tests all passed [on this commit](https://github.com/hashicorp/terraform-aws-consul-ecs/commit/b21ca1ab3ee951ed22a4538a1ff6191ef41c9165).


## How I expect reviewers to test this PR:

Reviewers can run through the steps described above or at least run through them to make sure they make sense.

## Checklist:
- [ ] Tests added (Not possible)
- [X] CHANGELOG entry added