### PR TITLE
Add a `-service-name` flag to the health-sync subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES
 * Add a `health-sync` subcommand to sync ECS health checks into Consul [[GH-33](https://github.com/hashicorp/consul-ecs/pull/33)]
 * Add the `-health-sync-containers` flag to `mesh-init` [[GH-36](https://github.com/hashicorp/consul-ecs/pull/36)]
 * Add `-tags`, `-service-name` and `-meta` flags to `mesh-init` [[GH-41](https://github.com/hashicorp/consul-ecs/pull/41)]
+* Add the `-service-name` flag to `health-sync`. [[GH-43](https://github.com/hashicorp/consul-ecs/pull/43)]
 
 BREAKING CHANGES
 * `consul-ecs` docker images no longer have the `consul` binary. The


### PR DESCRIPTION
## Changes proposed in this PR:
Add a `-service-name` flag to the health-sync subcommand. This allows users to override the default of using the ECS task definition's family name as the Consul service name.

Almost all of this was copied from https://github.com/hashicorp/consul-ecs/pull/41


## How I've tested this PR:
New tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added