### PR TITLE
Fix edge cases in the ACL controller when things could fail and never recover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ FEATURES
   to support graceful shutdown. [[GH-42](https://github.com/hashicorp/consul-ecs/pull/42)]
 
 BUG FIXES:
-* Fix edge cases in the ACL controller where ACL tokens never get cleaned
-  up. [[GH-45](https://github.com/hashicorp/consul-ecs/pull/45)]
+* Fix bugs in which ACL tokens are not created or deleted in certain cases.
+  [[GH-45](https://github.com/hashicorp/consul-ecs/pull/45)] [[GH-46](https://github.com/hashicorp/consul-ecs/pull/46)]
 
 ## 0.2.0-beta2 (September 30, 2021)
 IMPROVEMENTS

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/go-hclog v0.15.0
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/miekg/dns v1.1.31 // indirect
 	github.com/mitchellh/cli v1.1.2


### PR DESCRIPTION
## Changes proposed in this PR:
    
Since ACL tokens are used to determine if the reconcile process needs to do anything, there is a bug when ACL tokens are deleted or updated but the Secrets Manager secrets aren't. This is fixed by making the `Upsert` function only insert a secret once and then no longer default it again in the `Delete` function.  This means that after the initial insert, updating and deleting tokens only requires a single operation and can't end up in a partially inserted or deleted state.  The originally insert still takes two operations because it requires inserting the AWS secret and then inserting the ACL token into Consul. Interesting cases:
* The only failure case occurs if the AWS secret is successfully inserted and then the ACL token fails to be deleted. When this happens, a subsequent reconcile will see that the AWS secret has been inserted and then reuse that secret when setting the `AccessorID` and `SecretID` on the ACL token it inserts.
* If a delete fails to delete the ACL token and then then tasks for that service start again, the secret and token already be set correctly and nothing will need to be reconciled for the service to run.
* If an upsert fails to insert the ACL token and then all tasks for the service are stopped, the token will be deleted in the next reconcile.

## How I've tested this PR:
My 🧠 and a new test

## How I expect reviewers to test this PR:
👀 and 🧠 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added