### PR TITLE
Fix ACL Controller Race Conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ FEATURES
 * Add a `envoy-entrypoint` subcommand, which can be used as the entrypoint to the Envoy container running in ECS
   to support graceful shutdown. [[GH-42](https://github.com/hashicorp/consul-ecs/pull/42)]
 
+BUG FIXES:
+* Fix edge cases in the ACL controller where ACL tokens never get cleaned
+  up. [[GH-45](https://github.com/hashicorp/consul-ecs/pull/45)]
+
 ## 0.2.0-beta2 (September 30, 2021)
 IMPROVEMENTS
 * Clean up ACL tokens for services/task families that are deleted. [[GH-30](https://github.com/hashicorp/consul-ecs/pull/30)]

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -12,94 +11,55 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	cases := map[string]struct {
-		source map[ResourceID]struct{}
-		sink   map[ResourceID]struct{}
-	}{
-		"upsert single": {
-			source: map[ResourceID]struct{}{"foo": {}},
-			sink:   make(map[ResourceID]struct{}),
-		},
-		"upsert multiple": {
-			source: map[ResourceID]struct{}{"foo": {}, "bar": {}},
-			sink:   make(map[ResourceID]struct{}),
-		},
-		"delete": {
-			source: map[ResourceID]struct{}{"foo": {}, "bar": {}},
-			sink:   map[ResourceID]struct{}{"baz": {}},
-		},
+	resource1 := &testResource{
+		name: "resource1",
 	}
 
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			resourceLister := &testResourceLister{
-				source: c.source,
-				sink:   c.sink,
-			}
-
-			ctrl := Controller{
-				Resources:       resourceLister,
-				PollingInterval: 1 * time.Second,
-				Log:             hclog.NewNullLogger(),
-			}
-			// If sink already has resources, then we need to make sure
-			// that the controller's internal state has them too.
-			if c.sink != nil {
-				ctrl.resourceState = make(map[ResourceID]Resource)
-				for id := range c.sink {
-					ctrl.resourceState[id] = testResource{name: string(id), sink: &c.sink}
-				}
-			}
-
-			ctx, cancelFunc := context.WithCancel(context.Background())
-			t.Cleanup(cancelFunc)
-
-			go ctrl.Run(ctx)
-
-			retry.Run(t, func(r *retry.R) {
-				require.True(r, reflect.DeepEqual(resourceLister.sink, c.source))
-				resourceStateIDs := make(map[ResourceID]struct{})
-				for id := range ctrl.resourceState {
-					resourceStateIDs[id] = struct{}{}
-				}
-				require.True(t, reflect.DeepEqual(resourceStateIDs, c.source))
-			})
-		})
+	resource2 := &testResource{
+		name: "resource2",
 	}
+
+	lister := &testResourceLister{
+		resources: []*testResource{resource1, resource2},
+	}
+
+	ctrl := Controller{
+		Resources:       lister,
+		PollingInterval: 1 * time.Second,
+		Log:             hclog.NewNullLogger(),
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	go ctrl.Run(ctx)
+
+	retry.Run(t, func(r *retry.R) {
+		for _, resource := range lister.resources {
+			require.True(r, resource.reconciled)
+		}
+	})
 }
 
 type testResourceLister struct {
-	source map[ResourceID]struct{}
-	sink   map[ResourceID]struct{}
+	resources []*testResource
 }
 
 type testResource struct {
-	name string
-	sink *map[ResourceID]struct{}
+	name       string
+	reconciled bool
 }
 
 func (t testResourceLister) List() ([]Resource, error) {
 	var resources []Resource
-	for k := range t.source {
-		resources = append(resources, testResource{name: string(k), sink: &t.sink})
+	for _, resource := range t.resources {
+		resources = append(resources, resource)
 	}
 	return resources, nil
 }
 
-func (t testResource) ID() (ResourceID, error) {
-	return ResourceID(t.name), nil
-}
-
-func (t testResource) Upsert() error {
-	id, _ := t.ID()
-	(*t.sink)[id] = struct{}{}
-
-	return nil
-}
-
-func (t testResource) Delete() error {
-	id, _ := t.ID()
-	delete(*t.sink, id)
+func (t *testResource) Reconcile() error {
+	t.reconciled = true
 
 	return nil
 }

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,94 +15,290 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTaskLister_List(t *testing.T) {
+func TestServiceStateLister_List(t *testing.T) {
+	definitionArn := aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service1:1")
+	cluster := "cluster"
+	meshKey := "consul.hashicorp.com/mesh"
+	meshValue := "true"
+	task1 := ecs.Task{
+		TaskArn:           aws.String("task1"),
+		TaskDefinitionArn: definitionArn,
+		Tags: []*ecs.Tag{
+			{
+				Key:   &meshKey,
+				Value: &meshValue,
+			},
+		},
+	}
+	task2 := ecs.Task{
+		TaskArn:           aws.String("task2"),
+		TaskDefinitionArn: definitionArn,
+		Tags: []*ecs.Tag{
+			{
+				Key:   &meshKey,
+				Value: &meshValue,
+			},
+		},
+	}
+	nonMeshTask := ecs.Task{
+		TaskArn:           aws.String("nonMeshTask"),
+		TaskDefinitionArn: definitionArn,
+	}
+	aclToken1 := &api.ACLToken{
+		Description:       fmt.Sprintf("Token for service1 service\n%s: %s", clusterTag, cluster),
+		ServiceIdentities: []*api.ACLServiceIdentity{{ServiceName: "service1"}},
+	}
+	aclTokenListEntry1 := &api.ACLTokenListEntry{
+		Description:       fmt.Sprintf("Token for service1 service\n%s: %s", clusterTag, cluster),
+		ServiceIdentities: []*api.ACLServiceIdentity{{ServiceName: "service1"}},
+	}
+
+	aclToken3 := &api.ACLToken{
+		Description:       fmt.Sprintf("Token for service3 service\n%s: %s", clusterTag, cluster),
+		ServiceIdentities: []*api.ACLServiceIdentity{{ServiceName: "service3"}},
+	}
+	aclTokenListEntry3 := &api.ACLTokenListEntry{
+		Description:       fmt.Sprintf("Token for service3 service\n%s: %s", clusterTag, cluster),
+		ServiceIdentities: []*api.ACLServiceIdentity{{ServiceName: "service3"}},
+	}
+
 	cases := map[string]struct {
 		paginateResults bool
+		tasks           []ecs.Task
+		expected        map[string]ServiceState
+		aclTokens       []*api.ACLToken
 	}{
-		"without pagination": {},
-		"with pagination":    {paginateResults: true},
+		"no overlap between tasks, services and tokens": {
+			tasks:     []ecs.Task{task1, task2},
+			aclTokens: []*api.ACLToken{aclToken3},
+			expected: map[string]ServiceState{
+				"service1": {
+					ConsulECSTasks: true,
+				},
+				"service3": {
+					ACLTokens: []*api.ACLTokenListEntry{aclTokenListEntry3},
+				},
+			},
+		},
+		"all overlap between tasks, services and tokens": {
+			tasks:     []ecs.Task{task1, task2},
+			aclTokens: []*api.ACLToken{aclToken1},
+			expected: map[string]ServiceState{
+				"service1": {
+					ConsulECSTasks: true,
+					ACLTokens:      []*api.ACLTokenListEntry{aclTokenListEntry1},
+				},
+			},
+		},
+		"with pagination": {
+			tasks:           []ecs.Task{task1, task2},
+			paginateResults: true,
+			expected: map[string]ServiceState{
+				"service1": {
+					ConsulECSTasks: true,
+				},
+			},
+		},
+		"with non-mesh tasks": {
+			tasks:     []ecs.Task{nonMeshTask},
+			aclTokens: []*api.ACLToken{aclToken1},
+			expected: map[string]ServiceState{
+				"service1": {
+					ConsulECSTasks: false,
+					ACLTokens:      []*api.ACLTokenListEntry{aclTokenListEntry1},
+				},
+			},
+		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			task1 := &ecs.Task{
-				TaskArn: aws.String("task1"),
-			}
-			task2 := &ecs.Task{
-				TaskArn: aws.String("task2"),
-			}
-			tl := TaskLister{ECSClient: &mocks.ECSClient{Tasks: []*ecs.Task{task1, task2}, PaginateResults: c.paginateResults}}
+			adminToken := "123e4567-e89b-12d3-a456-426614174000"
+			testServer, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+				c.ACL.Enabled = true
+				c.ACL.Tokens.Master = adminToken
+				c.ACL.DefaultPolicy = "deny"
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = testServer.Stop() })
+			testServer.WaitForLeader(t)
 
-			tasks, err := tl.List()
+			clientConfig := api.DefaultConfig()
+			clientConfig.Address = testServer.HTTPAddr
+			clientConfig.Token = adminToken
+
+			consulClient, err := api.NewClient(clientConfig)
+			require.NoError(t, err)
+
+			for _, aclToken := range c.aclTokens {
+				_, _, err = consulClient.ACL().TokenCreate(aclToken, nil)
+				require.NoError(t, err)
+			}
+
+			var tasks []*ecs.Task
+
+			for i := range c.tasks {
+				tasks = append(tasks, &c.tasks[i])
+			}
+
+			s := ServiceStateLister{
+				Log:          hclog.NewNullLogger(),
+				ConsulClient: consulClient,
+				ECSClient: &mocks.ECSClient{
+					Tasks:           tasks,
+					PaginateResults: c.paginateResults,
+				}}
+
+			resources, err := s.List()
 
 			require.NoError(t, err)
-			require.Len(t, tasks, 2)
-			require.Equal(t, task1.TaskArn, tasks[0].(*Task).Task.TaskArn)
-			require.Equal(t, task2.TaskArn, tasks[1].(*Task).Task.TaskArn)
+
+			serviceStates := make(map[string]ServiceState)
+
+			for _, resource := range resources {
+				serviceInfo := resource.(*ServiceInfo)
+
+				// only set the expected acl token fields
+				var tokens []*api.ACLTokenListEntry
+				for _, token := range serviceInfo.ServiceState.ACLTokens {
+					tokens = append(tokens, &api.ACLTokenListEntry{
+						Description:       token.Description,
+						ServiceIdentities: token.ServiceIdentities,
+					})
+				}
+				serviceInfo.ServiceState.ACLTokens = tokens
+				serviceStates[serviceInfo.ServiceName] = serviceInfo.ServiceState
+			}
+
+			require.Equal(t, c.expected, serviceStates)
+		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	cluster := "test-cluster"
+	aclToken1 := &api.ACLToken{
+		Description:       fmt.Sprintf("Token for service1 service\n%s: %s", clusterTag, cluster),
+		ServiceIdentities: []*api.ACLServiceIdentity{{ServiceName: "service1"}},
+	}
+
+	cases := map[string]struct {
+		tasks          bool
+		aclTokens      []*api.ACLToken
+		sutServiceName string
+		expected       []*api.ACLToken
+	}{
+		"token should be deleted": {
+			tasks:          false,
+			aclTokens:      []*api.ACLToken{aclToken1},
+			sutServiceName: "service1",
+			expected:       nil,
+		},
+		"token should be added": {
+			tasks:          true,
+			aclTokens:      []*api.ACLToken{},
+			sutServiceName: "service1",
+			expected:       []*api.ACLToken{aclToken1},
+		},
+		"Does nothing when a task is running and a token exists for a given service": {
+			tasks:          true,
+			aclTokens:      []*api.ACLToken{aclToken1},
+			sutServiceName: "service1",
+			expected:       []*api.ACLToken{aclToken1},
+		},
+		"Does nothing when there are no tasks or tokens": {
+			tasks:          false,
+			sutServiceName: "service1",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			smClient := &mocks.SMClient{Secret: &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)}}
+
+			adminToken := "123e4567-e89b-12d3-a456-426614174000"
+			testServer, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+				c.ACL.Enabled = true
+				c.ACL.Tokens.Master = adminToken
+				c.ACL.DefaultPolicy = "deny"
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = testServer.Stop() })
+			testServer.WaitForLeader(t)
+
+			clientConfig := api.DefaultConfig()
+			clientConfig.Address = testServer.HTTPAddr
+			clientConfig.Token = adminToken
+
+			consulClient, err := api.NewClient(clientConfig)
+			require.NoError(t, err)
+
+			var beforeTokens []*api.ACLTokenListEntry
+			for _, aclToken := range c.aclTokens {
+				token, _, err := consulClient.ACL().TokenCreate(aclToken, nil)
+				require.NoError(t, err)
+				beforeTokens = append(beforeTokens, &api.ACLTokenListEntry{
+					AccessorID: token.AccessorID,
+				})
+			}
+
+			log := hclog.NewNullLogger()
+
+			serviceInfo := ServiceInfo{
+				SecretsManagerClient: smClient,
+				ConsulClient:         consulClient,
+				Cluster:              cluster,
+				SecretPrefix:         "test",
+				ServiceName:          c.sutServiceName,
+				ServiceState: ServiceState{
+					ConsulECSTasks: c.tasks,
+					ACLTokens:      beforeTokens,
+				},
+				Log: log,
+			}
+
+			err = serviceInfo.Reconcile()
+			require.NoError(t, err)
+
+			serviceStateLister := ServiceStateLister{
+				ConsulClient: consulClient,
+				Log:          log,
+			}
+
+			aclTokens, err := serviceStateLister.fetchACLTokens()
+			require.NoError(t, err)
+
+			var tokens []*api.ACLToken
+			for _, token := range aclTokens[c.sutServiceName] {
+				tokens = append(tokens, &api.ACLToken{
+					Description:       token.Description,
+					ServiceIdentities: token.ServiceIdentities,
+				})
+			}
+			require.Equal(t, len(c.expected), len(tokens))
+			require.Equal(t, c.expected, tokens)
 		})
 	}
 }
 
 func TestTask_Upsert(t *testing.T) {
 	cases := map[string]struct {
-		task                *ecs.Task
 		createExistingToken bool
 		existingSecret      *secretsmanager.GetSecretValueOutput
 		expectTokenToExist  bool
 		expectedError       string
 	}{
-		"task without mesh tag": {
-			task: &ecs.Task{
-				TaskArn:           aws.String("task-arn"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-			},
-			existingSecret:     &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)},
-			expectTokenToExist: false,
-		},
 		"task with mesh tag": {
-			task: &ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
 			existingSecret:     &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)},
 			expectTokenToExist: true,
 		},
-		"task with an invalid task definition ARN (no / separator)": {
-			task: &ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition-service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
-			existingSecret: &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)},
-			expectedError:  `could not determine service name: cannot determine task family from task definition ARN: "arn:aws:ecs:us-east-1:1234567890:task-definition-service:1"`,
-		},
-		"task with an invalid task definition ARN (no revision)": {
-			task: &ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
-			existingSecret: &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)},
-			expectedError:  `could not determine service name: cannot determine task family from task definition ARN: "arn:aws:ecs:us-east-1:1234567890:task-definition/service"`,
-		},
 		"when there is an existing token for the service, we don't create a new one": {
-			task: &ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
 			// When createExistingToken is true, existingSecret will be updated with the value of the created token.
 			existingSecret:      &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)},
 			createExistingToken: true,
 			expectTokenToExist:  true,
 		},
 		"when the token in the secret doesn't exist in Consul, the secret is updated with the new value": {
-			task: &ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
 			existingSecret: &secretsmanager.GetSecretValueOutput{
 				Name:         aws.String("test-service"),
 				SecretString: aws.String(`{"accessor_id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","token":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}`),
@@ -142,13 +339,16 @@ func TestTask_Upsert(t *testing.T) {
 				c.existingSecret.SecretString = aws.String(string(secretValue))
 			}
 
-			taskTokens := Task{
+			taskTokens := ServiceInfo{
 				SecretsManagerClient: smClient,
 				ConsulClient:         consulClient,
 				Cluster:              "test-cluster",
 				SecretPrefix:         "test",
-				Task:                 *c.task,
-				Log:                  hclog.NewNullLogger(),
+				ServiceName:          "service",
+				ServiceState: ServiceState{
+					ConsulECSTasks: true,
+				},
+				Log: hclog.NewNullLogger(),
 			}
 
 			err = taskTokens.Upsert()
@@ -192,68 +392,17 @@ func TestTask_Delete(t *testing.T) {
 		createExistingToken                bool
 		updateExistingSecret               bool
 		registerConsulService              bool
-		task                               ecs.Task
 		expectTokenDeletedAndSecretEmptied bool
 	}{
 		"the token for service doesn't exist in consul and the secret is empty": {
-			createExistingToken:  false,
-			updateExistingSecret: false,
-			task: ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
+			createExistingToken:                false,
+			updateExistingSecret:               false,
 			expectTokenDeletedAndSecretEmptied: true,
 		},
 		"the token for service doesn't exist in consul and the secret has some value": {
-			createExistingToken:  false,
-			updateExistingSecret: true,
-			task: ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
+			createExistingToken:                false,
+			updateExistingSecret:               true,
 			expectTokenDeletedAndSecretEmptied: true,
-		},
-		"the token for service exists in consul and the secret has the token value": {
-			createExistingToken:  true,
-			updateExistingSecret: true,
-			task: ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
-			expectTokenDeletedAndSecretEmptied: true,
-		},
-		"the token for service exists in consul but the secret is empty": {
-			createExistingToken:  true,
-			updateExistingSecret: false,
-			task: ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
-			expectTokenDeletedAndSecretEmptied: true,
-		},
-		"skips non-mesh services": {
-			createExistingToken:  true,
-			updateExistingSecret: true,
-			task: ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-			},
-			expectTokenDeletedAndSecretEmptied: false,
-		},
-		"skips if there is a service still registered with Consul": {
-			createExistingToken:   true,
-			updateExistingSecret:  true,
-			registerConsulService: true,
-			task: ecs.Task{
-				TaskArn:           aws.String("task"),
-				TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"),
-				Tags:              []*ecs.Tag{{Key: aws.String(meshTag), Value: aws.String("true")}},
-			},
-			expectTokenDeletedAndSecretEmptied: false,
 		},
 	}
 
@@ -310,13 +459,16 @@ func TestTask_Delete(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			taskTokens := Task{
+			taskTokens := ServiceInfo{
 				SecretsManagerClient: smClient,
 				ConsulClient:         consulClient,
 				Cluster:              "test-cluster",
 				SecretPrefix:         "test",
-				Task:                 c.task,
-				Log:                  hclog.NewNullLogger(),
+				ServiceName:          "service",
+				ServiceState: ServiceState{
+					ConsulECSTasks: true,
+				},
+				Log: hclog.NewNullLogger(),
 			}
 
 			err = taskTokens.Delete()
@@ -379,10 +531,7 @@ func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			task := Task{
-				Task: c.task,
-			}
-			serviceName, err := task.serviceNameForTask()
+			serviceName, err := serviceNameForTask(&c.task)
 			if c.serviceName == "" {
 				require.Error(t, err)
 			} else {

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -89,7 +89,7 @@ func (c *Command) run() error {
 		return err
 	}
 
-	taskTokens := &controller.TaskLister{
+	serviceStateLister := &controller.ServiceStateLister{
 		ECSClient:            ecsClient,
 		SecretsManagerClient: smClient,
 		ConsulClient:         consulClient,
@@ -98,7 +98,7 @@ func (c *Command) run() error {
 		Log:                  c.log,
 	}
 	ctrl := controller.Controller{
-		Resources:       taskTokens,
+		Resources:       serviceStateLister,
 		PollingInterval: controller.DefaultPollingInterval,
 		Log:             c.log,
 	}


### PR DESCRIPTION
## Changes proposed in this PR:
Fix race conditions in the ACL controller

It does this  by fetching all of the ACL tokens and ECS tasks. It then makes a mapping from inferred service name to the resources that are tied to that resource. The ACL controller modifies tokens in two cases:
* Tokens are deleted when there are ACL tokens for a service that doesn't have any tasks running
* Tokens are added when there are tasks running for a service that doesn't have an ACL token

## How I've tested this PR:
Writing tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [X] Tests added
- [x] CHANGELOG entry added