### PR TITLE
Get Service Name from ECS Tasks in the ACL Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ FEATURES
 * Add the `-health-sync-containers` flag to `mesh-init` [[GH-36](https://github.com/hashicorp/consul-ecs/pull/36)]
 * Add `-tags`, `-service-name` and `-meta` flags to `mesh-init` [[GH-41](https://github.com/hashicorp/consul-ecs/pull/41)]
 * Add the `-service-name` flag to `health-sync`. [[GH-43](https://github.com/hashicorp/consul-ecs/pull/43)]
+* The ACL controller now reads the Consul service name from the
+  `consul.hashicorp.com/service-name` tag on the ECS task. If the tag
+  does not exist, it uses the Task family as the Consul service name.
+  [[GH-44](https://github.com/hashicorp/consul-ecs/pull/44)]
 
 BREAKING CHANGES
 * `consul-ecs` docker images no longer have the `consul` binary. The


### PR DESCRIPTION
## Changes proposed in this PR:
- Rename `parseFamilyNameFromTaskDefinitionARN` to `parseServiceNameFromTaskDefinitionARN`
- From `parseServiceNameFromTaskDefinitionARN`, use the "consul.hashicorp.com/service-name" tag from the ECS task as the service name if it is defined.

## How I've tested this PR:
Unit tests. I'm planning on adding tests to terraform-aws-consul-ecs to ensure this works E2E in mesh-init, health-sync and the ACL controller after all of these PRs are merged.

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added