### PR TITLE
Update ACL controller to configure IAM auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ FEATURES
 * Add `consulHTTPAddr`, `consulCACertFile`, and `consulLogin` fields to config JSON.
   `mesh-init` now does a `consul login` to obtain a token if `consulLogin.enabled = true`.
   [[GH-69](https://github.com/hashicorp/consul-ecs/pull/69)]
+* Update `acl-controller` to configure Consul's AWS IAM auth method at startup.
+  Add `-iam-role-path` flag to specify the path of IAM roles permitted to login.
+  [[GH-71](https://github.com/hashicorp/consul-ecs/pull/71)]
 
 ## 0.4.1 (April 08, 2022)
 

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/hashicorp/consul-ecs/version"
@@ -46,22 +47,22 @@ func (e ECSTaskMeta) TaskID() string {
 }
 
 func (e ECSTaskMeta) AccountID() (string, error) {
-	split := strings.Split(e.TaskARN, ":")
-	if len(split) < 5 {
-		return "", fmt.Errorf("unable to determine AWS account id from Task metadata")
+	a, err := arn.Parse(e.TaskARN)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine AWS account id from Task ARN: %q", e.TaskARN)
 	}
-	return split[4], nil
+	return a.AccountID, nil
 }
 
 func (e ECSTaskMeta) region() (string, error) {
 	// Task ARN: "arn:aws:ecs:us-east-1:000000000000:task/cluster/00000000000000000000000000000000"
 	// https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 	// See also: https://github.com/aws/containers-roadmap/issues/337
-	split := strings.Split(e.TaskARN, ":")
-	if len(split) < 4 {
-		return "", fmt.Errorf("unable to determine AWS region from Task metadata")
+	a, err := arn.Parse(e.TaskARN)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine AWS region from Task ARN: %q", e.TaskARN)
 	}
-	return split[3], nil
+	return a.Region, nil
 }
 
 func ECSTaskMetadata() (ECSTaskMeta, error) {

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -45,6 +45,14 @@ func (e ECSTaskMeta) TaskID() string {
 	return split[len(split)-1]
 }
 
+func (e ECSTaskMeta) AccountID() (string, error) {
+	split := strings.Split(e.TaskARN, ":")
+	if len(split) < 5 {
+		return "", fmt.Errorf("unable to determine AWS account id from Task metadata")
+	}
+	return split[4], nil
+}
+
 func (e ECSTaskMeta) region() (string, error) {
 	// Task ARN: "arn:aws:ecs:us-east-1:000000000000:task/cluster/00000000000000000000000000000000"
 	// https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -93,6 +93,10 @@ func TestECSTaskMeta(t *testing.T) {
 	region, err := ecsMeta.region()
 	require.Nil(t, err)
 	require.Equal(t, "us-east-1", region)
+
+	account, err := ecsMeta.AccountID()
+	require.NoError(t, err)
+	require.Equal(t, "123456789", account)
 }
 
 // Helper to restore the environment after a test.

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -28,7 +28,7 @@ func TestNewSession(t *testing.T) {
 		},
 		"no-env-and-invalid-task-arn": {
 			taskArn:     "invalid-task-arn",
-			expectError: "unable to determine AWS region from Task metadata",
+			expectError: `unable to determine AWS region from Task ARN: "invalid-task-arn"`,
 		},
 		"aws-region": {
 			env:          map[string]string{"AWS_REGION": nonTaskRegion},

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -147,6 +147,8 @@ func TestServiceStateLister_List(t *testing.T) {
 	}
 
 	for name, c := range cases {
+		// Necessary to avoid sharing `c` across subtest functions,
+		// which would cause issues when running those functions in parallel.
 		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -21,16 +22,23 @@ import (
 )
 
 const (
+	flagIAMRolePath           = "iam-role-path"
 	flagConsulClientSecretARN = "consul-client-secret-arn"
 	flagSecretNamePrefix      = "secret-name-prefix"
 	flagPartition             = "partition"
 	flagPartitionsEnabled     = "partitions-enabled"
 
 	consulCACertEnvVar = "CONSUL_CACERT_PEM"
+
+	// Binding rules don't support a '/' character, so we need compatible IAM role
+	// tag names for the auth method until we can address this in Consul.
+	authMethodServiceNameTag = "consul.hashicorp.com.service-name"
+	authMethodNamespaceTag   = "consul.hashicorp.com.namespace"
 )
 
 type Command struct {
 	UI                        cli.Ui
+	flagIAMRolePath           string
 	flagConsulClientSecretARN string
 	flagSecretNamePrefix      string
 	flagPartition             string
@@ -46,6 +54,7 @@ type Command struct {
 
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flagSet.StringVar(&c.flagIAMRolePath, flagIAMRolePath, "", "IAM roles at this path will be trusted by the IAM Auth method created by the controller")
 	c.flagSet.StringVar(&c.flagConsulClientSecretARN, flagConsulClientSecretARN, "", "ARN of AWS Secrets Manager secret for Consul client")
 	c.flagSet.StringVar(&c.flagSecretNamePrefix, flagSecretNamePrefix, "", "The prefix for secret names stored in AWS Secrets Manager")
 	c.flagSet.StringVar(&c.flagPartition, flagPartition, "", "The Consul partition name that the ACL controller will use for ACL resources. If not provided will default to the `default` partition [Consul Enterprise]")
@@ -99,24 +108,30 @@ func (c *Command) run() error {
 	if err != nil {
 		return err
 	}
-
-	if c.flagPartitionsEnabled {
-		if c.flagPartition == "" {
-			// if an explicit partition was not provided use the default partition.
-			c.flagPartition = controller.DefaultPartition
-		}
-		if err = c.upsertPartition(consulClient); err != nil {
-			return err
-		}
-	} else if c.flagPartition != "" {
-		return fmt.Errorf("partition flag provided without partitions-enabled flag")
-	}
-
 	smClient := secretsmanager.New(clientSession, nil)
 
-	err = c.upsertConsulClientToken(consulClient, smClient)
-	if err != nil {
-		return err
+	if c.flagIAMRolePath != "" {
+		if err := c.upsertConsulResources(consulClient, ecsMeta); err != nil {
+			return err
+		}
+	} else {
+		// TODO: Remove this old behavior once fully switched to the auth method.
+		if c.flagPartitionsEnabled {
+			if c.flagPartition == "" {
+				// if an explicit partition was not provided use the default partition.
+				c.flagPartition = controller.DefaultPartition
+			}
+			if err = c.upsertPartition(consulClient); err != nil {
+				return err
+			}
+		} else if c.flagPartition != "" {
+			return fmt.Errorf("partition flag provided without partitions-enabled flag")
+		}
+
+		err = c.upsertConsulClientToken(consulClient, smClient)
+		if err != nil {
+			return err
+		}
 	}
 
 	serviceStateLister := &controller.ServiceStateLister{
@@ -145,6 +160,101 @@ func (c *Command) Synopsis() string {
 
 func (c *Command) Help() string {
 	return ""
+}
+
+// upsertConsulResources creates the necessary resources in Consul if they do not exist.
+// This includes the partition, client role and policy, client and service token auth methods,
+// and the necessary binding rules.
+func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsutil.ECSTaskMeta) error {
+	account, err := ecsMeta.AccountID()
+	if err != nil {
+		return err
+	}
+	path := strings.Trim(c.flagIAMRolePath, "/")
+	if path != "" {
+		path += "/"
+	}
+	boundArnPattern := fmt.Sprintf("arn:aws:iam::%s:role/%s*", account, path)
+
+	clientAuthMethod := &api.ACLAuthMethod{
+		Name:        "iam-ecs-client-token",
+		Type:        "aws-iam",
+		Description: "AWS IAM auth method for ECS client tokens",
+		Config: map[string]interface{}{
+			// Trust a wildcard - any roles at a path.
+			"BoundIAMPrincipalARNs": []string{boundArnPattern},
+			// Must be true to use a wildcard
+			"EnableIAMEntityDetails": true,
+		},
+	}
+	serviceAuthMethod := &api.ACLAuthMethod{
+		Name:        "iam-ecs-service-token",
+		Type:        "aws-iam",
+		Description: "AWS IAM auth method for ECS service tokens",
+		Config: map[string]interface{}{
+			// Trust a wildcard - any roles at a path.
+			"BoundIAMPrincipalARNs": []string{boundArnPattern},
+			// Must be true to use wildcard and tags
+			"EnableIAMEntityDetails": true,
+			"IAMEntityTags": []string{
+				authMethodServiceNameTag,
+				authMethodNamespaceTag,
+			},
+		},
+	}
+	if c.flagPartitionsEnabled {
+		serviceAuthMethod.NamespaceRules = append(serviceAuthMethod.NamespaceRules,
+			&api.ACLAuthMethodNamespaceRule{
+				Selector:      fmt.Sprintf(`entity_tags["%s"] != ""`, authMethodNamespaceTag),
+				BindNamespace: fmt.Sprintf(`${entity_tags.%s}`, authMethodNamespaceTag),
+			},
+		)
+	}
+
+	roleName := "consul-ecs-client-role"
+	policyName := "consul-ecs-client-policy"
+	clientBindingRule := &api.ACLBindingRule{
+		Description: "Bind a policy for Consul clients on ECS",
+		AuthMethod:  clientAuthMethod.Name,
+		BindType:    api.BindingRuleBindTypeRole,
+		BindName:    roleName,
+	}
+
+	serviceBindingRule := &api.ACLBindingRule{
+		Description: "Bind a service identity from IAM role tag for ECS",
+		AuthMethod:  serviceAuthMethod.Name,
+		BindType:    api.BindingRuleBindTypeService,
+		BindName:    fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag),
+	}
+
+	if c.flagPartitionsEnabled {
+		if c.flagPartition == "" {
+			// if an explicit partition was not provided use the default partition.
+			c.flagPartition = controller.DefaultPartition
+		}
+		if err := c.upsertPartition(consulClient); err != nil {
+			return err
+		}
+	} else if c.flagPartition != "" {
+		return fmt.Errorf("partition flag provided without partitions-enabled flag")
+	}
+
+	if err := c.upsertConsulClientRole(consulClient, roleName, policyName); err != nil {
+		return err
+	}
+	if err := c.upsertAuthMethod(consulClient, clientAuthMethod); err != nil {
+		return err
+	}
+	if err := c.upsertAuthMethod(consulClient, serviceAuthMethod); err != nil {
+		return err
+	}
+	if err := c.upsertBindingRule(consulClient, clientBindingRule); err != nil {
+		return err
+	}
+	if err := c.upsertBindingRule(consulClient, serviceBindingRule); err != nil {
+		return err
+	}
+	return nil
 }
 
 // upsertPartition ensures the partition that the controller is managing
@@ -184,6 +294,131 @@ var partitionedClientPolicyTpl = `partition "%s" {
     }
   }
 }`
+
+// upsertConsulClientRole creates or updates the Consul ACL role for the client token.
+func (c *Command) upsertConsulClientRole(consulClient *api.Client, roleName, policyName string) error {
+	if err := c.upsertClientPolicy(consulClient, policyName); err != nil {
+		return err
+	}
+	if err := c.upsertClientRole(consulClient, roleName, policyName); err != nil {
+		return err
+	}
+	return nil
+}
+
+// upsertClientPolicy creates the ACL policy for the Consul client, if the policy does not exist.
+func (c *Command) upsertClientPolicy(consulClient *api.Client, policyName string) error {
+	// If the policy already exists, we're done.
+	_, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
+	if err != nil && !controller.IsACLNotFoundError(err) {
+		return fmt.Errorf("reading Consul client ACL policy: %w", err)
+	} else if err == nil {
+		c.log.Info("ACL policy already exists; skipping policy creation", "name", policyName)
+		return nil
+	}
+
+	// Otherwise, the policy is not found, so create it.
+	c.log.Info("creating ACL policy", "name", policyName)
+	rules := ossClientPolicy
+	if c.flagPartitionsEnabled {
+		// If partitions are enabled then create a policy that supports partitions
+		rules = fmt.Sprintf(partitionedClientPolicyTpl, c.flagPartition)
+	}
+	_, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{
+		Name:        policyName,
+		Description: "Consul Client Token Policy for ECS",
+		Rules:       rules,
+	}, c.writeOptions())
+	if err != nil {
+		return fmt.Errorf("creating Consul client ACL policy: %w", err)
+	}
+	c.log.Info("ACL policy created successfully", "name", policyName)
+	return nil
+}
+
+// upsertClientRole creates the ACL role for the Consul client, if the role does not exist.
+func (c *Command) upsertClientRole(consulClient *api.Client, roleName, policyName string) error {
+	// If the role already exists, we're done.
+	role, _, err := consulClient.ACL().RoleReadByName(roleName, c.queryOptions())
+	if err != nil && !controller.IsACLNotFoundError(err) {
+		return fmt.Errorf("reading Consul client ACL role: %w", err)
+	} else if err == nil && role != nil { // returns role=nil and err=nil if not found
+		c.log.Info("ACL role already exists; skipping role creation", "name", roleName)
+
+		if len(role.Policies) == 0 {
+			c.log.Info("updating ACL role with policy", "role", roleName, "policy", policyName)
+			role.Policies = []*api.ACLLink{{Name: policyName}}
+			_, _, err := consulClient.ACL().RoleUpdate(role, c.writeOptions())
+			if err != nil {
+				return fmt.Errorf("updating Consul client ACL role: %s", err)
+			}
+			c.log.Info("update ACL role successfully", "name", roleName)
+		}
+		return nil
+	}
+
+	c.log.Info("creating ACL role", "name", roleName)
+	_, _, err = consulClient.ACL().RoleCreate(&api.ACLRole{
+		Name:        roleName,
+		Description: "Consul Client Token Role for ECS",
+		Policies: []*api.ACLLink{
+			{
+				Name: policyName,
+			},
+		},
+	}, c.writeOptions())
+	if err != nil {
+		return fmt.Errorf("creating Consul client ACL role: %w", err)
+	}
+	c.log.Info("ACL role created successfully", "name", roleName)
+
+	return nil
+}
+
+func (c *Command) upsertAuthMethod(consulClient *api.Client, authMethod *api.ACLAuthMethod) error {
+
+	method, _, err := consulClient.ACL().AuthMethodRead(authMethod.Name, c.queryOptions())
+	if err != nil && !controller.IsACLNotFoundError(err) {
+		return fmt.Errorf("reading ACL auth method: %w", err)
+	} else if err == nil && method != nil { // returns err=nil and method=nil if not found
+		c.log.Info("ACL auth method already exists; skipping creation", "name", authMethod.Name)
+		return nil
+	}
+
+	c.log.Info("creating ACL auth method", "name", authMethod.Name)
+	method, _, err = consulClient.ACL().AuthMethodCreate(authMethod, c.writeOptions())
+	if err != nil {
+		return fmt.Errorf("creating ACL auth method: %w", err)
+	}
+	c.log.Info("ACL auth method created successfully", "name", method.Name)
+
+	return nil
+}
+
+func (c *Command) upsertBindingRule(consulClient *api.Client, bindingRule *api.ACLBindingRule) error {
+	method := bindingRule.AuthMethod
+
+	rules, _, err := consulClient.ACL().BindingRuleList(method, c.queryOptions())
+	if err != nil {
+		return fmt.Errorf("listing ACL binding rules for auth method %s: %w", method, err)
+	}
+	if len(rules) > 0 {
+		// For now, we just expect at least one binding rule to exist.
+		// TODO: Can we create the rule with a client-generated ID?
+		c.log.Info("ACL binding rule created successfully", "method", method,
+			"bind-type", rules[0].BindType, "bind-name", rules[0].BindName)
+		return nil
+	}
+
+	rule, _, err := consulClient.ACL().BindingRuleCreate(bindingRule, c.writeOptions())
+	if err != nil {
+		return fmt.Errorf("create ACL binding rule: %w", err)
+	}
+	c.log.Info("ACL binding rule created successfully", "method", method,
+		"bind-type", rule.BindType, "bind-name", rule.BindName)
+
+	return nil
+}
 
 // upsertConsulClientToken creates or updates ACL policy and token for the Consul client in Consul.
 // It then saves the created token in AWS Secrets Manager in the secret provided by secretARN from the Command.

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -3,17 +3,11 @@
 package aclcontroller
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/hashicorp/consul-ecs/testutil"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-hclog"
-	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/require"
 )
 
 var expPartitionedClientPolicy = fmt.Sprintf(`partition "%s" {
@@ -26,6 +20,25 @@ var expPartitionedClientPolicy = fmt.Sprintf(`partition "%s" {
     }
   }
 }`, testPartitionName)
+
+func TestUpsertConsulResourcesEnt(t *testing.T) {
+	testUpsertConsulResources(t, map[string]iamAuthTestCase{
+		"recreate the partition": {
+			partitionsEnabled: true,
+			deletePartition:   true,
+			expPolicyRules:    expPartitionedClientPolicy,
+		},
+		"recreate all resources ent": {
+			deletePolicy:       true,
+			deleteRole:         true,
+			deleteAuthMethods:  true,
+			deleteBindingRules: true,
+			deletePartition:    true,
+			partitionsEnabled:  true,
+			expPolicyRules:     expPartitionedClientPolicy,
+		},
+	})
+}
 
 func TestUpsertConsulClientTokenEnt(t *testing.T) {
 	cases := testCases{
@@ -40,55 +53,4 @@ func TestUpsertConsulClientTokenEnt(t *testing.T) {
 		},
 	}
 	testUpsertConsulClientToken(t, cases)
-}
-
-func TestUpsertPartitionEnt(t *testing.T) {
-	cases := map[string]struct {
-		partition       string
-		createPartition bool
-		err             error
-	}{
-		"when partitions are enabled and the configured partition already exists": {
-			partition:       testPartitionName,
-			createPartition: true,
-		},
-		"when partitions are enabled and the configured partition does not exist": {
-			partition: testPartitionName,
-		},
-	}
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
-			if c.partition != "" {
-				cfg.Partition = c.partition
-			}
-
-			consulClient, err := api.NewClient(cfg)
-			require.NoError(t, err)
-
-			if c.createPartition {
-				_, _, err = consulClient.Partitions().Create(
-					context.Background(),
-					&api.Partition{Name: c.partition},
-					nil)
-				require.NoError(t, err)
-			}
-
-			cmd := Command{
-				UI:                    cli.NewMockUi(),
-				flagSecretNamePrefix:  "test",
-				flagPartitionsEnabled: c.partition != "",
-				flagPartition:         c.partition,
-				log:                   hclog.NewNullLogger(),
-				ctx:                   context.Background(),
-			}
-
-			err = cmd.upsertPartition(consulClient)
-			if c.err == nil {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-			}
-		})
-	}
 }

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -3,14 +3,19 @@ package aclcontroller
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul-ecs/controller"
 	"github.com/hashicorp/consul-ecs/controller/mocks"
+	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -18,7 +23,287 @@ import (
 
 const testPartitionName = "test-partition"
 
-var expOssClientPolicy = `node_prefix "" { policy = "write" } service_prefix "" { policy = "read" }`
+var (
+	testTaskMetadataResponse = awsutil.ECSTaskMeta{
+		Cluster: "test",
+		TaskARN: "arn:aws:ecs:us-east-1:123456789:task/test/abcdef",
+		Family:  "controller",
+	}
+	expOssClientPolicy = `node_prefix "" { policy = "write" } service_prefix "" { policy = "read" }`
+)
+
+type iamAuthTestCase struct {
+	deletePolicy       bool
+	deleteRole         bool
+	deleteAuthMethods  bool
+	deleteBindingRules bool
+	deletePartition    bool
+	partitionsEnabled  bool
+	expPolicyRules     string
+}
+
+func TestUpsertConsulResources(t *testing.T) {
+	testUpsertConsulResources(t, map[string]iamAuthTestCase{
+		"recreate no ACL resources": {
+			expPolicyRules: expOssClientPolicy,
+		},
+		"recreate the ACL auth method": {
+			deleteAuthMethods: true,
+			expPolicyRules:    expOssClientPolicy,
+		},
+		"recreate the ACL policy": {
+			deletePolicy:   true,
+			expPolicyRules: expOssClientPolicy,
+		},
+		"recreate the ACL role": {
+			deleteRole:     true,
+			expPolicyRules: expOssClientPolicy,
+		},
+		"recreate the ACL binding rule": {
+			deleteBindingRules: true,
+			expPolicyRules:     expOssClientPolicy,
+		},
+		"recreate all resources": {
+			deletePolicy:       true,
+			deleteRole:         true,
+			deleteAuthMethods:  true,
+			deleteBindingRules: true,
+			expPolicyRules:     expOssClientPolicy,
+		},
+	})
+}
+
+func testUpsertConsulResources(t *testing.T, cases map[string]iamAuthTestCase) {
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
+			if c.partitionsEnabled {
+				cfg.Partition = testPartitionName
+			}
+			consulClient, err := api.NewClient(cfg)
+			require.NoError(t, err)
+
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:              ui,
+				flagIAMRolePath: "/path/to/roles",
+				log:             hclog.Default().Named("acl-controller"),
+			}
+			if c.partitionsEnabled {
+				cmd.flagPartitionsEnabled = true
+				cmd.flagPartition = testPartitionName
+			}
+
+			// Upsert once to create the resources
+			err = cmd.upsertConsulResources(consulClient, testTaskMetadataResponse)
+			require.NoError(t, err)
+
+			checkConsulResources(t, consulClient, c.expPolicyRules, c.partitionsEnabled)
+
+			// Optionally, delete some of the resources
+			if c.deleteAuthMethods {
+				methods, _, err := consulClient.ACL().AuthMethodList(nil)
+				require.NoError(t, err)
+				for _, method := range methods {
+					_, err := consulClient.ACL().AuthMethodDelete(method.Name, nil)
+					require.NoError(t, err)
+				}
+				methods, _, err = consulClient.ACL().AuthMethodList(nil)
+				require.NoError(t, err)
+				require.Len(t, methods, 0)
+			}
+			if c.deletePolicy {
+				policies, _, err := consulClient.ACL().PolicyList(nil)
+				require.NoError(t, err)
+				for _, policy := range policies {
+					if policy.Name != "global-management" {
+						_, err := consulClient.ACL().PolicyDelete(policy.ID, nil)
+						require.NoError(t, err)
+					}
+				}
+				// Only the global management policy should exist.
+				policies, _, err = consulClient.ACL().PolicyList(nil)
+				require.NoError(t, err)
+				if c.partitionsEnabled {
+					require.Len(t, policies, 0)
+				} else {
+					// The default partition has a global-management policy
+					require.Len(t, policies, 1)
+					require.Equal(t, policies[0].Name, "global-management")
+				}
+			}
+			if c.deleteRole {
+				roles, _, err := consulClient.ACL().RoleList(nil)
+				require.NoError(t, err)
+				for _, role := range roles {
+					_, err := consulClient.ACL().RoleDelete(role.ID, nil)
+					require.NoError(t, err)
+				}
+				roles, _, err = consulClient.ACL().RoleList(nil)
+				require.NoError(t, err)
+				require.Len(t, roles, 0)
+			}
+			if c.deleteBindingRules {
+				methods, _, err := consulClient.ACL().AuthMethodList(nil)
+				require.NoError(t, err)
+				for _, method := range methods {
+					rules, _, err := consulClient.ACL().BindingRuleList(method.Name, nil)
+					require.NoError(t, err)
+					for _, rule := range rules {
+						_, err := consulClient.ACL().BindingRuleDelete(rule.ID, nil)
+						require.NoError(t, err)
+					}
+					rules, _, err = consulClient.ACL().BindingRuleList(method.Name, nil)
+					require.NoError(t, err)
+					require.Len(t, rules, 0)
+				}
+			}
+			if c.partitionsEnabled && c.deletePartition {
+				ctx := context.Background()
+				partitions, _, err := consulClient.Partitions().List(ctx, nil)
+				require.NoError(t, err)
+				for _, part := range partitions {
+					if part.Name != "default" {
+						_, err := consulClient.Partitions().Delete(ctx, part.Name, nil)
+						require.NoError(t, err)
+					}
+				}
+				// Apparently, takes moment for the partition to actually be deleted.
+				retry.RunWith(&retry.Timer{Timeout: 2 * time.Second, Wait: 200 * time.Millisecond}, t, func(r *retry.R) {
+					partitions, _, err = consulClient.Partitions().List(ctx, nil)
+					require.NoError(r, err)
+					require.Len(r, partitions, 1)
+				})
+			}
+
+			// Upsert again to recreate the deleted resources
+			err = cmd.upsertConsulResources(consulClient, testTaskMetadataResponse)
+			require.NoError(t, err)
+			checkConsulResources(t, consulClient, c.expPolicyRules, c.partitionsEnabled)
+		})
+	}
+
+}
+
+func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules string, partitionsEnabled bool) {
+	t.Helper()
+
+	// Check the partition is created.
+	if partitionsEnabled {
+		partitions, _, err := consulClient.Partitions().List(context.Background(), nil)
+		require.NoError(t, err)
+		require.Len(t, partitions, 2)
+		sort.Slice(partitions, func(i, j int) bool {
+			return partitions[i].Name < partitions[j].Name
+		})
+		require.Equal(t, partitions[0].Name, "default")
+		require.Equal(t, partitions[1].Name, testPartitionName)
+	}
+
+	// Check the client policy is created.
+	policies, _, err := consulClient.ACL().PolicyList(nil)
+	require.NoError(t, err)
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].Name < policies[j].Name
+	})
+
+	require.Equal(t, policies[0].Name, "consul-ecs-client-policy")
+	if partitionsEnabled {
+		require.Len(t, policies, 1)
+	} else {
+		// The default partition also has the global-management policy
+		require.Len(t, policies, 2)
+		require.Equal(t, policies[1].Name, "global-management")
+	}
+
+	policy, _, err := consulClient.ACL().PolicyReadByName("consul-ecs-client-policy", nil)
+	require.NoError(t, err)
+	require.Equal(t, expPolicyRules, policy.Rules)
+
+	// Check the client role is created with policy attached
+	// Note: When the policy is deleted, it is detached from the role
+	roles, _, err := consulClient.ACL().RoleList(nil)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+
+	role, _, err := consulClient.ACL().RoleReadByName("consul-ecs-client-role", nil)
+	require.NoError(t, err)
+	require.Len(t, role.Policies, 1)
+	require.Equal(t, role.Policies[0].Name, "consul-ecs-client-policy")
+
+	// Check the auth methods are created
+	methods, _, err := consulClient.ACL().AuthMethodList(nil)
+	require.NoError(t, err)
+	require.Len(t, methods, 2)
+	sort.Slice(methods, func(i, j int) bool {
+		return methods[i].Name < methods[j].Name
+	})
+	require.Equal(t, methods[0].Name, "iam-ecs-client-token")
+	require.Equal(t, methods[1].Name, "iam-ecs-service-token")
+
+	{
+		method, _, err := consulClient.ACL().AuthMethodRead("iam-ecs-client-token", nil)
+		require.NoError(t, err)
+		require.Equal(t, method.Type, "aws-iam")
+		require.Equal(t, method.Name, "iam-ecs-client-token")
+		require.Len(t, method.NamespaceRules, 0)
+		require.Equal(t, method.Config, map[string]interface{}{
+			"BoundIAMPrincipalARNs": []interface{}{
+				"arn:aws:iam::123456789:role/path/to/roles/*",
+			},
+			"EnableIAMEntityDetails": true,
+		})
+
+		// Check the binding rule is created.
+		rules, _, err := consulClient.ACL().BindingRuleList(method.Name, nil)
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+
+		rule, _, err := consulClient.ACL().BindingRuleRead(rules[0].ID, nil)
+		require.NoError(t, err)
+		require.Equal(t, rule.BindType, api.BindingRuleBindTypeRole)
+		require.Equal(t, rule.BindName, "consul-ecs-client-role")
+	}
+
+	{
+		method, _, err := consulClient.ACL().AuthMethodRead("iam-ecs-service-token", nil)
+		require.NoError(t, err)
+		require.Equal(t, method.Type, "aws-iam")
+		require.Equal(t, method.Name, "iam-ecs-service-token")
+		if partitionsEnabled {
+			require.Len(t, method.NamespaceRules, 1)
+			require.Equal(t, method.NamespaceRules[0], &api.ACLAuthMethodNamespaceRule{
+				Selector:      fmt.Sprintf(`entity_tags["%s"] != ""`, authMethodNamespaceTag),
+				BindNamespace: fmt.Sprintf(`${entity_tags.%s}`, authMethodNamespaceTag),
+			})
+		} else {
+			require.Len(t, method.NamespaceRules, 0)
+		}
+
+		require.Equal(t, method.Config, map[string]interface{}{
+			"BoundIAMPrincipalARNs": []interface{}{
+				"arn:aws:iam::123456789:role/path/to/roles/*",
+			},
+			"EnableIAMEntityDetails": true,
+			"IAMEntityTags": []interface{}{
+				authMethodServiceNameTag,
+				authMethodNamespaceTag,
+			},
+		})
+
+		// Check the binding rule is created.
+		rules, _, err := consulClient.ACL().BindingRuleList(method.Name, nil)
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+
+		rule, _, err := consulClient.ACL().BindingRuleRead(rules[0].ID, nil)
+		require.NoError(t, err)
+		require.Equal(t, rule.BindType, api.BindingRuleBindTypeService)
+		require.Equal(t, rule.BindName, fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag))
+	}
+}
 
 type testCase struct {
 	existingSecret       *secretsmanager.GetSecretValueOutput
@@ -80,25 +365,11 @@ func testUpsertConsulClientToken(t *testing.T, cases testCases) {
 		t.Run(name, func(t *testing.T) {
 			smClient := &mocks.SMClient{Secret: c.existingSecret}
 
-			adminToken := "123e4567-e89b-12d3-a456-426614174000"
-			testServer, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
-				c.ACL.Enabled = true
-				c.ACL.Tokens.Master = adminToken
-				c.ACL.DefaultPolicy = "deny"
-			})
-			require.NoError(t, err)
-			defer func() { _ = testServer.Stop() }()
-			testServer.WaitForLeader(t)
-
-			clientConfig := api.DefaultConfig()
-			clientConfig.Address = testServer.HTTPAddr
-			clientConfig.Token = adminToken
-
+			cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
 			if c.partitionsEnabled {
-				clientConfig.Partition = testPartitionName
+				cfg.Partition = testPartitionName
 			}
-
-			consulClient, err := api.NewClient(clientConfig)
+			consulClient, err := api.NewClient(cfg)
 			require.NoError(t, err)
 
 			if c.partitionsEnabled {


### PR DESCRIPTION
## Changes proposed in this PR:
This incrementally adds support for the auth method in the ACL controller.

This adds an `-iam-role-path` flag. If set, the ACL controller does the new behavior of ensuring the IAM auth method is created at startup. If not set, it does the "old" behavior of creating the client token at startup. Later, we'll replace/remove the old behavior.

The ACL controller configures the auth method to trust a wildcard arn, like `arn:aws:iam::123456789:role/path/to/roles/*`. This will permit any role at that path, and in the same account as the controller, to login to the auth method.

## How I've tested this PR:
- Unit tests
- Manually with Terraform in ECS

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
