### PR TITLE
Support auth method in mesh-init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,13 +137,13 @@ workflows:
       - go-fmt-and-vet
       - linters
       - test:
-          CONSUL_VERSION: "1.11.4"
+          CONSUL_VERSION: "1.12.0"
           name: test-consul
           requires:
             - go-fmt-and-vet
             - linters
       - test:
-          CONSUL_VERSION: "1.11.4+ent"
+          CONSUL_VERSION: "1.12.0+ent"
           ENTERPRISE_FLAG: "-enterprise"
           name: test-consul+ent
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ FEATURES
 * Add `-log-level` flag to `acl-controller`, `envoy-entrypoint`, and `app-entrypoint`
   commands. Add `logLevel` field to config JSON for `mesh-init` and `health-sync` commands.
   [[GH-67](https://github.com/hashicorp/consul-ecs/pull/67)]
+* Add `consulHTTPAddr`, `consulCACertFile`, and `consulLogin` fields to config JSON.
+  `mesh-init` now does a `consul login` to obtain a token if `consulLogin.enabled = true`.
+  [[GH-69](https://github.com/hashicorp/consul-ecs/pull/69)]
 
 ## 0.4.1 (April 08, 2022)
 

--- a/config/resources/test_config_empty_fields.json
+++ b/config/resources/test_config_empty_fields.json
@@ -1,6 +1,9 @@
 {
   "bootstrapDir": "/consul/",
   "healthSyncContainers": [],
+  "consulHTTPAddr": "",
+  "consulCACertFile": "",
+  "consulLogin": {},
   "service": {
     "name": "",
     "tags": [],

--- a/config/resources/test_config_null_nested_fields.json
+++ b/config/resources/test_config_null_nested_fields.json
@@ -1,6 +1,12 @@
 {
   "bootstrapDir": "/consul/",
   "healthSyncContainers": null,
+  "consulLogin": {
+    "enabled": null,
+    "method": null,
+    "includeEntity": null,
+    "extraLoginFlags": null
+  },
   "service": {
     "name": null,
     "tags": null,

--- a/config/resources/test_config_null_top_level_fields.json
+++ b/config/resources/test_config_null_top_level_fields.json
@@ -2,6 +2,9 @@
   "bootstrapDir": "/consul/",
   "healthSyncContainers": null,
   "logLevel": null,
+  "consulHTTPAddr": null,
+  "consulCACertFile": null,
+  "consulLogin": null,
   "service": {
     "name": null,
     "tags": null,

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -4,6 +4,14 @@
     "frontend"
   ],
   "logLevel": "DEBUG",
+  "consulHTTPAddr": "consul.example.com",
+  "consulCACertFile": "/consul/consul-ca-cert.pem",
+  "consulLogin": {
+    "enabled": true,
+    "method": "my-auth-method",
+    "includeEntity": false,
+    "extraLoginFlags": ["-aws-region", "fake"]
+  },
   "service": {
     "name": "frontend",
     "tags": [

--- a/config/schema.json
+++ b/config/schema.json
@@ -15,6 +15,22 @@
       "type": "string",
       "minLength": 1
     },
+    "authMethod": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable login to Consul's AWS IAM auth method to obtain an ACL token. This requires the auth method to be configured on the Consul server, and it the ECS task role to be trusted by the auth method. After login, the token is written to the file `<bootstrapDir>/service-token`.",
+          "type": "boolean"
+        },
+        "loginFlags": {
+          "description": "Additional CLI flags to pass to the `consul login` command. These are appended to `consul login -type aws -token-sink-file <file> -aws-auto-bearer-token -aws-include-identity`. The `-method` flag must be included to specify the auth method name.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "healthSyncContainers": {
       "description": "The names of containers that will have health check status synced from ECS into Consul. Cannot be specified with `service.checks`.",
       "type": ["array", "null"],

--- a/config/schema.json
+++ b/config/schema.json
@@ -24,18 +24,18 @@
       "type": ["string", "null"]
     },
     "consulLogin": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "enabled": {
           "description": "Enable login to Consul's AWS IAM auth method to obtain an ACL token. This requires the auth method to be configured on the Consul server, and the ECS task role must be trusted by the auth method. After login, the token is written to the file `<bootstrapDir>/service-token`.",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "method": {
           "description": "The name of Consul auth method. This is passed as the `-method` option to the `consul login` command. Defaults to `iam-ecs-service-token`.",
           "type": ["string", "null"]
         },
-        "noIncludeEntity": {
-          "description": "Set this to true to remove the `-aws-include-entity` flag from the `consul login` command. By default, the `-aws-include-entity` flag is passed to the `consul login` command. The `-aws-include-entity` flag should be passed if and only if the Consul AWS IAM auth method is configured with `EnableIAMEntityDetails=true`.",
+        "includeEntity": {
+          "description": "Defaults to true. Set this to false to remove the `-aws-include-entity` flag from the `consul login` command. The `-aws-include-entity` flag should be passed if and only if the Consul AWS IAM auth method is configured with `EnableIAMEntityDetails=true`.",
           "type": ["boolean", "null"]
         },
         "extraLoginFlags": {

--- a/config/schema.json
+++ b/config/schema.json
@@ -23,7 +23,7 @@
       "description": "The file path of the Consul server CA certificate.",
       "type": ["string", "null"]
     },
-    "authMethod": {
+    "consulLogin": {
       "type": "object",
       "properties": {
         "enabled": {

--- a/config/schema.json
+++ b/config/schema.json
@@ -15,15 +15,31 @@
       "type": "string",
       "minLength": 1
     },
+    "consulHTTPAddr": {
+      "description": "The HTTP(S) URL of the Consul server. Required when `authMethod.enabled` is set",
+      "type": ["string", "null"]
+    },
+    "consulCACertFile": {
+      "description": "The file path of the Consul server CA certificate.",
+      "type": ["string", "null"]
+    },
     "authMethod": {
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Enable login to Consul's AWS IAM auth method to obtain an ACL token. This requires the auth method to be configured on the Consul server, and it the ECS task role to be trusted by the auth method. After login, the token is written to the file `<bootstrapDir>/service-token`.",
+          "description": "Enable login to Consul's AWS IAM auth method to obtain an ACL token. This requires the auth method to be configured on the Consul server, and the ECS task role must be trusted by the auth method. After login, the token is written to the file `<bootstrapDir>/service-token`.",
           "type": "boolean"
         },
-        "loginFlags": {
-          "description": "Additional CLI flags to pass to the `consul login` command. These are appended to `consul login -type aws -token-sink-file <file> -aws-auto-bearer-token -aws-include-identity`. The `-method` flag must be included to specify the auth method name.",
+        "method": {
+          "description": "The name of Consul auth method. This is passed as the `-method` option to the `consul login` command. Defaults to `iam-ecs-service-token`.",
+          "type": ["string", "null"]
+        },
+        "noIncludeEntity": {
+          "description": "Set this to true to remove the `-aws-include-entity` flag from the `consul login` command. By default, the `-aws-include-entity` flag is passed to the `consul login` command. The `-aws-include-entity` flag should be passed if and only if the Consul AWS IAM auth method is configured with `EnableIAMEntityDetails=true`.",
+          "type": ["boolean", "null"]
+        },
+        "extraLoginFlags": {
+          "description": "Additional CLI flags to pass to the `consul login` command. These are appended to the command `consul login -type aws -method <name> -token-sink-file <file> -aws-auto-bearer-token -aws-include-identity`.",
           "type": ["array", "null"],
           "items": {
             "type": "string"

--- a/config/types.go
+++ b/config/types.go
@@ -16,15 +16,15 @@ type Config struct {
 	BootstrapDir         string                          `json:"bootstrapDir"`
 	ConsulHTTPAddr       string                          `json:"consulHTTPAddr"`
 	ConsulCACertFile     string                          `json:"consulCACertFile"`
-	AuthMethod           AuthMethod                      `json:"authMethod"`
+	ConsulLogin          ConsulLogin                     `json:"consulLogin"`
 	HealthSyncContainers []string                        `json:"healthSyncContainers,omitempty"`
 	LogLevel             string                          `json:"logLevel,omitempty"`
 	Proxy                *AgentServiceConnectProxyConfig `json:"proxy"`
 	Service              ServiceRegistration             `json:"service"`
 }
 
-// AuthMethod configures login options for the Consul IAM auth method.
-type AuthMethod struct {
+// ConsulLogin configures login options for the Consul IAM auth method.
+type ConsulLogin struct {
 	Enabled         bool     `json:"enabled"`
 	Method          string   `json:"method"`
 	NoIncludeEntity bool     `json:"noIncludeEntity"`

--- a/config/types.go
+++ b/config/types.go
@@ -8,9 +8,14 @@ import "github.com/hashicorp/consul/api"
 // if auth method login is enabled.
 const ServiceTokenFilename = "service-token"
 
+// DefaultAuthMethodName is the default name of the Consul IAM auth method used for `consul login`.
+const DefaultAuthMethodName = "iam-ecs-service-token"
+
 // Config is the top-level config object.
 type Config struct {
 	BootstrapDir         string                          `json:"bootstrapDir"`
+	ConsulHTTPAddr       string                          `json:"consulHTTPAddr"`
+	ConsulCACertFile     string                          `json:"consulCACertFile"`
 	AuthMethod           AuthMethod                      `json:"authMethod"`
 	HealthSyncContainers []string                        `json:"healthSyncContainers,omitempty"`
 	LogLevel             string                          `json:"logLevel,omitempty"`
@@ -18,9 +23,12 @@ type Config struct {
 	Service              ServiceRegistration             `json:"service"`
 }
 
+// AuthMethod configures login options for the Consul IAM auth method.
 type AuthMethod struct {
-	Enabled    bool     `json:"enabled"`
-	LoginFlags []string `json:"loginFlags"`
+	Enabled         bool     `json:"enabled"`
+	Method          string   `json:"method"`
+	NoIncludeEntity bool     `json:"noIncludeEntity"`
+	ExtraLoginFlags []string `json:"extraLoginFlags"`
 }
 
 // ServiceRegistration configures the Consul service registration.

--- a/config/types.go
+++ b/config/types.go
@@ -4,13 +4,23 @@ package config
 
 import "github.com/hashicorp/consul/api"
 
+// ServiceTokenFilename is the file in the BootstrapDir where the token is written by `consul login`
+// if auth method login is enabled.
+const ServiceTokenFilename = "service-token"
+
 // Config is the top-level config object.
 type Config struct {
 	BootstrapDir         string                          `json:"bootstrapDir"`
+	AuthMethod           AuthMethod                      `json:"authMethod"`
 	HealthSyncContainers []string                        `json:"healthSyncContainers,omitempty"`
 	LogLevel             string                          `json:"logLevel,omitempty"`
 	Proxy                *AgentServiceConnectProxyConfig `json:"proxy"`
 	Service              ServiceRegistration             `json:"service"`
+}
+
+type AuthMethod struct {
+	Enabled    bool     `json:"enabled"`
+	LoginFlags []string `json:"loginFlags"`
 }
 
 // ServiceRegistration configures the Consul service registration.

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -27,9 +27,9 @@ func TestParse(t *testing.T) {
 			filename:       "resources/test_config_null_top_level_fields.json",
 			expectedConfig: expectedConfigNullTopLevelFields,
 		},
-		"null_proxy_and_service_fields": {
-			filename:       "resources/test_config_null_proxy_and_service_fields.json",
-			expectedConfig: expectedConfigNullProxyAndServiceFields,
+		"null_nested_fields": {
+			filename:       "resources/test_config_null_nested_fields.json",
+			expectedConfig: expectedConfigNullNestedFields,
 		},
 		"empty_fields": {
 			filename:       "resources/test_config_empty_fields.json",
@@ -116,6 +116,14 @@ var (
 		BootstrapDir:         "/consul/",
 		HealthSyncContainers: []string{"frontend"},
 		LogLevel:             "DEBUG",
+		ConsulHTTPAddr:       "consul.example.com",
+		ConsulCACertFile:     "/consul/consul-ca-cert.pem",
+		ConsulLogin: &ConsulLogin{
+			Enabled:         true,
+			Method:          "my-auth-method",
+			IncludeEntity:   false,
+			ExtraLoginFlags: []string{"-aws-region", "fake"},
+		},
 		Service: ServiceRegistration{
 			Name:              "frontend",
 			Tags:              []string{"frontend"},
@@ -226,6 +234,9 @@ var (
 		BootstrapDir:         "/consul/",
 		HealthSyncContainers: nil,
 		LogLevel:             "",
+		ConsulHTTPAddr:       "",
+		ConsulCACertFile:     "",
+		ConsulLogin:          nil,
 		Service: ServiceRegistration{
 			Name:              "",
 			Tags:              nil,
@@ -240,9 +251,17 @@ var (
 		Proxy: nil,
 	}
 
-	expectedConfigNullProxyAndServiceFields = &Config{
+	expectedConfigNullNestedFields = &Config{
 		BootstrapDir:         "/consul/",
 		HealthSyncContainers: nil,
+		ConsulHTTPAddr:       "",
+		ConsulCACertFile:     "",
+		ConsulLogin: &ConsulLogin{
+			Enabled:         false,
+			Method:          "",
+			IncludeEntity:   true, // default true
+			ExtraLoginFlags: nil,
+		},
 		Service: ServiceRegistration{
 			Name:              "",
 			Tags:              nil,
@@ -303,6 +322,12 @@ var (
 	expectedConfigEmptyFields = &Config{
 		BootstrapDir:         "/consul/",
 		HealthSyncContainers: []string{},
+		ConsulLogin: &ConsulLogin{
+			Enabled:         false,
+			Method:          "",
+			IncludeEntity:   true, // default true
+			ExtraLoginFlags: nil,
+		},
 		Service: ServiceRegistration{
 			Name:              "",
 			Tags:              []string{},

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestRun(t *testing.T) {
+	t.Parallel()
 	resource1 := &testResource{
 		name: "resource1",
 	}

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestServiceStateLister_List(t *testing.T) {
+	t.Parallel()
 	enterprise := enterpriseFlag()
 	cluster := "cluster"
 	meshKey := "consul.hashicorp.com/mesh"
@@ -147,6 +148,7 @@ func TestServiceStateLister_List(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			consulClient := initConsul(t)
 
 			if enterprise {
@@ -221,6 +223,7 @@ func TestServiceStateLister_List(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
+	t.Parallel()
 	cluster := "test-cluster"
 	aclToken1 := &api.ACLToken{}
 	aclPolicy1 := &api.ACLPolicy{Name: "service1-service"}
@@ -264,6 +267,7 @@ func TestReconcile(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			smClient := &mocks.SMClient{Secret: &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)}}
 			consulClient := initConsul(t)
 
@@ -366,6 +370,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func TestRecreatingAToken(t *testing.T) {
+	t.Parallel()
 	smClient := &mocks.SMClient{Secret: &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)}}
 	consulClient := initConsul(t)
 
@@ -414,6 +419,7 @@ func TestRecreatingAToken(t *testing.T) {
 }
 
 func TestTask_Upsert(t *testing.T) {
+	t.Parallel()
 	cases := map[string]struct {
 		createExistingToken bool
 		existingSecret      *secretsmanager.GetSecretValueOutput
@@ -441,6 +447,7 @@ func TestTask_Upsert(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			smClient := &mocks.SMClient{Secret: c.existingSecret}
 			consulClient := initConsul(t)
 
@@ -503,6 +510,7 @@ func TestTask_Upsert(t *testing.T) {
 }
 
 func TestTask_Delete(t *testing.T) {
+	t.Parallel()
 	cases := map[string]struct {
 		createExistingToken   bool
 		updateExistingSecret  bool
@@ -520,6 +528,7 @@ func TestTask_Delete(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			existingSecret := &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)}
 			smClient := &mocks.SMClient{Secret: existingSecret}
 			consulClient := initConsul(t)
@@ -586,6 +595,7 @@ func TestTask_Delete(t *testing.T) {
 }
 
 func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
+	t.Parallel()
 	validARN := "arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"
 	cases := map[string]struct {
 		task        ecs.Task
@@ -711,6 +721,7 @@ func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			l := ServiceStateLister{
 				Partition: c.partition,
 			}
@@ -726,6 +737,7 @@ func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
 }
 
 func TestReconcileNamespaces(t *testing.T) {
+	t.Parallel()
 	cases := map[string]struct {
 		partition string
 		expNS     map[string][]string
@@ -759,6 +771,7 @@ func TestReconcileNamespaces(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			consulClient := initConsul(t)
 
 			if !enterpriseFlag() {
@@ -800,6 +813,7 @@ func TestReconcileNamespaces(t *testing.T) {
 }
 
 func TestTaskLifecycle(t *testing.T) {
+	t.Parallel()
 	cluster := "cluster"
 	meshKey := "consul.hashicorp.com/mesh"
 	meshValue := "true"
@@ -972,6 +986,7 @@ func TestTaskLifecycle(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
 			enterprise := enterpriseFlag()
 			if !enterprise {
@@ -1119,6 +1134,7 @@ func TestTaskLifecycle(t *testing.T) {
 }
 
 func TestACLDescriptions(t *testing.T) {
+	t.Parallel()
 	cases := map[string]struct {
 		cluster     string
 		serviceName ServiceName
@@ -1134,6 +1150,7 @@ func TestACLDescriptions(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			s := &ServiceInfo{
 				Cluster:     c.cluster,
 				ServiceName: c.serviceName,

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -985,6 +985,7 @@ func TestTaskLifecycle(t *testing.T) {
 		},
 	}
 	for name, c := range cases {
+		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -47,7 +47,7 @@ func (c *Command) Run(args []string) int {
 	c.log = logging.FromConfig(c.config).Logger()
 
 	cfg := api.DefaultConfig()
-	if c.config.AuthMethod.Enabled {
+	if c.config.ConsulLogin.Enabled {
 		// This file will already have been written by mesh-init.
 		cfg.TokenFile = filepath.Join(c.config.BootstrapDir, config.ServiceTokenFilename)
 	}

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -156,7 +156,7 @@ func (c *Command) loginToAuthMethod(tokenFile string, taskMeta awsutil.ECSTaskMe
 		"-meta", fmt.Sprintf("consul.hashicorp.com/ecs-task-id=%s", taskMeta.TaskID()),
 		"-aws-auto-bearer-token",
 	}
-	if !c.config.ConsulLogin.NoIncludeEntity {
+	if c.config.ConsulLogin.IncludeEntity {
 		loginOpts = append(loginOpts, "-aws-include-entity")
 	}
 	if len(c.config.ConsulLogin.ExtraLoginFlags) > 0 {
@@ -169,14 +169,14 @@ func (c *Command) loginToAuthMethod(tokenFile string, taskMeta awsutil.ECSTaskMe
 		cmd := exec.Command("consul", loginOpts...)
 		out, err := cmd.CombinedOutput()
 		// TODO: Distinguish unrecoverable errors, like lack of permission to log in.
-		if err != nil {
-			if out != nil {
-				c.log.Error(string(out))
-			}
-			c.log.Error(err.Error())
-			return err
+		if out != nil && err != nil {
+			c.log.Error("login", "output", string(out))
 		} else if out != nil {
 			c.log.Debug("login", "output", string(out))
+		}
+		if err != nil {
+			c.log.Error(err.Error())
+			return err
 		}
 		c.log.Info("login success")
 		return nil

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -2,6 +2,7 @@ package meshinit
 
 import (
 	"fmt"
+	"net/http/httptest"
 	"os"
 	"path"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul-ecs/testutil"
+	"github.com/hashicorp/consul-ecs/testutil/iamauthtest"
 	"github.com/hashicorp/consul/api"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -64,6 +66,8 @@ func TestRun(t *testing.T) {
 		expAdditionalMeta map[string]string
 		serviceName       string
 		expServiceName    string
+
+		consulLogin config.ConsulLogin
 	}{
 		"basic service": {},
 		"service with port": {
@@ -136,6 +140,14 @@ func TestRun(t *testing.T) {
 			serviceName:    serviceName,
 			expServiceName: serviceName,
 		},
+		"auth method enabled": {
+			consulLogin: config.ConsulLogin{
+				Enabled: true,
+				ExtraLoginFlags: []string{
+					"-meta", "unittest-tag=12345",
+				},
+			},
+		},
 	}
 
 	for name, c := range cases {
@@ -179,14 +191,32 @@ func TestRun(t *testing.T) {
 				c.expUpstreams[i].DestinationNamespace = expectedNamespace
 			}
 
+			var srvConfig testutil.ServerConfigCallback
+			if c.consulLogin.Enabled {
+				// Enable ACLs to test with the auth method
+				srvConfig = testutil.ConsulACLConfigFn
+			}
+
 			// Start a Consul server. This sets the CONSUL_HTTP_ADDR for `consul connect envoy -bootstrap`.
-			cfg := testutil.ConsulServer(t, nil)
+			cfg := testutil.ConsulServer(t, srvConfig)
 			consulClient, err := api.NewClient(cfg)
 			require.NoError(t, err)
 
 			// Set up ECS container metadata server. This sets ECS_CONTAINER_METADATA_URI_V4.
 			taskMetadataResponse := fmt.Sprintf(`{"Cluster": "test", "TaskARN": "%s", "Family": "%s"}`, taskARN, family)
 			testutil.TaskMetaServer(t, testutil.TaskMetaHandler(t, taskMetadataResponse))
+
+			if c.consulLogin.Enabled {
+				fakeAws := authMethodInit(t, consulClient, expectedServiceName)
+
+				// Point `consul login` at the local fake AWS server.
+				c.consulLogin.ExtraLoginFlags = append(c.consulLogin.ExtraLoginFlags,
+					"-aws-sts-endpoint", fakeAws.URL+"/sts",
+					"-aws-region", "fake-region",
+					"-aws-access-key-id", "fake-key-id",
+					"-aws-secret-access-key", "fake-secret-key",
+				)
+			}
 
 			ui := cli.NewMockUi()
 			cmd := Command{UI: ui}
@@ -196,8 +226,10 @@ func TestRun(t *testing.T) {
 			copyConsulECSBinary := path.Join(envoyBootstrapDir, "consul-ecs")
 
 			consulEcsConfig := config.Config{
+				LogLevel:             "DEBUG",
 				BootstrapDir:         envoyBootstrapDir,
 				HealthSyncContainers: nil,
+				ConsulLogin:          c.consulLogin,
 				Proxy: &config.AgentServiceConnectProxyConfig{
 					Upstreams: c.upstreams,
 				},
@@ -296,6 +328,62 @@ func TestRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+// authMethodInit sets up necessary pieces for the IAM auth method:
+// - Start a fake AWS server. This responds an IAM role tagged with expectedServiceName.
+// - Configures an auth method + binding rule uses the tagged service name from the IAM
+//   role for the service identity.
+//
+// When using this, you will also need to point the login command at the fake AWS server:
+//
+//    fakeAws := authMethodInit(...)
+//    consulLogin.ExtraLoginFlags = []string{"-aws-sts-endpoint", fakeAws.URL + "/sts"}
+func authMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName string) *httptest.Server {
+	arn := "arn:aws:iam::1234567890:role/my-role"
+	uniqueId := "AAAsomeuniqueid"
+
+	// Start a fake AWS API server for STS and IAM.
+	fakeAws := iamauthtest.NewTestServer(t, &iamauthtest.Server{
+		GetCallerIdentityResponse: iamauthtest.MakeGetCallerIdentityResponse(
+			arn, uniqueId, "1234567890",
+		),
+		GetRoleResponse: iamauthtest.MakeGetRoleResponse(
+			arn, uniqueId, iamauthtest.Tags{
+				Members: []iamauthtest.TagMember{
+					{Key: "service-name", Value: expectedServiceName},
+				},
+			},
+		),
+	})
+
+	method, _, err := consulClient.ACL().AuthMethodCreate(&api.ACLAuthMethod{
+		Name:        config.DefaultAuthMethodName,
+		Type:        "aws-iam",
+		Description: "aws auth method for unit test",
+		Config: map[string]interface{}{
+			// Trust the role to login.
+			"BoundIAMPrincipalARNs": []string{arn},
+			// Enable fetching the IAM role
+			"EnableIAMEntityDetails": true,
+			// Make this tag available to the binding rule: `entity_tags.service_name`
+			"IAMEntityTags": []string{"service-name"},
+			// Point the auth method at the local fake AWS server.
+			"STSEndpoint": fakeAws.URL + "/sts",
+			"IAMEndpoint": fakeAws.URL + "/iam",
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	_, _, err = consulClient.ACL().BindingRuleCreate(&api.ACLBindingRule{
+		AuthMethod: method.Name,
+		BindType:   api.BindingRuleBindTypeService,
+		// Pull the service name from the IAM role `service-name` tag.
+		BindName: "${entity_tags.service-name}",
+	}, nil)
+	require.NoError(t, err)
+
+	return fakeAws
 }
 
 func TestConstructChecks(t *testing.T) {

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -142,7 +142,8 @@ func TestRun(t *testing.T) {
 		},
 		"auth method enabled": {
 			consulLogin: config.ConsulLogin{
-				Enabled: true,
+				Enabled:       true,
+				IncludeEntity: true,
 				ExtraLoginFlags: []string{
 					"-meta", "unittest-tag=12345",
 				},
@@ -229,7 +230,7 @@ func TestRun(t *testing.T) {
 				LogLevel:             "DEBUG",
 				BootstrapDir:         envoyBootstrapDir,
 				HealthSyncContainers: nil,
-				ConsulLogin:          c.consulLogin,
+				ConsulLogin:          &c.consulLogin,
 				Proxy: &config.AgentServiceConnectProxyConfig{
 					Upstreams: c.upstreams,
 				},

--- a/testutil/consul.go
+++ b/testutil/consul.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type ServerConfigCallback = testutil.ServerConfigCallback
+
 const AdminToken = "123e4567-e89b-12d3-a456-426614174000"
 
 // ConsulServer initializes a Consul test server and returns Consul client config.
-func ConsulServer(t *testing.T, cb testutil.ServerConfigCallback) *api.Config {
+func ConsulServer(t *testing.T, cb ServerConfigCallback) *api.Config {
 	server, err := testutil.NewTestServerConfigT(t, cb)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/testutil/iamauthtest/arn.go
+++ b/testutil/iamauthtest/arn.go
@@ -1,0 +1,97 @@
+package iamauthtest
+
+// This file is copied from Consul:
+// https://github.com/hashicorp/consul/blob/76c03872b709297b7649cb3f8999c3d1323361fb/internal/iamauth/responses/arn.go
+
+import (
+	"fmt"
+	"strings"
+)
+
+// https://github.com/hashicorp/vault/blob/ba533d006f2244103648785ebfe8a9a9763d2b6e/builtin/credential/aws/path_login.go#L1722-L1744
+type ParsedArn struct {
+	Partition     string
+	AccountNumber string
+	Type          string
+	Path          string
+	FriendlyName  string
+	SessionInfo   string
+}
+
+// https://github.com/hashicorp/vault/blob/ba533d006f2244103648785ebfe8a9a9763d2b6e/builtin/credential/aws/path_login.go#L1482-L1530
+// However, instance profiles are not support in Consul.
+func ParseArn(iamArn string) (*ParsedArn, error) {
+	// iamArn should look like one of the following:
+	// 1. arn:aws:iam::<account_id>:<entity_type>/<UserName>
+	// 2. arn:aws:sts::<account_id>:assumed-role/<RoleName>/<RoleSessionName>
+	// if we get something like 2, then we want to transform that back to what
+	// most people would expect, which is arn:aws:iam::<account_id>:role/<RoleName>
+	var entity ParsedArn
+	fullParts := strings.Split(iamArn, ":")
+	if len(fullParts) != 6 {
+		return nil, fmt.Errorf("unrecognized arn: contains %d colon-separated parts, expected 6", len(fullParts))
+	}
+	if fullParts[0] != "arn" {
+		return nil, fmt.Errorf("unrecognized arn: does not begin with \"arn:\"")
+	}
+	// normally aws, but could be aws-cn or aws-us-gov
+	entity.Partition = fullParts[1]
+	if entity.Partition == "" {
+		return nil, fmt.Errorf("unrecognized arn: %q is missing the partition", iamArn)
+	}
+	if fullParts[2] != "iam" && fullParts[2] != "sts" {
+		return nil, fmt.Errorf("unrecognized service: %v, not one of iam or sts", fullParts[2])
+	}
+	// fullParts[3] is the region, which doesn't matter for AWS IAM entities
+	entity.AccountNumber = fullParts[4]
+	if entity.AccountNumber == "" {
+		return nil, fmt.Errorf("unrecognized arn: %q is missing the account number", iamArn)
+	}
+	// fullParts[5] would now be something like user/<UserName> or assumed-role/<RoleName>/<RoleSessionName>
+	parts := strings.Split(fullParts[5], "/")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("unrecognized arn: %q contains fewer than 2 slash-separated parts", fullParts[5])
+	}
+	entity.Type = parts[0]
+	entity.Path = strings.Join(parts[1:len(parts)-1], "/")
+	entity.FriendlyName = parts[len(parts)-1]
+	// now, entity.FriendlyName should either be <UserName> or <RoleName>
+	switch entity.Type {
+	case "assumed-role":
+		// Check for three parts for assumed role ARNs
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("unrecognized arn: %q contains fewer than 3 slash-separated parts", fullParts[5])
+		}
+		// Assumed roles don't have paths and have a slightly different format
+		// parts[2] is <RoleSessionName>
+		entity.Path = ""
+		entity.FriendlyName = parts[1]
+		entity.SessionInfo = parts[2]
+	case "user":
+	case "role":
+	// case "instance-profile":
+	default:
+		return nil, fmt.Errorf("unrecognized principal type: %q", entity.Type)
+	}
+
+	if entity.FriendlyName == "" {
+		return nil, fmt.Errorf("unrecognized arn: %q is missing the resource name", iamArn)
+	}
+
+	return &entity, nil
+}
+
+// CanonicalArn returns the canonical ARN for referring to an IAM entity
+func (p *ParsedArn) CanonicalArn() string {
+	entityType := p.Type
+	// canonicalize "assumed-role" into "role"
+	if entityType == "assumed-role" {
+		entityType = "role"
+	}
+	// Annoyingly, the assumed-role entity type doesn't have the Path of the role which was assumed
+	// So, we "canonicalize" it by just completely dropping the path. The other option would be to
+	// make an AWS API call to look up the role by FriendlyName, which introduces more complexity to
+	// code and test, and it also breaks backwards compatibility in an area where we would really want
+	// it
+	return fmt.Sprintf("arn:%s:iam::%s:%s/%s", p.Partition, p.AccountNumber, entityType, p.FriendlyName)
+}

--- a/testutil/iamauthtest/responses.go
+++ b/testutil/iamauthtest/responses.go
@@ -1,0 +1,177 @@
+package iamauthtest
+
+// This file is copied from these Consul files:
+// https://github.com/hashicorp/consul/blob/76c03872b709297b7649cb3f8999c3d1323361fb/internal/iamauth/responses/responses.go
+// https://github.com/hashicorp/consul/blob/main/internal/iamauth/responsestest/testing.go
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+func MakeGetCallerIdentityResponse(arn, userId, accountId string) GetCallerIdentityResponse {
+	// Sanity check the UserId for unit tests.
+	parsed := parseArn(arn)
+	switch parsed.Type {
+	case "assumed-role":
+		if !strings.Contains(userId, ":") {
+			panic("UserId for assumed-role in GetCallerIdentity response must be '<uniqueId>:<session>'")
+		}
+	default:
+		if strings.Contains(userId, ":") {
+			panic("UserId in GetCallerIdentity must not contain ':'")
+		}
+	}
+
+	return GetCallerIdentityResponse{
+		GetCallerIdentityResult: []GetCallerIdentityResult{
+			{
+				Arn:     arn,
+				UserId:  userId,
+				Account: accountId,
+			},
+		},
+	}
+}
+
+func MakeGetRoleResponse(arn, id string, tags Tags) GetRoleResponse {
+	if strings.Contains(id, ":") {
+		panic("RoleId in GetRole response must not contain ':'")
+	}
+	parsed := parseArn(arn)
+	return GetRoleResponse{
+		GetRoleResult: []GetRoleResult{
+			{
+				Role: Role{
+					Arn:      arn,
+					Path:     parsed.Path,
+					RoleId:   id,
+					RoleName: parsed.FriendlyName,
+					Tags:     tags,
+				},
+			},
+		},
+	}
+}
+
+func MakeGetUserResponse(arn, id string, tags Tags) GetUserResponse {
+	if strings.Contains(id, ":") {
+		panic("UserId in GetUser resposne must not contain ':'")
+	}
+	parsed := parseArn(arn)
+	return GetUserResponse{
+		GetUserResult: []GetUserResult{
+			{
+				User: User{
+					Arn:      arn,
+					Path:     parsed.Path,
+					UserId:   id,
+					UserName: parsed.FriendlyName,
+					Tags:     tags,
+				},
+			},
+		},
+	}
+}
+
+func parseArn(arn string) *ParsedArn {
+	parsed, err := ParseArn(arn)
+	if err != nil {
+		// For testing, just fail immediately.
+		panic(err)
+	}
+	return parsed
+}
+
+type GetCallerIdentityResponse struct {
+	XMLName                 xml.Name                  `xml:"GetCallerIdentityResponse"`
+	GetCallerIdentityResult []GetCallerIdentityResult `xml:"GetCallerIdentityResult"`
+	ResponseMetadata        []ResponseMetadata        `xml:"ResponseMetadata"`
+}
+
+type GetCallerIdentityResult struct {
+	Arn     string `xml:"Arn"`
+	UserId  string `xml:"UserId"`
+	Account string `xml:"Account"`
+}
+
+type ResponseMetadata struct {
+	RequestId string `xml:"RequestId"`
+}
+
+// IAMEntity is an interface for getting details from an IAM Role or User.
+type IAMEntity interface {
+	EntityPath() string
+	EntityArn() string
+	EntityName() string
+	EntityId() string
+	EntityTags() map[string]string
+}
+
+var _ IAMEntity = (*Role)(nil)
+var _ IAMEntity = (*User)(nil)
+
+type GetRoleResponse struct {
+	XMLName          xml.Name           `xml:"GetRoleResponse"`
+	GetRoleResult    []GetRoleResult    `xml:"GetRoleResult"`
+	ResponseMetadata []ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type GetRoleResult struct {
+	Role Role `xml:"Role"`
+}
+
+type Role struct {
+	Arn      string `xml:"Arn"`
+	Path     string `xml:"Path"`
+	RoleId   string `xml:"RoleId"`
+	RoleName string `xml:"RoleName"`
+	Tags     Tags   `xml:"Tags"`
+}
+
+func (r *Role) EntityPath() string            { return r.Path }
+func (r *Role) EntityArn() string             { return r.Arn }
+func (r *Role) EntityName() string            { return r.RoleName }
+func (r *Role) EntityId() string              { return r.RoleId }
+func (r *Role) EntityTags() map[string]string { return tagsToMap(r.Tags) }
+
+type GetUserResponse struct {
+	XMLName          xml.Name           `xml:"GetUserResponse"`
+	GetUserResult    []GetUserResult    `xml:"GetUserResult"`
+	ResponseMetadata []ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type GetUserResult struct {
+	User User `xml:"User"`
+}
+
+type User struct {
+	Arn      string `xml:"Arn"`
+	Path     string `xml:"Path"`
+	UserId   string `xml:"UserId"`
+	UserName string `xml:"UserName"`
+	Tags     Tags   `xml:"Tags"`
+}
+
+func (u *User) EntityPath() string            { return u.Path }
+func (u *User) EntityArn() string             { return u.Arn }
+func (u *User) EntityName() string            { return u.UserName }
+func (u *User) EntityId() string              { return u.UserId }
+func (u *User) EntityTags() map[string]string { return tagsToMap(u.Tags) }
+
+type Tags struct {
+	Members []TagMember `xml:"member"`
+}
+
+type TagMember struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+func tagsToMap(tags Tags) map[string]string {
+	result := map[string]string{}
+	for _, tag := range tags.Members {
+		result[tag.Key] = tag.Value
+	}
+	return result
+}

--- a/testutil/iamauthtest/responses.go
+++ b/testutil/iamauthtest/responses.go
@@ -2,7 +2,7 @@ package iamauthtest
 
 // This file is copied from these Consul files:
 // https://github.com/hashicorp/consul/blob/76c03872b709297b7649cb3f8999c3d1323361fb/internal/iamauth/responses/responses.go
-// https://github.com/hashicorp/consul/blob/main/internal/iamauth/responsestest/testing.go
+// https://github.com/hashicorp/consul/blob/76c03872b709297b7649cb3f8999c3d1323361fb/internal/iamauth/responsestest/testing.go
 
 import (
 	"encoding/xml"

--- a/testutil/iamauthtest/testing.go
+++ b/testutil/iamauthtest/testing.go
@@ -1,0 +1,187 @@
+package iamauthtest
+
+// This file is copied from Consul:
+// https://github.com/hashicorp/consul/blob/76c03872b709297b7649cb3f8999c3d1323361fb/internal/iamauth/iamauthtest/testing.go
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// NewTestServer returns a fake AWS API server for local tests:
+// It supports the following paths:
+//   /sts returns STS API responses
+//   /iam returns IAM API responses
+func NewTestServer(t *testing.T, s *Server) *httptest.Server {
+	server := httptest.NewUnstartedServer(s)
+	t.Cleanup(server.Close)
+	server.Start()
+	return server
+}
+
+// Server contains configuration for the fake AWS API server.
+type Server struct {
+	GetCallerIdentityResponse GetCallerIdentityResponse
+	GetRoleResponse           GetRoleResponse
+	GetUserResponse           GetUserResponse
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		writeError(w, http.StatusBadRequest, r)
+		return
+	}
+
+	switch {
+	case strings.HasPrefix(r.URL.Path, "/sts"):
+		writeXML(w, s.GetCallerIdentityResponse)
+	case strings.HasPrefix(r.URL.Path, "/iam"):
+		if bodyBytes, err := io.ReadAll(r.Body); err == nil {
+			body := string(bodyBytes)
+			switch {
+			case strings.Contains(body, "Action=GetRole"):
+				writeXML(w, s.GetRoleResponse)
+				return
+			case strings.Contains(body, "Action=GetUser"):
+				writeXML(w, s.GetUserResponse)
+				return
+			}
+		}
+		writeError(w, http.StatusBadRequest, r)
+	default:
+		writeError(w, http.StatusNotFound, r)
+	}
+}
+
+func writeXML(w http.ResponseWriter, val interface{}) {
+	str, err := xml.MarshalIndent(val, "", " ")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, err.Error())
+		return
+	}
+	w.Header().Add("Content-Type", "text/xml")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, string(str))
+}
+
+func writeError(w http.ResponseWriter, code int, r *http.Request) {
+	w.WriteHeader(code)
+	msg := fmt.Sprintf("%s %s", r.Method, r.URL)
+	fmt.Fprintf(w, `<ErrorResponse xmlns="https://fakeaws/">
+  <Error>
+	<Message>Fake AWS Server Error: %s</Message>
+  </Error>
+</ErrorResponse>`, msg)
+}
+
+type Fixture struct {
+	AssumedRoleARN   string
+	CanonicalRoleARN string
+	RoleARN          string
+	RoleARNWildcard  string
+	RoleName         string
+	RolePath         string
+	RoleTags         map[string]string
+
+	EntityID            string
+	EntityIDWithSession string
+	AccountID           string
+
+	UserARN         string
+	UserARNWildcard string
+	UserName        string
+	UserPath        string
+	UserTags        map[string]string
+
+	ServerForRole *Server
+	ServerForUser *Server
+}
+
+func MakeFixture() Fixture {
+	f := Fixture{
+		AssumedRoleARN:   "arn:aws:sts::1234567890:assumed-role/my-role/some-session",
+		CanonicalRoleARN: "arn:aws:iam::1234567890:role/my-role",
+		RoleARN:          "arn:aws:iam::1234567890:role/some/path/my-role",
+		RoleARNWildcard:  "arn:aws:iam::1234567890:role/some/path/*",
+		RoleName:         "my-role",
+		RolePath:         "some/path",
+		RoleTags: map[string]string{
+			"service-name": "my-service",
+			"env":          "my-env",
+		},
+
+		EntityID:            "AAAsomeuniqueid",
+		EntityIDWithSession: "AAAsomeuniqueid:some-session",
+		AccountID:           "1234567890",
+
+		UserARN:         "arn:aws:iam::1234567890:user/my-user",
+		UserARNWildcard: "arn:aws:iam::1234567890:user/*",
+		UserName:        "my-user",
+		UserPath:        "",
+		UserTags:        map[string]string{"user-group": "my-group"},
+	}
+
+	f.ServerForRole = &Server{
+		GetCallerIdentityResponse: MakeGetCallerIdentityResponse(
+			f.AssumedRoleARN, f.EntityIDWithSession, f.AccountID,
+		),
+		GetRoleResponse: MakeGetRoleResponse(
+			f.RoleARN, f.EntityID, toTags(f.RoleTags),
+		),
+	}
+
+	f.ServerForUser = &Server{
+		GetCallerIdentityResponse: MakeGetCallerIdentityResponse(
+			f.UserARN, f.EntityID, f.AccountID,
+		),
+		GetUserResponse: MakeGetUserResponse(
+			f.UserARN, f.EntityID, toTags(f.UserTags),
+		),
+	}
+
+	return f
+}
+
+func (f *Fixture) RoleTagKeys() []string   { return keys(f.RoleTags) }
+func (f *Fixture) UserTagKeys() []string   { return keys(f.UserTags) }
+func (f *Fixture) RoleTagValues() []string { return values(f.RoleTags) }
+func (f *Fixture) UserTagValues() []string { return values(f.UserTags) }
+
+// toTags converts the map to a slice of Tag
+func toTags(tags map[string]string) Tags {
+	members := []TagMember{}
+	for k, v := range tags {
+		members = append(members, TagMember{
+			Key:   k,
+			Value: v,
+		})
+	}
+	return Tags{Members: members}
+
+}
+
+// keys returns the keys in sorted order
+func keys(tags map[string]string) []string {
+	result := []string{}
+	for k := range tags {
+		result = append(result, k)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// values returns values in tags, ordered by sorted keys
+func values(tags map[string]string) []string {
+	result := []string{}
+	for _, k := range keys(tags) { // ensures sorted by key
+		result = append(result, tags[k])
+	}
+	return result
+}


### PR DESCRIPTION
## Changes proposed in this PR:
This enables mesh-init to login and obtain a service token from Consul's IAM auth method.

- Support `consulLogin.enabled` and `consulLogin.method` options in the config json (among a couple others). Also, add `consulHTTPAddr` and `consulCACertFile` config fields.
- mesh-init is responsible for logging in to obtain the service token, and putting it in the bootstrap directory
- health-sync assumes the service-token file exists and uses (created by mesh-init)

## How I've tested this PR:
- Manually with Terraform in ECS
- Unit test

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
