### PR TITLE
Extract unit test utils into testutils package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
         default: ""
         type: string
       ENTERPRISE_FLAG:
-        description: | 
+        description: |
           Flag to indicate if the tests are running against Consul Enterprise.
           If using an Enterprise version of Consul this flag must be set to "-enterprise"
         default: ""
@@ -77,7 +77,11 @@ jobs:
                unzip consul_"${CONSUL_VERSION}"_linux_amd64.zip -d /home/circleci/bin &&
                rm consul_"${CONSUL_VERSION}"_linux_amd64.zip
           PACKAGE_NAMES=$(go list ./...)
-          gotestsum --junitfile $TEST_RESULTS/gotestsum-report.xml -- -p 4 $PACKAGE_NAMES -- << parameters.ENTERPRISE_FLAG >>
+          TAGS=""
+          if [ -n "<< parameters.ENTERPRISE_FLAG >>" ]; then
+            TAGS="-tags=enterprise"
+          fi
+          gotestsum --junitfile $TEST_RESULTS/gotestsum-report.xml -- -p 4 $PACKAGE_NAMES $TAGS -- << parameters.ENTERPRISE_FLAG >>
 
       - store_test_results:
           path: /tmp/test-results/consul_<< parameters.CONSUL_VERSION >>

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/hashicorp/consul-ecs/controller/mocks"
+	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
@@ -1147,23 +1147,10 @@ func TestACLDescriptions(t *testing.T) {
 
 // helper func that initializes a Consul test server and returns a Consul API client.
 func initConsul(t *testing.T) *api.Client {
-	adminToken := "123e4567-e89b-12d3-a456-426614174000"
-	testServer, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
-		c.ACL.Enabled = true
-		c.ACL.Tokens.Master = adminToken
-		c.ACL.DefaultPolicy = "deny"
-	})
+	cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
+	client, err := api.NewClient(cfg)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = testServer.Stop() })
-	testServer.WaitForLeader(t)
-
-	clientConfig := api.DefaultConfig()
-	clientConfig.Address = testServer.HTTPAddr
-	clientConfig.Token = adminToken
-
-	consulClient, err := api.NewClient(clientConfig)
-	require.NoError(t, err)
-	return consulClient
+	return client
 }
 
 // listNamespaces is a helper func that returns a list of namespaces mapped to partition.

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -61,22 +61,11 @@ func TestCreatePartitionEnt(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			adminToken := "123e4567-e89b-12d3-a456-426614174000"
-			testServer, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
-				c.ACL.Enabled = true
-				c.ACL.Tokens.Master = adminToken
-				c.ACL.DefaultPolicy = "deny"
-			})
-			require.NoError(t, err)
-			defer func() { _ = testServer.Stop() }()
-			testServer.WaitForLeader(t)
-
-			clientConfig := api.DefaultConfig()
-			clientConfig.Address = testServer.HTTPAddr
-			clientConfig.Token = adminToken
+			cfg := ecstestutil.ConsulServer(t, ecstestutil.ConsulACLConfigFn)
 			if c.partition != "" {
-				clientConfig.Partition = c.partition
+				cfg.Partition = c.partition
 			}
+
 			consulClient, err := api.NewClient(clientConfig)
 			require.NoError(t, err)
 

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -42,15 +42,12 @@ func TestUpsertConsulClientTokenEnt(t *testing.T) {
 	testUpsertConsulClientToken(t, cases)
 }
 
-func TestCreatePartitionEnt(t *testing.T) {
+func TestUpsertPartitionEnt(t *testing.T) {
 	cases := map[string]struct {
 		partition       string
 		createPartition bool
 		err             error
 	}{
-		"when partitions are not enabled": {
-			partition: "",
-		},
 		"when partitions are enabled and the configured partition already exists": {
 			partition:       testPartitionName,
 			createPartition: true,
@@ -61,12 +58,12 @@ func TestCreatePartitionEnt(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			cfg := ecstestutil.ConsulServer(t, ecstestutil.ConsulACLConfigFn)
+			cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
 			if c.partition != "" {
 				cfg.Partition = c.partition
 			}
 
-			consulClient, err := api.NewClient(clientConfig)
+			consulClient, err := api.NewClient(cfg)
 			require.NoError(t, err)
 
 			if c.createPartition {
@@ -86,7 +83,7 @@ func TestCreatePartitionEnt(t *testing.T) {
 				ctx:                   context.Background(),
 			}
 
-			err = cmd.createPartition(consulClient)
+			err = cmd.upsertPartition(consulClient)
 			if c.err == nil {
 				require.NoError(t, err)
 			} else {

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -19,25 +19,23 @@ import (
 )
 
 func TestConfigValidation(t *testing.T) {
-	ui := cli.NewMockUi()
-	cmd := Command{UI: ui}
-	code := cmd.Run(nil)
-	require.Equal(t, code, 1)
-	require.Contains(t, ui.ErrorWriter.String(),
-		fmt.Sprintf(`invalid config: "%s" isn't populated`, config.ConfigEnvironmentVariable))
+	t.Run("CONSUL_ECS_CONFIG_JSON unset", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		cmd := Command{UI: ui}
+		code := cmd.Run(nil)
+		require.Equal(t, code, 1)
+		require.Contains(t, ui.ErrorWriter.String(),
+			fmt.Sprintf(`invalid config: "%s" isn't populated`, config.ConfigEnvironmentVariable))
 
-	err := os.Setenv(config.ConfigEnvironmentVariable, "{}")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.Unsetenv(config.ConfigEnvironmentVariable)
 	})
-
-	ui = cli.NewMockUi()
-	cmd = Command{UI: ui}
-	code = cmd.Run(nil)
-	require.Equal(t, code, 1)
-	require.Contains(t, ui.ErrorWriter.String(), "invalid config: 2 errors occurred:")
-
+	t.Run("CONSUL_ECS_CONFIG_JSON is empty json", func(t *testing.T) {
+		testutil.SetECSConfigEnvVar(t, map[string]interface{}{})
+		ui := cli.NewMockUi()
+		cmd := Command{UI: ui}
+		code := cmd.Run(nil)
+		require.Equal(t, code, 1)
+		require.Contains(t, ui.ErrorWriter.String(), "invalid config: 2 errors occurred:")
+	})
 }
 
 // Note: this test cannot currently run in parallel with other tests

--- a/testutil/aws.go
+++ b/testutil/aws.go
@@ -1,0 +1,42 @@
+package testutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TaskMetaHandler returns an http.Handler that always responds with the given string
+// for the 'GET /task' request of the ECS Task Metadata server.
+func TaskMetaHandler(t *testing.T, resp string) http.Handler {
+	return TaskMetaHandlerFn(t, func() string { return resp })
+}
+
+// TaskMetaHandler wraps the respFn in an http.Handler for the ECS Task Metadata server.
+// respFn should return a response to the 'GET /task' request.
+func TaskMetaHandlerFn(t *testing.T, respFn func() string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r != nil && r.URL.Path == "/task" && r.Method == "GET" {
+			resp := respFn()
+			_, err := w.Write([]byte(resp))
+			require.NoError(t, err)
+		}
+	})
+}
+
+// TaskMetaServer starts a local HTTP server to mimic the ECS Task Metadata server.
+// This sets ECS_CONTAINER_METADATA_URI_V4 and configures a test cleanup.
+// Because of the environment variable, this is unsafe for running tests in parallel.
+func TaskMetaServer(t *testing.T, handler http.Handler) {
+	ecsMetadataServer := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		_ = os.Unsetenv(awsutil.ECSMetadataURIEnvVar)
+		ecsMetadataServer.Close()
+	})
+	err := os.Setenv(awsutil.ECSMetadataURIEnvVar, ecsMetadataServer.URL)
+	require.NoError(t, err)
+}

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -1,0 +1,44 @@
+package testutil
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul-ecs/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TempDir creates a temporary "bootstrap" directory. A test cleanup is configured to removes the
+// temp directory and its contents.
+func TempDir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Logf("warning, failed to cleanup temp dir %s - %s", dir, err)
+		}
+	})
+
+	return dir
+}
+
+// SetECSConfigEnvVar the CONSUL_ECS_CONFIG_JSON environment variable
+// to the JSON string of the provided config.Config object. A test clean is added
+// to unset the environment variable.
+func SetECSConfigEnvVar(t *testing.T, conf *config.Config) {
+	configBytes, err := json.MarshalIndent(conf, "", "  ")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.Unsetenv(config.ConfigEnvironmentVariable)
+	})
+
+	err = os.Setenv(config.ConfigEnvironmentVariable, string(configBytes))
+	require.NoError(t, err)
+
+	t.Logf("%s=%s", config.ConfigEnvironmentVariable, os.Getenv(config.ConfigEnvironmentVariable))
+}

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TempDir creates a temporary "bootstrap" directory. A test cleanup is configured to removes the
-// temp directory and its contents.
+// TempDir creates a temporary directory. A test cleanup removes the directory
+// and its contents.
 func TempDir(t *testing.T) string {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
@@ -27,10 +27,9 @@ func TempDir(t *testing.T) string {
 }
 
 // SetECSConfigEnvVar the CONSUL_ECS_CONFIG_JSON environment variable
-// to the JSON string of the provided config.Config object. A test clean is added
-// to unset the environment variable.
-func SetECSConfigEnvVar(t *testing.T, conf *config.Config) {
-	configBytes, err := json.MarshalIndent(conf, "", "  ")
+// to the JSON string of the provided value, with a test cleanup.
+func SetECSConfigEnvVar(t *testing.T, val interface{}) {
+	configBytes, err := json.MarshalIndent(val, "", "  ")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/testutil/consul.go
+++ b/testutil/consul.go
@@ -1,0 +1,43 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const AdminToken = "123e4567-e89b-12d3-a456-426614174000"
+
+// ConsulServer initializes a Consul test server and returns Consul client config.
+func ConsulServer(t *testing.T, cb testutil.ServerConfigCallback) *api.Config {
+	server, err := testutil.NewTestServerConfigT(t, cb)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = server.Stop()
+	})
+	server.WaitForLeader(t)
+
+	cfg := api.DefaultConfig()
+	cfg.Address = server.HTTPAddr
+	if server.Config.ACL.Enabled {
+		cfg.Token = server.Config.ACL.Tokens.Master
+	}
+
+	// Set CONSUL_HTTP_ADDR for mesh-init. Required to invoke the consul binary (i.e. in mesh-init).
+	require.NoError(t, os.Setenv("CONSUL_HTTP_ADDR", server.HTTPAddr))
+	t.Cleanup(func() {
+		_ = os.Unsetenv("CONSUL_HTTP_ADDR")
+	})
+
+	return cfg
+}
+
+// ConsulACLConfigFn configures a Consul test server with ACLs.
+func ConsulACLConfigFn(c *testutil.TestServerConfig) {
+	c.ACL.Enabled = true
+	c.ACL.Tokens.Master = AdminToken
+	c.ACL.DefaultPolicy = "deny"
+}


### PR DESCRIPTION
## Changes proposed in this PR:
Add a `testutils` package that extracts common unit test behaviors and encapsulates their setup/cleanup.

- Starting a Consul test server
- Starting an ECS task metadata server
- Creating a temp dir
- Setting CONSUL_ECS_CONFIG_JSON from a `config.Config`

## How I've tested this PR:
- Unit tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] ~CHANGELOG entry added~ n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
