### PR TITLE
Set TTL health checks to critical on shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/consul/api v1.10.1
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/go-hclog v0.15.0
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/miekg/dns v1.1.31 // indirect
 	github.com/mitchellh/cli v1.1.2

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -248,6 +248,10 @@ func TestRunWithContainerNames(t *testing.T) {
 				assertHealthChecks(t, ecsServiceMetadata, consulClient, c.updatedContainers, c.updatedExpChecks)
 			}
 
+			cancel()
+
+			// Ensure that checks are set to unhealthy after the context is canceled
+			assertHealthChecks(t, ecsServiceMetadata, consulClient, c.initialContainers, sanityChecks)
 		})
 	}
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- On shutdown, `health-sync` stops updating Consul checks based on ECS' health checks and immediately tries to set checks for all containers to critical. This will prevent the containers from receiving additional incoming traffic. The exponential backoff should prevent a thundering herd if tons of tasks are terminating at the same time.


## How I've tested this PR:
Unit tests

## How I expect reviewers to test this PR:
I wish there were a good way to test the failure conditions since that logic is relatively complicated. Let me know if anyone has ideas.

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added - I don't think this is needed since it already includes this https://github.com/hashicorp/consul-ecs/blob/main/CHANGELOG.md?plain=1#L5