### PR TITLE
Admin partition updates

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -10,6 +10,8 @@ type Config struct {
 	HealthSyncContainers []string                        `json:"healthSyncContainers,omitempty"`
 	Proxy                *AgentServiceConnectProxyConfig `json:"proxy"`
 	Service              ServiceRegistration             `json:"service"`
+	Namespace            string                          `json:"namespace,omitempty"`
+	Partition            string                          `json:"partition,omitempty"`
 }
 
 // ServiceRegistration configures the Consul service registration.

--- a/config/types.go
+++ b/config/types.go
@@ -10,8 +10,6 @@ type Config struct {
 	HealthSyncContainers []string                        `json:"healthSyncContainers,omitempty"`
 	Proxy                *AgentServiceConnectProxyConfig `json:"proxy"`
 	Service              ServiceRegistration             `json:"service"`
-	Namespace            string                          `json:"namespace,omitempty"`
-	Partition            string                          `json:"partition,omitempty"`
 }
 
 // ServiceRegistration configures the Consul service registration.
@@ -152,6 +150,7 @@ func (w *AgentWeights) ToConsulType() *api.AgentWeights {
 // - The bind address is always localhost in ECS, so the Address and SocketPath are excluded.
 // - The Connect field is excluded. Since the sidecar proxy is being used, it's not a Connect-native
 //   service, and we don't need the nested proxy config included in the Connect field.
+// - The Partition field is excluded. mesh-init will use the partition from the service registration.
 // - The Namespace field is excluded. mesh-init will use the namespace from the service registration.
 // - There's not a use-case for specifying TaggedAddresses with Consul ECS, and Enable
 // For the proxy configuration (api.AgentServiceConnectProxyConfig in Consul),

--- a/controller/policy.go
+++ b/controller/policy.go
@@ -32,10 +32,10 @@ const entServicePolicyTpl = `partition "%s" {
   }
 }`
 
-// Cross namespace policy constants
-const xnsPolicyName = "cross-namespace-read"
-const xnsPolicyDesc = "Allow service and node reads across namespaces within the partition"
-const xnsPolicyTpl = `partition "%s" {
+// Cross partition/namespace policy constants
+const xpPolicyName = "cross-ap-ns-read"
+const xpPolicyDesc = "Allow service and node reads across all partitions and namespaces"
+const xpPolicy = `partition_prefix "" {
   namespace_prefix "" {
     service_prefix "" {
       policy = "read"

--- a/controller/policy.go
+++ b/controller/policy.go
@@ -32,10 +32,10 @@ const entServicePolicyTpl = `partition "%s" {
   }
 }`
 
-// Cross partition/namespace policy constants
-const xpPolicyName = "cross-ap-ns-read"
-const xpPolicyDesc = "Allow service and node reads across all partitions and namespaces"
-const xpPolicy = `partition_prefix "" {
+// Cross namespace policy constants
+const xnsPolicyName = "cross-namespace-read"
+const xnsPolicyDesc = "Allow service and node reads across namespaces within the partition"
+const xnsPolicyTpl = `partition "%s" {
   namespace_prefix "" {
     service_prefix "" {
       policy = "read"

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -600,10 +600,14 @@ func (s *ServiceInfo) createServiceToken(secret TokenSecretJSON) error {
 }
 
 func (s *ServiceInfo) secretName() string {
-	if s.ServiceName.Namespace == "" || s.ServiceName.Namespace == DefaultNamespace {
-		return fmt.Sprintf("%s-%s", s.SecretPrefix, s.ServiceName.Name)
+	if PartitionsEnabled(s.ServiceName.Partition) {
+		return fmt.Sprintf("%s-%s-%s-%s",
+			s.SecretPrefix,
+			s.ServiceName.Name,
+			s.ServiceName.Namespace,
+			s.ServiceName.Partition)
 	} else {
-		return fmt.Sprintf("%s-%s-%s", s.SecretPrefix, s.ServiceName.Name, s.ServiceName.Namespace)
+		return fmt.Sprintf("%s-%s", s.SecretPrefix, s.ServiceName.Name)
 	}
 }
 

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -339,7 +339,6 @@ func (s ServiceStateLister) createNamespaces(resources []Resource) error {
 		_, _, err = s.ConsulClient.Namespaces().Create(&api.Namespace{
 			Partition: s.Partition,
 			Name:      n,
-			ACLs:      &api.NamespaceACLConfig{PolicyDefaults: []api.ACLLink{{Name: xpPolicyName}}},
 		}, nil)
 		if err != nil {
 			s.Log.Error("failed to create namespace", "name", n)

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -521,7 +521,7 @@ func (s *ServiceInfo) upsertSecret() (TokenSecretJSON, error) {
 	// Get current secret from AWS.
 	currSecretValue, err := s.SecretsManagerClient.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretId: aws.String(secretName)})
 	if err != nil {
-		return currSecret, fmt.Errorf("retrieving secret: %w", err)
+		return currSecret, fmt.Errorf("retrieving secret %s: %w", secretName, err)
 	}
 	err = json.Unmarshal([]byte(*currSecretValue.SecretString), &currSecret)
 	if err != nil {

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -44,6 +44,8 @@ type ServiceName struct {
 	Partition string
 	// Namespace that the service belongs to (Consul Enterprise).
 	Namespace string
+	// ACLPartition defines the partition that ACL tokens and policies are scoped to (Consul Enterprise).
+	ACLPartition string
 	// ACLNamespace defines the namespace that ACL tokens and policies are scoped to (Consul Enterprise).
 	ACLNamespace string
 }
@@ -261,8 +263,8 @@ func (s ServiceStateLister) ReconcileNamespaces(resources []Resource) error {
 		return nil
 	}
 
-	// create the cross-namespace read policy
-	if err := s.upsertCrossNSPolicy(); err != nil {
+	// create the cross partition read policy
+	if err := s.upsertCrossAPPolicy(); err != nil {
 		return err
 	}
 
@@ -274,15 +276,15 @@ func (s ServiceStateLister) ReconcileNamespaces(resources []Resource) error {
 	return nil
 }
 
-// upsertCrossNSPolicy creates the cross-namespace read policy in the local
-// partition and default namespace, if it does not already exist.
-func (s ServiceStateLister) upsertCrossNSPolicy() error {
+// upsertCrossAPPolicy creates the cross-partition read policy in the default
+// partition and namespace, if it does not already exist.
+func (s ServiceStateLister) upsertCrossAPPolicy() error {
 	policy, _, err := s.ConsulClient.ACL().PolicyReadByName(
-		xnsPolicyName,
-		&api.QueryOptions{Partition: s.Partition, Namespace: DefaultNamespace},
+		xpPolicyName,
+		&api.QueryOptions{Partition: DefaultPartition, Namespace: DefaultNamespace},
 	)
 	if err != nil && !IsACLNotFoundError(err) {
-		return fmt.Errorf("reading cross-namespace policy: %w", err)
+		return fmt.Errorf("reading cross-partition policy: %w", err)
 	}
 
 	if policy != nil {
@@ -292,17 +294,17 @@ func (s ServiceStateLister) upsertCrossNSPolicy() error {
 
 	// create the policy in the local partition and default namespace.
 	_, _, err = s.ConsulClient.ACL().PolicyCreate(&api.ACLPolicy{
-		Name:        xnsPolicyName,
-		Description: xnsPolicyDesc,
-		Partition:   s.Partition,
+		Name:        xpPolicyName,
+		Description: xpPolicyDesc,
+		Partition:   DefaultPartition,
 		Namespace:   DefaultNamespace,
-		Rules:       fmt.Sprintf(xnsPolicyTpl, s.Partition),
+		Rules:       xpPolicy,
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("creating cross-namespace policy: %w", err)
+		return fmt.Errorf("creating cross-partition policy: %w", err)
 	}
 
-	s.Log.Info("created cross-namespace policy", "name", xnsPolicyName)
+	s.Log.Info("created cross-partition policy", "name", xpPolicyName)
 	return nil
 }
 
@@ -337,7 +339,7 @@ func (s ServiceStateLister) createNamespaces(resources []Resource) error {
 		_, _, err = s.ConsulClient.Namespaces().Create(&api.Namespace{
 			Partition: s.Partition,
 			Name:      n,
-			ACLs:      &api.NamespaceACLConfig{PolicyDefaults: []api.ACLLink{{Name: xnsPolicyName}}},
+			ACLs:      &api.NamespaceACLConfig{PolicyDefaults: []api.ACLLink{{Name: xpPolicyName}}},
 		}, nil)
 		if err != nil {
 			s.Log.Error("failed to create namespace", "name", n)
@@ -361,9 +363,11 @@ func (s ServiceStateLister) newServiceInfo(serviceName ServiceName, serviceState
 
 // Task definition ARN looks like this: arn:aws:ecs:us-east-1:1234567890:task-definition/service:1
 func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error) {
-	var partition, namespace, aclNamespace string
+	var partition, namespace, aclPartition, aclNamespace string
 	if PartitionsEnabled(s.Partition) {
-		// ACLs are always created in the default namespace.
+		// ACLs are always created in the default partition and namespace to allow for networking
+		// across admin partitions
+		aclPartition = DefaultPartition
 		aclNamespace = DefaultNamespace
 		partition = tagValue(t.Tags, partitionTag)
 		namespace = tagValue(t.Tags, namespaceTag)
@@ -381,6 +385,7 @@ func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error)
 			Name:         serviceName,
 			Partition:    partition,
 			Namespace:    namespace,
+			ACLPartition: aclPartition,
 			ACLNamespace: aclNamespace}, nil
 	}
 	taskDefArn := *t.TaskDefinitionArn
@@ -397,6 +402,7 @@ func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error)
 		Name:         splits[0],
 		Partition:    partition,
 		Namespace:    namespace,
+		ACLPartition: aclPartition,
 		ACLNamespace: aclNamespace}, nil
 }
 
@@ -407,9 +413,10 @@ func (s ServiceStateLister) serviceNameFromDescription(d string) ServiceName {
 	// description is of the form: "<Policy|Token> for <name> service..."
 	var n int
 	var err error
-	var key, name, cluster, partition, namespace, aclNamespace string
+	var key, name, cluster, partition, namespace, aclPartition, aclNamespace string
 
 	if PartitionsEnabled(s.Partition) {
+		aclPartition = DefaultPartition
 		aclNamespace = DefaultNamespace
 		scanFmt := fmt.Sprintf("%%s for %%s service\n%s: %%s\n%s: %%s\n%s: %%s",
 			clusterTag,
@@ -424,7 +431,13 @@ func (s ServiceStateLister) serviceNameFromDescription(d string) ServiceName {
 		return ServiceName{}
 	}
 
-	return ServiceName{Name: name, Partition: partition, Namespace: namespace, ACLNamespace: aclNamespace}
+	return ServiceName{
+		Name:         name,
+		Partition:    partition,
+		Namespace:    namespace,
+		ACLPartition: aclPartition,
+		ACLNamespace: aclNamespace,
+	}
 }
 
 // ServiceState contains all of the information needed to determine if an ACL
@@ -472,7 +485,7 @@ func (s *ServiceInfo) Reconcile() error {
 // Upsert creates a service policy and token for the task if one doesn't already exist
 // and updates the secret with the contents of the token.
 func (s *ServiceInfo) Upsert() error {
-	opts := &api.QueryOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.ACLNamespace}
+	opts := &api.QueryOptions{Partition: s.ServiceName.ACLPartition, Namespace: s.ServiceName.ACLNamespace}
 
 	// upsert policy
 	currPolicy, _, err := s.ConsulClient.ACL().PolicyReadByName(s.policyName(), opts)
@@ -515,7 +528,7 @@ func (s *ServiceInfo) Upsert() error {
 
 // Delete removes the service policy and token for the given ServiceInfo.
 func (s *ServiceInfo) Delete() error {
-	opts := &api.WriteOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.ACLNamespace}
+	opts := &api.WriteOptions{Partition: s.ServiceName.ACLPartition, Namespace: s.ServiceName.ACLNamespace}
 
 	for _, token := range s.ServiceState.ACLTokens {
 		_, err := s.ConsulClient.ACL().TokenDelete(token.AccessorID, opts)
@@ -597,7 +610,7 @@ func (s *ServiceInfo) createServicePolicy() error {
 	_, _, err := s.ConsulClient.ACL().PolicyCreate(&api.ACLPolicy{
 		Name:        s.policyName(),
 		Description: s.aclDescription("Policy"),
-		Partition:   s.ServiceName.Partition,
+		Partition:   s.ServiceName.ACLPartition,
 		Namespace:   s.ServiceName.ACLNamespace,
 		Rules:       s.policy(),
 	}, nil)
@@ -615,7 +628,7 @@ func (s *ServiceInfo) createServiceToken(secret TokenSecretJSON) error {
 	policies := []*api.ACLTokenPolicyLink{&api.ACLLink{Name: s.policyName()}}
 	if PartitionsEnabled(s.ServiceName.Partition) {
 		// Include the cross-namespace read policy when partitions are enabled.
-		policies = append(policies, &api.ACLLink{Name: xnsPolicyName})
+		policies = append(policies, &api.ACLLink{Name: xpPolicyName})
 	}
 
 	// Create ACL token for envoy to register the service.
@@ -624,7 +637,7 @@ func (s *ServiceInfo) createServiceToken(secret TokenSecretJSON) error {
 		SecretID:    secret.Token,
 		Description: s.aclDescription("Token"),
 		Policies:    policies,
-		Partition:   s.ServiceName.Partition,
+		Partition:   s.ServiceName.ACLPartition,
 		Namespace:   s.ServiceName.ACLNamespace,
 	}, nil)
 	if err != nil {
@@ -660,7 +673,7 @@ func (s *ServiceInfo) aclDescription(d string) string {
 
 func (s *ServiceInfo) policyName() string {
 	if PartitionsEnabled(s.ServiceName.Partition) {
-		return fmt.Sprintf("%s-%s-service", s.ServiceName.Name, s.ServiceName.Namespace)
+		return fmt.Sprintf("service-%s-%s-%s", s.ServiceName.Name, s.ServiceName.Partition, s.ServiceName.Namespace)
 	} else {
 		return fmt.Sprintf("%s-service", s.ServiceName.Name)
 	}

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -170,6 +170,8 @@ func (s ServiceStateLister) fetchECSTasks() (map[ServiceName]struct{}, error) {
 			}
 
 			serviceName, err := s.serviceNameForTask(task)
+			// TODO: remove log message
+			s.Log.Info("found mesh task", "service-name", serviceName)
 
 			if err != nil {
 				s.Log.Error("couldn't get service name from task", "task-arn", task.TaskArn, "tags", task.Tags, "err", err)

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -170,8 +170,6 @@ func (s ServiceStateLister) fetchECSTasks() (map[ServiceName]struct{}, error) {
 			}
 
 			serviceName, err := s.serviceNameForTask(task)
-			// TODO: remove log message
-			s.Log.Info("found mesh task", "service-name", serviceName)
 
 			if err != nil {
 				s.Log.Error("couldn't get service name from task", "task-arn", task.TaskArn, "tags", task.Tags, "err", err)

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -44,6 +44,8 @@ type ServiceName struct {
 	Partition string
 	// Namespace that the service belongs to (Consul Enterprise).
 	Namespace string
+	// ACLNamespace defines the namespace that ACL tokens and policies are scoped to (Consul Enterprise).
+	ACLNamespace string
 }
 
 // ResourceLister is an interface for listing Resources.
@@ -223,12 +225,7 @@ func (s ServiceStateLister) fetchACLState() (map[ServiceName]*ServiceState, erro
 
 		for _, policy := range policyList {
 			if isInCluster(s.Cluster, policy.Description) {
-				name := serviceNameFromDescription(policy.Description)
-				serviceName := ServiceName{
-					Name:      name,
-					Partition: s.Partition,
-					Namespace: ns.Name,
-				}
+				serviceName := s.serviceNameFromDescription(policy.Description)
 				if state, ok := aclState[serviceName]; ok {
 					state.ACLPolicies = append(state.ACLPolicies, policy)
 				} else {
@@ -244,11 +241,7 @@ func (s ServiceStateLister) fetchACLState() (map[ServiceName]*ServiceState, erro
 
 		for _, token := range tokenList {
 			if isInCluster(s.Cluster, token.Description) {
-				serviceName := ServiceName{
-					Name:      serviceNameFromDescription(token.Description),
-					Partition: s.Partition,
-					Namespace: ns.Name,
-				}
+				serviceName := s.serviceNameFromDescription(token.Description)
 				if state, ok := aclState[serviceName]; ok {
 					state.ACLTokens = append(state.ACLTokens, token)
 				} else {
@@ -368,8 +361,10 @@ func (s ServiceStateLister) newServiceInfo(serviceName ServiceName, serviceState
 
 // Task definition ARN looks like this: arn:aws:ecs:us-east-1:1234567890:task-definition/service:1
 func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error) {
-	var partition, namespace string
+	var partition, namespace, aclNamespace string
 	if PartitionsEnabled(s.Partition) {
+		// ACLs are always created in the default namespace.
+		aclNamespace = DefaultNamespace
 		partition = tagValue(t.Tags, partitionTag)
 		namespace = tagValue(t.Tags, namespaceTag)
 		if partition == "" && namespace == "" {
@@ -382,7 +377,11 @@ func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error)
 		}
 	}
 	if serviceName := tagValue(t.Tags, serviceNameTag); serviceName != "" {
-		return ServiceName{Name: serviceName, Partition: partition, Namespace: namespace}, nil
+		return ServiceName{
+			Name:         serviceName,
+			Partition:    partition,
+			Namespace:    namespace,
+			ACLNamespace: aclNamespace}, nil
 	}
 	taskDefArn := *t.TaskDefinitionArn
 	splits := strings.Split(taskDefArn, "/")
@@ -394,7 +393,38 @@ func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error)
 	if len(splits) != 2 {
 		return ServiceName{}, fmt.Errorf("cannot determine task family from task definition ARN: %q", taskDefArn)
 	}
-	return ServiceName{Name: splits[0], Partition: partition, Namespace: namespace}, nil
+	return ServiceName{
+		Name:         splits[0],
+		Partition:    partition,
+		Namespace:    namespace,
+		ACLNamespace: aclNamespace}, nil
+}
+
+// serviceNameFromDescription returns the fully qualified service name from the
+// description field of a token or policy created by the ACL controller.
+// If a valid name can't be determined from the input an empty name is returned.
+func (s ServiceStateLister) serviceNameFromDescription(d string) ServiceName {
+	// description is of the form: "<Policy|Token> for <name> service..."
+	var n int
+	var err error
+	var key, name, cluster, partition, namespace, aclNamespace string
+
+	if PartitionsEnabled(s.Partition) {
+		aclNamespace = DefaultNamespace
+		scanFmt := fmt.Sprintf("%%s for %%s service\n%s: %%s\n%s: %%s\n%s: %%s",
+			clusterTag,
+			partitionTag,
+			namespaceTag)
+		n, err = fmt.Sscanf(d, scanFmt, &key, &name, &cluster, &partition, &namespace)
+	} else {
+		n, err = fmt.Sscanf(d, "%s for %s service\n", &key, &name)
+	}
+
+	if err != nil || n < 2 {
+		return ServiceName{}
+	}
+
+	return ServiceName{Name: name, Partition: partition, Namespace: namespace, ACLNamespace: aclNamespace}
 }
 
 // ServiceState contains all of the information needed to determine if an ACL
@@ -442,7 +472,7 @@ func (s *ServiceInfo) Reconcile() error {
 // Upsert creates a service policy and token for the task if one doesn't already exist
 // and updates the secret with the contents of the token.
 func (s *ServiceInfo) Upsert() error {
-	opts := &api.QueryOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.Namespace}
+	opts := &api.QueryOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.ACLNamespace}
 
 	// upsert policy
 	currPolicy, _, err := s.ConsulClient.ACL().PolicyReadByName(s.policyName(), opts)
@@ -485,7 +515,7 @@ func (s *ServiceInfo) Upsert() error {
 
 // Delete removes the service policy and token for the given ServiceInfo.
 func (s *ServiceInfo) Delete() error {
-	opts := &api.WriteOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.Namespace}
+	opts := &api.WriteOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.ACLNamespace}
 
 	for _, token := range s.ServiceState.ACLTokens {
 		_, err := s.ConsulClient.ACL().TokenDelete(token.AccessorID, opts)
@@ -568,7 +598,7 @@ func (s *ServiceInfo) createServicePolicy() error {
 		Name:        s.policyName(),
 		Description: s.aclDescription("Policy"),
 		Partition:   s.ServiceName.Partition,
-		Namespace:   s.ServiceName.Namespace,
+		Namespace:   s.ServiceName.ACLNamespace,
 		Rules:       s.policy(),
 	}, nil)
 	if err != nil {
@@ -589,7 +619,7 @@ func (s *ServiceInfo) createServiceToken(secret TokenSecretJSON) error {
 		Description: s.aclDescription("Token"),
 		Policies:    []*api.ACLTokenPolicyLink{&api.ACLLink{Name: s.policyName()}},
 		Partition:   s.ServiceName.Partition,
-		Namespace:   s.ServiceName.Namespace,
+		Namespace:   s.ServiceName.ACLNamespace,
 	}, nil)
 	if err != nil {
 		return fmt.Errorf("creating ACL token: %s", err)
@@ -612,11 +642,22 @@ func (s *ServiceInfo) secretName() string {
 }
 
 func (s *ServiceInfo) aclDescription(d string) string {
-	return fmt.Sprintf("%s for %s service\n%s: %s", d, s.ServiceName.Name, clusterTag, s.Cluster)
+	desc := fmt.Sprintf("%s for %s service\n%s: %s", d, s.ServiceName.Name, clusterTag, s.Cluster)
+	if PartitionsEnabled(s.ServiceName.Partition) {
+		desc = fmt.Sprintf("%s\n%s: %s\n%s: %s",
+			desc,
+			partitionTag, s.ServiceName.Partition,
+			namespaceTag, s.ServiceName.Namespace)
+	}
+	return desc
 }
 
 func (s *ServiceInfo) policyName() string {
-	return fmt.Sprintf("%s-service", s.ServiceName.Name)
+	if PartitionsEnabled(s.ServiceName.Partition) {
+		return fmt.Sprintf("%s-%s-service", s.ServiceName.Name, s.ServiceName.Namespace)
+	} else {
+		return fmt.Sprintf("%s-service", s.ServiceName.Name)
+	}
 }
 
 func (s *ServiceInfo) policy() string {
@@ -654,19 +695,6 @@ func tagValue(tags []*ecs.Tag, key string) string {
 // IsACLNotFoundError returns true if the ACL is not found.
 func IsACLNotFoundError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "Unexpected response code: 403 (ACL not found)")
-}
-
-// serviceNameFromDescription returns the fully qualified service name from the
-// description field of a token or policy created by the ACL controller.
-// If a valid name can't be determined from the input the empty string is returned.
-func serviceNameFromDescription(d string) string {
-	// description is of the form: "<Policy|Token> for <name> service..."
-	var key, val string
-	n, err := fmt.Sscanf(d, "%s for %s", &key, &val)
-	if err == nil && n == 2 {
-		return val
-	}
-	return ""
 }
 
 // PartitionsEnabled indicates if support for partitions and namespaces is enabled.

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -306,6 +306,11 @@ func TestReconcile(t *testing.T) {
 			}
 
 			log := hclog.NewNullLogger()
+			serviceStateLister := ServiceStateLister{
+				ConsulClient: consulClient,
+				Partition:    c.sutServiceName.Partition,
+				Log:          log,
+			}
 
 			serviceInfo := ServiceInfo{
 				SecretsManagerClient: smClient,
@@ -321,14 +326,13 @@ func TestReconcile(t *testing.T) {
 				Log: log,
 			}
 
+			if enterpriseFlag() {
+				// for enterprise testing we need to create the cross-namespace policy
+				require.NoError(t, serviceStateLister.ReconcileNamespaces([]Resource{&serviceInfo}))
+			}
+
 			err := serviceInfo.Reconcile()
 			require.NoError(t, err)
-
-			serviceStateLister := ServiceStateLister{
-				ConsulClient: consulClient,
-				Partition:    c.sutServiceName.Partition,
-				Log:          log,
-			}
 
 			aclState, err := serviceStateLister.fetchACLState()
 			require.NoError(t, err)

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -62,7 +62,6 @@ func TestServiceStateLister_List(t *testing.T) {
 		if enterprise {
 			name.Partition = partition
 			name.Namespace = namespace
-			name.ACLPartition = DefaultPartition
 			name.ACLNamespace = DefaultNamespace
 			token.Partition = partition
 			token.Namespace = DefaultNamespace
@@ -272,7 +271,6 @@ func TestReconcile(t *testing.T) {
 			if enterpriseFlag() {
 				c.sutServiceName.Partition = "default"
 				c.sutServiceName.Namespace = "default"
-				c.sutServiceName.ACLPartition = "default"
 				c.sutServiceName.ACLNamespace = "default"
 
 				aclToken1.Partition = "default"
@@ -622,7 +620,7 @@ func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
 	if enterpriseFlag() {
 		c := cases["add"]
 		c.partition = "test-partition"
-		c.serviceName = ServiceName{Name: "real-service-name", Partition: "test-partition", Namespace: "test-namespace", ACLPartition: "default", ACLNamespace: "default"}
+		c.serviceName = ServiceName{Name: "real-service-name", Partition: "test-partition", Namespace: "test-namespace", ACLNamespace: "default"}
 		c.task = ecs.Task{
 			TaskDefinitionArn: aws.String(validARN),
 			Tags: []*ecs.Tag{
@@ -644,7 +642,7 @@ func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
 
 		c = cases["add"]
 		c.partition = "default"
-		c.serviceName = ServiceName{Name: "real-service-name", Partition: "default", Namespace: "default", ACLPartition: "default", ACLNamespace: "default"}
+		c.serviceName = ServiceName{Name: "real-service-name", Partition: "default", Namespace: "default", ACLNamespace: "default"}
 		c.task = ecs.Task{
 			TaskDefinitionArn: aws.String(validARN),
 			Tags: []*ecs.Tag{
@@ -784,15 +782,15 @@ func TestReconcileNamespaces(t *testing.T) {
 				resourcesIF = append(resourcesIF, r)
 			}
 
-			// create the namespaces and cross-partition policies
+			// create the namespaces and cross-namespace policies
 			// this does nothing if enterprise features are not enabled
 			require.NoError(t, s.ReconcileNamespaces(resourcesIF))
 
 			if c.partition != "" {
-				// if partitions are enabled ensure that the cross-partition read policy exists
-				rules, err := getPolicyRules(t, consulClient, c.partition, DefaultNamespace, xpPolicyName)
+				// if partitions are enabled ensure that the cross-namespace read policy exists
+				rules, err := getPolicyRules(t, consulClient, c.partition, DefaultNamespace, xnsPolicyName)
 				require.NoError(t, err)
-				require.Equal(t, xpPolicy, rules)
+				require.Equal(t, fmt.Sprintf(xnsPolicyTpl, c.partition), rules)
 			}
 
 			obsNS := listNamespaces(t, consulClient)
@@ -849,7 +847,7 @@ func TestTaskLifecycle(t *testing.T) {
 			},
 			expServices: []*ServiceInfo{
 				{
-					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[0], ACLPartition: "default", ACLNamespace: "default"},
+					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[0], ACLNamespace: "default"},
 					ServiceState: ServiceState{
 						ConsulECSTasks: true,
 						ACLPolicies: []*api.ACLPolicyListEntry{
@@ -868,7 +866,7 @@ func TestTaskLifecycle(t *testing.T) {
 					},
 				},
 				{
-					ServiceName: ServiceName{Name: "service2", Partition: "default", Namespace: namespaces[0], ACLPartition: "default", ACLNamespace: "default"},
+					ServiceName: ServiceName{Name: "service2", Partition: "default", Namespace: namespaces[0], ACLNamespace: "default"},
 					ServiceState: ServiceState{
 						ConsulECSTasks: true,
 						ACLPolicies: []*api.ACLPolicyListEntry{
@@ -887,7 +885,7 @@ func TestTaskLifecycle(t *testing.T) {
 					},
 				},
 				{
-					ServiceName: ServiceName{Name: "service3", Partition: "default", Namespace: namespaces[1], ACLPartition: "default", ACLNamespace: "default"},
+					ServiceName: ServiceName{Name: "service3", Partition: "default", Namespace: namespaces[1], ACLNamespace: "default"},
 					ServiceState: ServiceState{
 						ConsulECSTasks: true,
 						ACLPolicies: []*api.ACLPolicyListEntry{
@@ -933,7 +931,7 @@ func TestTaskLifecycle(t *testing.T) {
 			},
 			expServices: []*ServiceInfo{
 				{
-					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[0], ACLPartition: "default", ACLNamespace: "default"},
+					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[0], ACLNamespace: "default"},
 					ServiceState: ServiceState{
 						ConsulECSTasks: true,
 						ACLPolicies: []*api.ACLPolicyListEntry{
@@ -952,7 +950,7 @@ func TestTaskLifecycle(t *testing.T) {
 					},
 				},
 				{
-					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[1], ACLPartition: "default", ACLNamespace: "default"},
+					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[1], ACLNamespace: "default"},
 					ServiceState: ServiceState{
 						ConsulECSTasks: true,
 						ACLPolicies: []*api.ACLPolicyListEntry{
@@ -1007,7 +1005,6 @@ func TestTaskLifecycle(t *testing.T) {
 					lister.Partition = ""
 					service.ServiceName.Partition = ""
 					service.ServiceName.Namespace = ""
-					service.ServiceName.ACLPartition = ""
 					service.ServiceName.ACLNamespace = ""
 					for _, policy := range service.ServiceState.ACLPolicies {
 						policy.Partition = ""
@@ -1110,7 +1107,7 @@ func TestTaskLifecycle(t *testing.T) {
 			afterPolicies := make([]*api.ACLPolicyListEntry, 0, len(newPolicies))
 			for _, p := range newPolicies {
 				// we don't (currently) clean up namespaces nor their policies, so ignore them
-				if p.Name != xpPolicyName && p.Name != "namespace-management" {
+				if p.Name != "cross-namespace-read" && p.Name != "namespace-management" {
 					afterPolicies = append(afterPolicies, p)
 				}
 			}
@@ -1128,7 +1125,7 @@ func TestACLDescriptions(t *testing.T) {
 	}{
 		"with partitions": {
 			cluster:     "c1",
-			serviceName: ServiceName{Name: "s1", Partition: "p1", Namespace: "n1", ACLPartition: "default", ACLNamespace: "default"},
+			serviceName: ServiceName{Name: "s1", Partition: "p1", Namespace: "n1", ACLNamespace: "default"},
 		},
 		"without partitions": {
 			cluster:     "c1",

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -88,23 +88,24 @@ func (c *Command) run() error {
 			CAPem: []byte(caCert),
 		}
 	}
-	if c.flagPartitionsEnabled {
-		cfg.Partition = c.flagPartition
-	}
 
 	consulClient, err := api.NewClient(cfg)
 	if err != nil {
 		return err
 	}
 
-	smClient := secretsmanager.New(clientSession, nil)
-
-	err = c.upsertConsulClientToken(consulClient, smClient)
-	if err != nil {
+	if err = c.createPartition(consulClient); err != nil {
 		return err
 	}
 
-	if err = c.createPartition(consulClient); err != nil {
+	smClient := secretsmanager.New(clientSession, nil)
+
+	if c.flagPartitionsEnabled {
+		cfg.Partition = c.flagPartition
+	}
+
+	err = c.upsertConsulClientToken(consulClient, smClient)
+	if err != nil {
 		return err
 	}
 

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -111,7 +111,7 @@ func (c *Command) run() error {
 		ConsulClient:         consulClient,
 		Cluster:              cluster,
 		SecretPrefix:         c.flagSecretNamePrefix,
-		Partition:            cfg.Partition,
+		Partition:            c.flagPartition,
 		Log:                  c.log,
 	}
 	ctrl := controller.Controller{
@@ -140,6 +140,7 @@ func (c *Command) Help() string {
 // A non-nil error is returned if the operation fails.
 func (c *Command) createPartition(consulClient *api.Client) error {
 	if !c.flagPartitionsEnabled {
+		c.flagPartition = ""
 		return nil
 	}
 	// check if the partition already exists.

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -100,10 +100,6 @@ func (c *Command) run() error {
 
 	smClient := secretsmanager.New(clientSession, nil)
 
-	if c.flagPartitionsEnabled {
-		cfg.Partition = c.flagPartition
-	}
-
 	err = c.upsertConsulClientToken(consulClient, smClient)
 	if err != nil {
 		return err

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -94,9 +94,6 @@ func (c *Command) realRun() error {
 			"-namespace", serviceRegistration.Namespace)
 	}
 
-	// TODO remove
-	connectArgs = append(connectArgs, "--", "--component-log-level", "upstream:debug,http:debug,router:debug,config:debug")
-
 	cmd := exec.Command("consul", connectArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -100,9 +100,6 @@ func (c *Command) realRun() error {
 		return fmt.Errorf("%s: %s", err, string(out))
 	}
 
-	// TODO remove
-	c.log.Info("envoy", "bootstrap-config", string(out))
-
 	envoyBootstrapFile := path.Join(c.config.BootstrapDir, envoyBoostrapConfigFilename)
 	err = ioutil.WriteFile(envoyBootstrapFile, out, 0444)
 	if err != nil {

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -86,7 +86,13 @@ func (c *Command) realRun() error {
 	c.log.Info("service and proxy registered successfully", "name", serviceRegistration.Name, "id", serviceRegistration.ID)
 
 	// Run consul envoy -bootstrap to generate bootstrap file.
-	cmd := exec.Command("consul", "connect", "envoy", "-proxy-id", proxyRegistration.ID, "-bootstrap", "-grpc-addr=localhost:8502")
+	connectArgs := []string{"connect", "envoy", "-proxy-id", proxyRegistration.ID, "-bootstrap", "-grpc-addr=localhost:8502"}
+	if c.config.Partition != "" {
+		// Partition/namespace support is enabled so augment the connect command.
+		connectArgs = append(connectArgs, "-partition", c.config.Partition, "-namespace", c.config.Namespace)
+	}
+
+	cmd := exec.Command("consul", connectArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %s", err, string(out))

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -95,13 +95,16 @@ func (c *Command) realRun() error {
 	}
 
 	// TODO remove
-	c.log.Info("consul connect", "args", connectArgs)
+	connectArgs = append(connectArgs, "--", "--component-log-level", "upstream:debug,http:debug,router:debug,config:debug")
 
 	cmd := exec.Command("consul", connectArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %s", err, string(out))
 	}
+
+	// TODO remove
+	c.log.Info("envoy", "bootstrap-config", string(out))
 
 	envoyBootstrapFile := path.Join(c.config.BootstrapDir, envoyBoostrapConfigFilename)
 	err = ioutil.WriteFile(envoyBootstrapFile, out, 0444)

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -87,10 +87,15 @@ func (c *Command) realRun() error {
 
 	// Run consul envoy -bootstrap to generate bootstrap file.
 	connectArgs := []string{"connect", "envoy", "-proxy-id", proxyRegistration.ID, "-bootstrap", "-grpc-addr=localhost:8502"}
-	if c.config.Partition != "" {
+	if serviceRegistration.Partition != "" {
 		// Partition/namespace support is enabled so augment the connect command.
-		connectArgs = append(connectArgs, "-partition", c.config.Partition, "-namespace", c.config.Namespace)
+		connectArgs = append(connectArgs,
+			"-partition", serviceRegistration.Partition,
+			"-namespace", serviceRegistration.Namespace)
 	}
+
+	// TODO remove
+	c.log.Info("consul connect", "args", connectArgs)
 
 	cmd := exec.Command("consul", connectArgs...)
 	out, err := cmd.CombinedOutput()
@@ -233,6 +238,7 @@ func (c *Command) constructProxyRegistration(serviceRegistration *api.AgentServi
 			AliasService: serviceRegistration.ID,
 		},
 	}
+	proxyRegistration.Partition = serviceRegistration.Partition
 	proxyRegistration.Namespace = serviceRegistration.Namespace
 	proxyRegistration.Weights = serviceRegistration.Weights
 	proxyRegistration.EnableTagOverride = serviceRegistration.EnableTagOverride


### PR DESCRIPTION
## Changes proposed in this PR:
- Fix the order of operations for the ACL controller initialization: It needs to create the admin partition before creating the ACL policies and tokens.

## How I've tested this PR:
- Using the updated Consul ECS dev image w/ HCP Consul and ECS.

## How I expect reviewers to test this PR:
:eyes: 
