### PR TITLE
Swap out circleci/golang with cimg/go now that circleci/golang is deprecated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   go:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.17
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
       CONSUL_VERSION: 1.10.4 # Consul's OSS version to use in tests


### PR DESCRIPTION
## Changes proposed in this PR:
- Swap out `circleci/golang` image with `cimg/go` in the CircleCI configuration.

## How I've tested this PR:
The tests still pass

## How I expect reviewers to test this PR:
👁️ 

## Checklist:
- [ ] Tests added - Not necessary
- [ ] CHANGELOG entry added - Not necessary