### PR TITLE
Generate reference config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,14 @@ dev-docker: build-dev-dockerfile
 		--build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
 		-f $(CURDIR)/build-support/docker/Dev.dockerfile $(CURDIR)
 
-.PHONY: build-image ci.dev-docker dev-docker build-dev-dockerfile
+# Generate reference config documentation.
+# Usage:
+#   make reference-configuration
+#   make reference-configuration consul=<path-to-consul-repo>
+# The consul repo path is relative to the defaults to ../../../consul.
+consul?=../../../consul
+reference-configuration:
+	cd $(CURDIR)/hack/generate-config-reference; go run . > "$(consul)/website/content/docs/ecs/configuration-reference.mdx"
+
+
+.PHONY: build-image ci.dev-docker dev-docker build-dev-dockerfile reference-configuration

--- a/config/schema.go
+++ b/config/schema.go
@@ -3,4 +3,4 @@ package config
 import _ "embed"
 
 //go:embed schema.json
-var schema string
+var Schema string

--- a/config/schema.json
+++ b/config/schema.json
@@ -2,16 +2,16 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://hashicorp.com/schemas/consul-ecs",
   "title": "Consul ECS Configuration",
-  "description": "Configuration for the consul-ecs binary",
+  "description": "These are the top-level fields for the Consul ECS configuration format.",
   "type": "object",
   "properties": {
     "bootstrapDir": {
-      "description": "The directory of the shared data volume where Envoy bootstrap configuration is written.",
+      "description": "The directory at which to mount the shared volume where Envoy bootstrap configuration is written by `consul-ecs mesh-init`.",
       "type": "string",
       "minLength": 1
     },
     "healthSyncContainers": {
-      "description": "The names of containers that will have health check status synced from ECS into Consul. Cannot be specified with service.checks.",
+      "description": "The names of containers that will have health check status synced from ECS into Consul. Cannot be specified with `service.checks`.",
       "type": ["array", "null"],
       "items": {
         "type": "string"
@@ -27,6 +27,7 @@
           "type": ["string", "null"]
         },
         "tags": {
+          "description": "List of string values that can be used to add service-level labels.",
           "type": ["array", "null"],
           "items": {
             "type": "string"
@@ -34,12 +35,15 @@
           "uniqueItems": true
         },
         "port": {
+          "description": "Port the application listens on, if any.",
           "type": "integer"
         },
         "enableTagOverride": {
+          "description": "Determines if the anti-entropy feature for the service is enabled",
           "type": ["boolean", "null"]
         },
         "meta": {
+          "description": "Key-value pairs of metadata to include for the Consul service.",
           "type": ["object", "null"],
           "patternProperties": {
             ".*": {
@@ -48,12 +52,15 @@
           }
         },
         "weights": {
+          "description": "Configures the weight of the service in terms of its DNS service (SRV) response.",
           "type": ["object", "null"],
           "properties": {
             "passing": {
+              "description": "Weight for the service when its health checks are passing.",
               "type": "integer"
             },
             "warning": {
+              "description": "Weight for the service when it has health checks in `warning` status.",
               "type": "integer"
             }
           },
@@ -61,36 +68,45 @@
           "additionalProperties": false
         },
         "checks": {
-          "description": "Consul checks for the service. Cannot be specified with healthSyncContainers.",
+          "description": "The list of Consul checks for the service. Cannot be specified with `healthSyncContainers`.",
           "type": ["array", "null"],
           "items": {
+            "description": "Defines the Consul checks for the service. Each check may contain these fields.",
             "type": "object",
             "properties": {
               "checkId": {
+                "description": "The unique ID for this check on the node. Defaults to the check `name`.",
                 "type": ["string", "null"]
               },
               "name": {
+                "description": "The name of the check.",
                 "type": "string"
               },
               "args": {
+                "description": "Command arguments to run to update the status of the check.",
                 "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "interval": {
+                "description": "Specifies the frequency at which to run this check. Required for HTTP and TCP checks.",
                 "type": ["string", "null"]
               },
               "timeout": {
+                "description": "Specifies a timeout for outgoing connections in the case of a Script, HTTP, TCP, or gRPC check. Must be a duration string, such as `10s` or `5m`.",
                 "type": ["string", "null"]
               },
               "ttl": {
+                "description": "Specifies this is a TTL check. Must be a duration string, such as `10s` or `5m`.",
                 "type": ["string", "null"]
               },
               "http": {
+                "description": "Specifies this is an HTTP check. Must be a URL against which request is performed every `interval`.",
                 "type": ["string", "null"]
               },
               "header": {
+                "description": "Specifies a set of headers that should be set for HTTP checks. Each header can have multiple values.",
                 "type": ["object", "null"],
                 "patternProperties": {
                   ".*": {
@@ -102,31 +118,40 @@
                 }
               },
               "method": {
+                "description": "Specifies the HTTP method to be used for an HTTP check. When no value is specified, `GET` is used.",
                 "type": ["string", "null"]
               },
               "body": {
+                "description": "Specifies a body that should be sent with `HTTP` checks.",
                 "type": ["string", "null"]
               },
               "tcp": {
+                "description": "Specifies this is a TCP check. Must be an IP/hostname plus port to which a TCP connection is made every `interval`.",
                 "type": ["string", "null"]
               },
               "status": {
+                "description": "Specifies the initial status the health check.",
                 "type": ["string", "null"],
                 "enum": ["passing", "warning", "critical", "maintenance", null]
               },
               "notes": {
+                "description": "Specifies arbitrary information for humans. This is not used by Consul internally.",
                 "type": ["string", "null"]
               },
               "tlsServerName": {
+                "description": "Specifies an optional string used to set the SNI host when connecting via TLS.",
                 "type": ["string", "null"]
               },
               "tlsSkipVerify": {
+                "description": "Specifies if the certificate for an HTTPS check should not be verified.",
                 "type": ["boolean", "null"]
               },
               "grpc": {
+                "description": "Specifies a `gRPC` check. Must be an endpoint that supports the [standard gRPC health checking protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md). The endpoint will be probed every `interval`.",
                 "type": ["string", "null"]
               },
               "grpcUseTls": {
+                "description": "Specifies whether to use TLS for this gRPC health check.",
                 "type": ["boolean", "null"]
               },
               "h2ping": {
@@ -138,15 +163,19 @@
                 "type": ["boolean", "null"]
               },
               "aliasNode": {
+                "description": "Specifies the ID of the node for an alias check.",
                 "type": ["string", "null"]
               },
               "aliasService": {
+                "description": "Specifies the ID of a service for an alias check.",
                 "type": ["string", "null"]
               },
               "successBeforePassing": {
+                "description": "Specifies the number of consecutive successful results required before check status transitions to passing.",
                 "type": ["integer", "null"]
               },
               "failuresBeforeCritical": {
+                "description": "Specifies the number of consecutive unsuccessful results required before check status transitions to critical.",
                 "type": ["integer", "null"]
               }
             },
@@ -154,10 +183,11 @@
           }
         },
         "namespace": {
+          "description": "The Consul namespace where the service will be registered [Consul Enterprise].",
           "type": ["string", "null"]
         },
         "partition": {
-          "description": "The Consul admin partition where the service will be registered.",
+          "description": "The Consul admin partition where the service will be registered [Consul Enterprise].",
           "type": ["string", "null"]
         }
       },
@@ -165,47 +195,60 @@
       "additionalProperties": true
     },
     "proxy": {
-      "description": "Configuration for the sidecar proxy registration.",
+      "description": "Configuration for the sidecar proxy registration with Consul.",
       "type": ["object", "null"],
       "properties": {
         "config": {
+          "description": "Object value that specifies an opaque JSON configuration. The JSON is stored and returned along with the service instance when called from the API.",
           "type": ["object", "null"]
         },
         "upstreams": {
+          "description": "The list of the upstream services that the proxy should create listeners for.",
           "type": ["array", "null"],
           "items": {
+            "description": "The list of the upstream services that the proxy should create listeners for. Each upstream may contain these fields.",
             "type": "object",
             "properties": {
               "destinationType": {
+                "description": "Specifies the type of discovery query the proxy should use for finding service mesh instances.",
                 "type": ["string", "null"],
                 "enum": ["service", "prepared_query", null]
               },
               "destinationNamespace": {
+                "description": "Specifies the namespace containing the upstream service [Consul Enterprise].",
                 "type": ["string", "null"]
               },
               "destinationPartition": {
-                "description": "The name of the admin partition containing the upstream service.",
+                "description": "Specifies the name of the admin partition containing the upstream service [Consul Enterprise].",
                 "type": ["string", "null"]
               },
               "destinationName": {
+                "description": "Specifies the name of the upstream service or prepared query to route the service mesh to.",
                 "type": "string"
               },
               "datacenter": {
+                "description": "Specifies the datacenter to issue the discovery query to.",
                 "type": ["string", "null"]
               },
               "localBindAddress": {
+                "description": "Specifies the address to bind a local listener to.",
                 "type": ["string", "null"]
               },
               "localBindPort": {
+                "description": "Specifies the port to bind a local listener to. The application will make outbound connections to the upstream from the local port.",
                 "type": "integer"
               },
               "config": {
+                "description": "Specifies opaque configuration options that will be provided to the proxy instance for the upstream.",
                 "type": ["object", "null"]
               },
               "meshGateway": {
+                "description": "Specifies the mesh gateway configuration for the proxy for this upstream.",
                 "type": ["object", "null"],
                 "properties": {
                   "mode": {
+                    "description": "Specifies how the upstream with a remote destination datacenter gets resolved.",
+                    "type": "string",
                     "enum": ["none", "local", "remote"]
                   }
                 },
@@ -217,9 +260,12 @@
           }
         },
         "meshGateway": {
+          "description": "Specifies the mesh gateway configuration for the proxy.",
           "type": ["object", "null"],
           "properties": {
             "mode": {
+              "description": "Specifies how upstreams with a remote destination datacenter get resolved.",
+              "type": "string",
               "enum": ["none", "local", "remote"]
             }
           },
@@ -227,26 +273,33 @@
         }
       },
       "expose": {
+        "description": "Specifies a configuration for exposing HTTP paths through the proxy.",
         "type": ["object", "null"],
         "properties": {
           "checks": {
+            "description": "If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.",
             "type": "boolean"
           },
           "paths": {
+            "description": "A list of paths to expose through Envoy.",
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
                 "listenerPort": {
+                  "description": "The port where the proxy will listen for connections.",
                   "type": "integer"
                 },
                 "path": {
+                  "description": "The HTTP path to expose. The path must be prefixed by a slash.",
                   "type": "string"
                 },
                 "localPathPort": {
+                  "description": "The port where the local service is listening for connections to the path.",
                   "type": "integer"
                 },
                 "protocol": {
+                  "description": "Sets the protocol of the listener.",
                   "enum": ["http", "http2"]
                 }
               }
@@ -254,8 +307,7 @@
           }
         }
       }
-    },
-    "additionalProperties": false
+    }
   },
   "required": ["service", "bootstrapDir"],
   "additionalProperties": false

--- a/config/validate.go
+++ b/config/validate.go
@@ -14,7 +14,7 @@ const (
 )
 
 func validate(config string) error {
-	schemaLoader := gojsonschema.NewStringLoader(schema)
+	schemaLoader := gojsonschema.NewStringLoader(Schema)
 	configLoader := gojsonschema.NewStringLoader(config)
 
 	result, err := gojsonschema.Validate(schemaLoader, configLoader)

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -53,7 +53,7 @@ func TestMetaSchemaValidation(t *testing.T) {
 	// gojsonschema embeds the meta-schema document, so no HTTP requests needed.
 	loader := gojsonschema.NewSchemaLoader()
 	loader.Validate = true
-	err := loader.AddSchemas(gojsonschema.NewStringLoader(schema))
+	err := loader.AddSchemas(gojsonschema.NewStringLoader(Schema))
 	require.NoError(t, err)
 }
 

--- a/hack/generate-config-reference/main.go
+++ b/hack/generate-config-reference/main.go
@@ -1,0 +1,106 @@
+// Generate markdown from the JSON schema for the Consul ECS config.
+//
+// You can use the Makefile in the root of the repository to run this script.
+// Usage:
+//    make reference-configuration
+//    make reference-configuration consul=<path-to-consul-repo>
+//    go run . > ../../../website/content/docs/ecs/configuration-reference.mdx
+//
+// This generates configuration from the schema.json, recursively:
+// - First, write the preamble to stdout (see ./preamble.mdx).
+// - For each object or array type in schema.json, render a template to stdout (see ./properties.tpl)
+//
+// Edit the <repoRoot>/config/schema.json to modify descriptions.
+// After editing the schema.json, re-run this script to update the Consul ECS documentation.
+// The generated markdown should be included in ECS docs in the Consul repo.
+
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/hashicorp/consul-ecs/config"
+)
+
+var (
+	//go:embed preamble.mdx
+	preamble string
+
+	//go:embed properties.tpl
+	propertiesTemplate string
+
+	// Markdown heading prefixes
+	depthToHeading = []string{
+		0: "#",
+		1: "#",
+		2: "##",
+		3: "###",
+		4: "####",
+		5: "#####",
+		6: "######",
+	}
+)
+
+// getTemplate returns a template for a section of markdown, with the given path as the heading.
+func getTemplate(path string) *template.Template {
+	// Generate heading based on path depth: "## `service.checks`"
+	depth := strings.Count(path, ".")
+	heading := depthToHeading[depth]
+	if path == "" {
+		heading += " Top-level fields"
+	} else {
+		heading += " `" + path + "`"
+	}
+
+	templateString := heading + "\n\n" + propertiesTemplate
+	tpl, err := template.New(path).Parse(templateString)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return tpl
+}
+
+// RenderTemplates walks through the schema recursively to generate markdown.
+// It writes directly to the provided io.Writer.
+func RenderTemplates(path string, schema *Schema, wr io.Writer) {
+	if schema.Type[0] == "array" {
+		itemSchema := schema.Items
+		RenderTemplates(path, itemSchema, wr)
+		return
+	}
+
+	if schema.Type[0] == "object" && schema.Properties != nil {
+		tpl := getTemplate(path)
+
+		schema.Path = path
+		err := tpl.Execute(wr, schema)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for field := range schema.Properties {
+			propSchema := schema.Properties[field]
+			propPath := strings.Trim(path+"."+field, ".")
+			RenderTemplates(propPath, propSchema, wr)
+		}
+	}
+}
+
+func main() {
+	var schema Schema
+	if err := json.Unmarshal([]byte(config.Schema), &schema); err != nil {
+		log.Fatal(err)
+	}
+
+	outWriter := os.Stdout
+
+	_, _ = fmt.Fprintln(outWriter, preamble)
+	RenderTemplates("", &schema, outWriter)
+}

--- a/hack/generate-config-reference/preamble.mdx
+++ b/hack/generate-config-reference/preamble.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: AWS ECS
+description: >-
+  Configuration Reference for Consul on AWS ECS (Elastic Container Service).
+  Do not modify by hand! This is automatically generated documentation.
+---
+
+# Configuration Reference
+
+This pages details the configuration options for the JSON config format used
+by the `consul-ecs` binary. This configuration is passed to the `consul-ecs`
+binary as a string using the `CONSUL_ECS_CONFIG_JSON` environment variable.
+
+This configuration format follows a [JSON schema](https://github.com/hashicorp/consul-ecs/blob/main/config/schema.json)
+that can be used for validation.
+
+## Terraform Mesh Task Module Configuration
+
+The `mesh-task` Terraform module provides input variables for commonly used fields.
+The following table shows which Terraform input variables correspond to each field
+of the Consul ECS configuration. Refer to the
+[Terraform registry documentation](https://registry.terraform.io/modules/hashicorp/consul-ecs/aws/latest/submodules/mesh-task?tab=inputs)
+for a complete reference of supported input variables for the `mesh-task` module.
+
+| Terraform Input Variable | Consul ECS Config Field               |
+| ------------------------ | ------------------------------------- |
+| `upstreams`              | [`proxy.upstreams`](#proxy-upstreams) |
+| `checks`                 | [`service.checks`](#service-checks)   |
+| `consul_service_name`    | [`service.name`](#service)            |
+| `consul_service_tags`    | [`service.tags`](#service)            |
+| `consul_service_meta`    | [`service.meta`](#service)            |
+| `consul_namespace`       | [`service.namespace`](#service)       |
+| `consul_partition`       | [`service.partition`](#service)       |
+
+Each of these Terraform input variables follow the Consul ECS config schema.
+The remaining fields of the Consul ECS configuration not listed in this table can be passed
+using the `consul_ecs_config` input variable.

--- a/hack/generate-config-reference/properties.tpl
+++ b/hack/generate-config-reference/properties.tpl
@@ -1,0 +1,12 @@
+{{ .Description }}
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+{{- range $key, $val := .Properties }}
+{{- with $anchor := $.PropertyAnchor $key }}
+| [`{{ $key }}`](#{{ $anchor }}) | `{{ index $val.Type 0 }}` | {{ $.RequiredStr $key }} | {{ $val.Description }} {{ $val.EnumStr }} |
+{{- else }}
+| `{{ $key }}` | `{{ index $val.Type 0 }}` | {{ $.RequiredStr $key }} | {{ $val.Description }} {{ $val.EnumStr }} |
+{{- end }}
+{{- end }}
+

--- a/hack/generate-config-reference/schema.go
+++ b/hack/generate-config-reference/schema.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Schema struct {
+	ID          string             `json:"$id"`
+	Schema      string             `json:"$schema"`
+	Title       string             `json:"title"`
+	Description string             `json:"description"`
+	Type        jsonschemaType     `json:"type"`
+	Properties  map[string]*Schema `json:"properties"`
+	Items       *Schema            `json:"items"`
+
+	AdditionalProperties bool      `json:"additionalProperties"`
+	MinLength            int       `json:"minLength"`
+	Enum                 []*string `json:"enum"`
+	MinItems             int       `json:"minItems"`
+	Required             []string  `json:"required"`
+	UniqueItems          bool      `json:"uniqueItems"`
+
+	// Extra fields for template args.
+	Path string `json:"-"`
+}
+
+// RequiredStr returns "required" or "optional" if the given
+// field is in the list of required fields for this schema.
+func (s *Schema) RequiredStr(field string) string {
+	for _, req := range s.Required {
+		if req == field {
+			return "required"
+		}
+	}
+	return "optional"
+}
+
+// EnumStr joins the enum list for this schema into human-readable markdown, such as
+// "Must be one of `local`, `remote`, or `none`."  If this schema has no enum field,
+// an empty string is returned.
+func (s *Schema) EnumStr() string {
+	result := ""
+	for i, val := range s.Enum {
+		if len(s.Enum) > 2 && i > 0 {
+			result += ", "
+			if i == len(s.Enum)-1 {
+				result += "or"
+			}
+		}
+
+		if val == nil {
+			result += "`null`"
+		} else {
+			result += "`" + *val + "`"
+		}
+	}
+	if len(result) > 0 {
+		result = "Must be one of " + result + "."
+	}
+	return result
+}
+
+// PropertyAnchor returns the markdown/html anchor for a field in a table, if the field
+// is an object or array type. The anchor links to another section in the page describing
+// that field so that users can navigate the page more easily.
+//
+// This will return an empty string if the field has no suitable link.
+func (t *Schema) PropertyAnchor(field string) string {
+	propSchema := t.Properties[field]
+
+	var fieldProperties map[string]*Schema
+	switch propSchema.Type[0] {
+	case "object":
+		fieldProperties = propSchema.Properties
+	case "array":
+		fieldProperties = propSchema.Items.Properties
+	default:
+		return ""
+	}
+
+	if len(fieldProperties) == 0 {
+		// If the type has no properties documented, there's no section in the markdown describing those properties,
+		// so there's nothing to link to. This is the case for, e.g. the `meta` field, which has arbitrary data.
+		return ""
+	}
+	// Convert from e.g. `proxy.upstreams.meshGateway` -> `proxy-upstreams-meshgateway` to
+	// match markdown/html anchors.
+	anchor := strings.Trim(t.Path+"."+field, ".")
+	anchor = strings.ReplaceAll(anchor, ".", "-")
+	return strings.ToLower(anchor)
+}
+
+// Special parsing for the `type` field, which can be a string or []string.
+// Normalize the "type" to []string.
+type jsonschemaType []string
+
+func (t *jsonschemaType) UnmarshalJSON(data []byte) error {
+	var array []string
+	if err := json.Unmarshal(data, &array); err == nil {
+		*t = append(*t, array...)
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*t = append(*t, str)
+		return nil
+	}
+
+	return fmt.Errorf("cannot unmarshal type field as string or []string: %s", string(data))
+}


### PR DESCRIPTION
## Changes proposed in this PR:
* Add a script to generate reference config from the JSON schema (`docgen` directory).
* Add descriptions to all the fields in the schema.json

## How I've tested this PR:

Ran the script, and reviewed the markdown.

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
