### PR TITLE
Fix nil pointer when ConsulLogin not specified

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -19,7 +19,7 @@ type Config struct {
 	BootstrapDir         string                          `json:"bootstrapDir"`
 	ConsulHTTPAddr       string                          `json:"consulHTTPAddr"`
 	ConsulCACertFile     string                          `json:"consulCACertFile"`
-	ConsulLogin          *ConsulLogin                    `json:"consulLogin"`
+	ConsulLogin          ConsulLogin                     `json:"consulLogin"`
 	HealthSyncContainers []string                        `json:"healthSyncContainers,omitempty"`
 	LogLevel             string                          `json:"logLevel,omitempty"`
 	Proxy                *AgentServiceConnectProxyConfig `json:"proxy"`

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -94,6 +94,15 @@ func OpenFile(t *testing.T, path string) string {
 var (
 	expectedConfig = &Config{
 		LogLevel: "",
+		ConsulLogin: ConsulLogin{
+			Enabled: false,
+			Method:  "",
+			// Because ConsulLogin is not a pointer, when `consulLogin` is absent from
+			// the JSON, UnmarshalJSON is not called, so IncludeEntity is not defaulted
+			// to `true`. This is okay since if Enabled=false, IncludeEntity is not used.
+			IncludeEntity:   false,
+			ExtraLoginFlags: nil,
+		},
 		Service: ServiceRegistration{
 			Name: "blah",
 			Port: 1234,
@@ -118,7 +127,7 @@ var (
 		LogLevel:             "DEBUG",
 		ConsulHTTPAddr:       "consul.example.com",
 		ConsulCACertFile:     "/consul/consul-ca-cert.pem",
-		ConsulLogin: &ConsulLogin{
+		ConsulLogin: ConsulLogin{
 			Enabled:         true,
 			Method:          "my-auth-method",
 			IncludeEntity:   false,
@@ -236,7 +245,12 @@ var (
 		LogLevel:             "",
 		ConsulHTTPAddr:       "",
 		ConsulCACertFile:     "",
-		ConsulLogin:          nil,
+		ConsulLogin: ConsulLogin{
+			Enabled:         false,
+			Method:          "",
+			IncludeEntity:   true, // default true
+			ExtraLoginFlags: nil,
+		},
 		Service: ServiceRegistration{
 			Name:              "",
 			Tags:              nil,
@@ -256,7 +270,7 @@ var (
 		HealthSyncContainers: nil,
 		ConsulHTTPAddr:       "",
 		ConsulCACertFile:     "",
-		ConsulLogin: &ConsulLogin{
+		ConsulLogin: ConsulLogin{
 			Enabled:         false,
 			Method:          "",
 			IncludeEntity:   true, // default true
@@ -322,7 +336,7 @@ var (
 	expectedConfigEmptyFields = &Config{
 		BootstrapDir:         "/consul/",
 		HealthSyncContainers: []string{},
-		ConsulLogin: &ConsulLogin{
+		ConsulLogin: ConsulLogin{
 			Enabled:         false,
 			Method:          "",
 			IncludeEntity:   true, // default true

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -230,7 +230,7 @@ func TestRun(t *testing.T) {
 				LogLevel:             "DEBUG",
 				BootstrapDir:         envoyBootstrapDir,
 				HealthSyncContainers: nil,
-				ConsulLogin:          &c.consulLogin,
+				ConsulLogin:          c.consulLogin,
 				Proxy: &config.AgentServiceConnectProxyConfig{
 					Upstreams: c.upstreams,
 				},


### PR DESCRIPTION
## Changes proposed in this PR:
This fixes a nil pointer when `consulLogin` is absent or nil.

## How I've tested this PR:
- Unit tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] ~CHANGELOG entry added~ n/a, `consulLogin` is new in the next release and already included in the changelog

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
