### PR TITLE
Fix a bug that causes ACL token flapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+BUG FIXES:
+* Fix a bug in which ACL tokens are repeatedly created and destroyed, leading to
+  ECS services never reaching a steady state.
+  [[GH-49](https://github.com/hashicorp/consul-ecs/pull/49)]
+
 ## 0.2.0 (November 16, 2021)
 
 BREAKING CHANGES

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -8,7 +8,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-const DefaultPollingInterval = 10 * time.Second
+const DefaultUpsertPollingInterval = 10 * time.Second
+const DefaultDeletePollingInterval = 2 * time.Minute
 
 // Controller is a generic controller implementation.
 // It periodically polls for Resources and reconciles
@@ -16,36 +17,47 @@ const DefaultPollingInterval = 10 * time.Second
 type Controller struct {
 	// Resources lists resources for Controller to reconcile.
 	Resources ResourceLister
-	// PollingInterval is an interval that Controller will use to reconcile all Resources.
-	PollingInterval time.Duration
+	// UpsertPollingInterval is an interval that Controller will use to upsert Resources.
+	UpsertPollingInterval time.Duration
+	// DeletePollingInterval is an interval that Controller will use to delete Resources. This should be larger than and evenly divisible by UpsertPollingInterval.
+	DeletePollingInterval time.Duration
 	// Log is the logger used by the Controller.
 	Log hclog.Logger
 }
 
 // Run starts the Controller loop. The loop will exit when ctx is canceled.
+// Upserting and deleting are combined into a single call to reconcile to
+// reduce calls to Consul and the ECS API.
 func (c *Controller) Run(ctx context.Context) {
+	iteration := 0
+
 	for {
 		select {
-		case <-time.After(c.PollingInterval):
-			err := c.reconcile()
+		case <-time.After(c.UpsertPollingInterval):
+			err := c.reconcile(c.canDelete(iteration))
 			if err != nil {
 				c.Log.Error("error during reconcile", "err", err)
 			}
+			iteration++
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
+func (c *Controller) canDelete(iteration int) bool {
+	return iteration%int(c.DeletePollingInterval/c.UpsertPollingInterval) == 0
+}
+
 // reconcile first lists all resources and then reconciles them with Controller's state.
-func (c *Controller) reconcile() error {
+func (c *Controller) reconcile(canDelete bool) error {
 	c.Log.Info("starting reconcile")
 	resources, err := c.Resources.List()
 	if err != nil {
 		return fmt.Errorf("listing resources: %w", err)
 	}
 	for _, resource := range resources {
-		err = resource.Reconcile()
+		err = resource.Reconcile(canDelete)
 		if err != nil {
 			c.Log.Error("error reconciling resource", "err", err)
 		}

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -29,7 +29,7 @@ type ResourceLister interface {
 // Resource is a generic type that needs to be reconciled by the Controller.
 // It offers Upsert and Delete functions to reconcile itself with an external state.
 type Resource interface {
-	Reconcile() error
+	Reconcile(bool) error
 }
 
 // ServiceStateLister is an implementation of ResourceLister that constructs ServiceInfo
@@ -210,13 +210,13 @@ type tokenSecretJSON struct {
 }
 
 // Reconcile inserts or deletes ACL tokens based on their ServiceState.
-func (s *ServiceInfo) Reconcile() error {
+func (s *ServiceInfo) Reconcile(canDelete bool) error {
 	state := s.ServiceState
 	if len(state.ACLTokens) == 0 && state.ConsulECSTasks {
 		return s.Upsert()
 	}
 
-	if !state.ConsulECSTasks && len(state.ACLTokens) > 0 {
+	if !state.ConsulECSTasks && len(state.ACLTokens) > 0 && canDelete {
 		return s.Delete()
 	}
 

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -186,13 +186,22 @@ func TestReconcile(t *testing.T) {
 		tasks          bool
 		aclTokens      []*api.ACLToken
 		sutServiceName string
+		canDelete      bool
 		expected       []*api.ACLToken
 	}{
 		"token should be deleted": {
 			tasks:          false,
 			aclTokens:      []*api.ACLToken{aclToken1},
 			sutServiceName: "service1",
+			canDelete:      true,
 			expected:       nil,
+		},
+		"token should be deleted, but it isn't a delete iteration": {
+			tasks:          false,
+			aclTokens:      []*api.ACLToken{aclToken1},
+			sutServiceName: "service1",
+			canDelete:      false,
+			expected:       []*api.ACLToken{aclToken1},
 		},
 		"token should be added": {
 			tasks:          true,
@@ -257,7 +266,7 @@ func TestReconcile(t *testing.T) {
 				Log: log,
 			}
 
-			err = serviceInfo.Reconcile()
+			err = serviceInfo.Reconcile(c.canDelete)
 			require.NoError(t, err)
 
 			serviceStateLister := ServiceStateLister{

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -98,9 +98,10 @@ func (c *Command) run() error {
 		Log:                  c.log,
 	}
 	ctrl := controller.Controller{
-		Resources:       serviceStateLister,
-		PollingInterval: controller.DefaultPollingInterval,
-		Log:             c.log,
+		Resources:             serviceStateLister,
+		UpsertPollingInterval: controller.DefaultUpsertPollingInterval,
+		DeletePollingInterval: controller.DefaultDeletePollingInterval,
+		Log:                   c.log,
 	}
 
 	ctrl.Run(context.Background())


### PR DESCRIPTION
## Changes proposed in this PR:
- While running performance tests [on this branch](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/68), I ran into a case where ACL tokens were being repeatedly created and deleted. This caused services to never reach a steady state. This fixes that bug by keeping the ACL token creation interval set to 10 seconds and reduce the deletion interval to 2 minutes. This greatly reduces the chances of the flapping I observed.

## How I've tested this PR:
These results are on [the performance testing branch](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/68).

Before:
```
2021-11-25T15:15:01.214Z [INFO]  token deleted successfully: service=consul-ecs-perf-5-load-client
...
2021-11-25T15:15:37.495Z [INFO]  creating service token: id=consul-ecs-perf-5-load-client
2021-11-25T15:15:37.503Z [INFO]  service token created successfully: service=consul-ecs-perf-5-load-client
...
2021-11-25T15:16:01.511Z [INFO]  token deleted successfully: service=consul-ecs-perf-5-load-client
2021-11-25T15:21:00.916Z [INFO]  creating service token: id=consul-ecs-perf-5-load-client
2021-11-25T15:21:00.921Z [INFO]  service token created successfully: service=consul-ecs-perf-5-load-client
...
2021-11-25T15:21:36.550Z [INFO]  token deleted successfully: service=consul-ecs-perf-5-load-client
...
```

After:
1. I didn't observe any flapping while running the performance tests with 100 server tasks and 10 server tasks per service group.
2. I ran a test with 50 server tasks, 1 server tasks per service group and 100% of server tasks restarting and even with the restart no ACL tokens were deleted.
3. I scaled the cluster back down to 1 server task with 1 server task per service group and all of the tokens were successfully cleaned up in batches two minutes apart. 

## How I expect reviewers to test this PR:
👁️ 🧠 

## Checklist:
- [X] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
