### PR TITLE
Replace deprecated ioutil functions

### DIFF
--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -3,7 +3,7 @@ package awsutil
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -67,7 +67,7 @@ func ECSTaskMetadata() (ECSTaskMeta, error) {
 	if err != nil {
 		return metadataResp, fmt.Errorf("calling metadata uri: %s", err)
 	}
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return metadataResp, fmt.Errorf("reading metadata uri response body: %s", err)
 	}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -87,7 +86,7 @@ func TestFromEnv(t *testing.T) {
 }
 
 func OpenFile(t *testing.T, path string) string {
-	byteFile, err := ioutil.ReadFile(path)
+	byteFile, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return string(byteFile)
 }

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -2,7 +2,6 @@ package meshinit
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -101,7 +100,7 @@ func (c *Command) realRun() error {
 	}
 
 	envoyBootstrapFile := path.Join(c.config.BootstrapDir, envoyBoostrapConfigFilename)
-	err = ioutil.WriteFile(envoyBootstrapFile, out, 0444)
+	err = os.WriteFile(envoyBootstrapFile, out, 0444)
 	if err != nil {
 		return err
 	}
@@ -114,13 +113,13 @@ func (c *Command) realRun() error {
 	if err != nil {
 		return err
 	}
-	data, err := ioutil.ReadFile(ex)
+	data, err := os.ReadFile(ex)
 	if err != nil {
 		return err
 	}
 
 	copyConsulECSBinary := path.Join(c.config.BootstrapDir, "consul-ecs")
-	err = ioutil.WriteFile(copyConsulECSBinary, data, 0755)
+	err = os.WriteFile(copyConsulECSBinary, data, 0755)
 	if err != nil {
 		return err
 	}

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -3,7 +3,6 @@ package meshinit
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -210,7 +209,7 @@ func TestRun(t *testing.T) {
 			ui := cli.NewMockUi()
 			cmd := Command{UI: ui}
 
-			envoyBootstrapDir, err := ioutil.TempDir("", "")
+			envoyBootstrapDir, err := os.MkdirTemp("", "")
 			require.NoError(t, err)
 			envoyBootstrapFile := path.Join(envoyBootstrapDir, envoyBoostrapConfigFilename)
 			copyConsulECSBinary := path.Join(envoyBootstrapDir, "consul-ecs")
@@ -306,7 +305,7 @@ func TestRun(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(expectedProxyServiceRegistration, proxyService, agentServiceIgnoreFields))
 
-			envoyBootstrapContents, err := ioutil.ReadFile(envoyBootstrapFile)
+			envoyBootstrapContents, err := os.ReadFile(envoyBootstrapFile)
 			require.NoError(t, err)
 			require.NotEmpty(t, envoyBootstrapContents)
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Remove deprecated `io/ioutil` functions and replace them with the recommended replacements.

## How I've tested this PR:
- Unit tests (OSS + Enterprise)

## How I expect reviewers to test this PR:
:eyes: 
