### PR TITLE
health-sync: Do consul logout during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ FEATURES
 * Add `-log-level` flag to `acl-controller`, `envoy-entrypoint`, and `app-entrypoint`
   commands. Add `logLevel` field to config JSON for `mesh-init` and `health-sync` commands.
   [[GH-67](https://github.com/hashicorp/consul-ecs/pull/67)]
-* Add `consulHTTPAddr`, `consulCACertFile`, and `consulLogin` fields to config JSON.
+* Support obtaining ACL tokens from Consul's AWS IAM auth method. This requires Consul 1.12.0+.
   `mesh-init` now does a `consul login` to obtain a token if `consulLogin.enabled = true`.
+  `health-sync` does a `consul logout` during shutdown to destroy these tokens.
+  Add `consulHTTPAddr`, `consulCACertFile`, and `consulLogin` fields to the config JSON.
   [[GH-69](https://github.com/hashicorp/consul-ecs/pull/69)]
+  [[GH-76](https://github.com/hashicorp/consul-ecs/pull/76)]
   [[GH-77](https://github.com/hashicorp/consul-ecs/pull/77)]
 * Update `acl-controller` to configure Consul's AWS IAM auth method at startup.
   Add `-iam-role-path` flag to specify the path of IAM roles permitted to login.

--- a/config/types.go
+++ b/config/types.go
@@ -7,9 +7,12 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-// ServiceTokenFilename is the file in the BootstrapDir where the token is written by `consul login`
-// if auth method login is enabled.
+// ServiceTokenFilename is the file in the BootstrapDir where the service token is written by `consul login`.
 const ServiceTokenFilename = "service-token"
+
+// ClientTokenFilename is the file in the BootstrapDir where the Consul client token is expected.
+// The consul-ecs binary does not write this file, but health-sync will attempt to do a `consul logout` for this token.
+const ClientTokenFilename = "client-token"
 
 // DefaultAuthMethodName is the default name of the Consul IAM auth method used for `consul login`.
 const DefaultAuthMethodName = "iam-ecs-service-token"

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -133,13 +133,13 @@ func (c *Command) syncChecks(consulClient *api.Client, currentStatuses map[strin
 		if err != nil {
 			c.log.Error("failed to update Consul health status for missing container", "err", err, "container", name)
 		} else {
-			c.log.Info("Container health check updated in Consul for missing container", "container", name)
+			c.log.Info("container health check updated in Consul for missing container", "container", name)
 			currentStatuses[name] = api.HealthCritical
 		}
 	}
 
 	for _, container := range containersToSync {
-		c.log.Debug("Updating Consul TTL check from ECS container health",
+		c.log.Debug("updating Consul TTL check from ECS container health",
 			"name", container.Name,
 			"status", container.Health.Status,
 			"statusSince", container.Health.StatusSince,
@@ -154,7 +154,7 @@ func (c *Command) syncChecks(consulClient *api.Client, currentStatuses map[strin
 			if err != nil {
 				c.log.Warn("failed to update Consul health status", "err", err)
 			} else {
-				c.log.Info("Container health check updated in Consul",
+				c.log.Info("container health check updated in Consul",
 					"name", container.Name,
 					"status", container.Health.Status,
 					"statusSince", container.Health.StatusSince,

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -193,6 +193,7 @@ func (c *Command) setChecksCritical(consulClient *api.Client, taskID string, ser
 // logout calls POST /acl/logout to destroy the token in the given file.
 // The given file should be relative path of a file in the bootstrap directory.
 func (c *Command) logout(tokenFile string) error {
+	c.log.Info("log out token", "file", tokenFile)
 	tokenFile = filepath.Join(c.config.BootstrapDir, tokenFile)
 	cfg := api.DefaultConfig()
 	if c.config.ConsulHTTPAddr != "" {

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -87,10 +87,10 @@ func (c *Command) realRun(ctx context.Context, consulClient *api.Client) error {
 		case <-ctx.Done():
 			result := c.setChecksCritical(consulClient, taskMeta.TaskID(), serviceName, healthSyncContainers)
 			if c.config.ConsulLogin.Enabled {
-				if err := c.logout(filepath.Join(c.config.BootstrapDir, config.ServiceTokenFilename)); err != nil {
+				if err := c.logout(config.ServiceTokenFilename); err != nil {
 					result = multierror.Append(result, err)
 				}
-				if err := c.logout(filepath.Join(c.config.BootstrapDir, config.ClientTokenFilename)); err != nil {
+				if err := c.logout(config.ClientTokenFilename); err != nil {
 					result = multierror.Append(result, err)
 				}
 			}
@@ -190,7 +190,10 @@ func (c *Command) setChecksCritical(consulClient *api.Client, taskID string, ser
 	return result
 }
 
+// logout calls POST /acl/logout to destroy the token in the given file.
+// The given file should be relative path of a file in the bootstrap directory.
 func (c *Command) logout(tokenFile string) error {
+	tokenFile = filepath.Join(c.config.BootstrapDir, tokenFile)
 	cfg := api.DefaultConfig()
 	if c.config.ConsulHTTPAddr != "" {
 		cfg.Address = c.config.ConsulHTTPAddr

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -193,8 +193,8 @@ func (c *Command) setChecksCritical(consulClient *api.Client, taskID string, ser
 // logout calls POST /acl/logout to destroy the token in the given file.
 // The given file should be relative path of a file in the bootstrap directory.
 func (c *Command) logout(tokenFile string) error {
-	c.log.Info("log out token", "file", tokenFile)
 	tokenFile = filepath.Join(c.config.BootstrapDir, tokenFile)
+	c.log.Info("log out token", "file", tokenFile)
 	cfg := api.DefaultConfig()
 	if c.config.ConsulHTTPAddr != "" {
 		cfg.Address = c.config.ConsulHTTPAddr

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -85,7 +85,16 @@ func (c *Command) realRun(ctx context.Context, consulClient *api.Client) error {
 		case <-time.After(pollInterval):
 			currentStatuses = c.syncChecks(consulClient, currentStatuses, serviceName, healthSyncContainers)
 		case <-ctx.Done():
-			return c.setChecksCritical(consulClient, taskMeta.TaskID(), serviceName, healthSyncContainers)
+			result := c.setChecksCritical(consulClient, taskMeta.TaskID(), serviceName, healthSyncContainers)
+			if c.config.ConsulLogin.Enabled {
+				if err := c.logout(filepath.Join(c.config.BootstrapDir, config.ServiceTokenFilename)); err != nil {
+					result = multierror.Append(result, err)
+				}
+				if err := c.logout(filepath.Join(c.config.BootstrapDir, config.ClientTokenFilename)); err != nil {
+					result = multierror.Append(result, err)
+				}
+			}
+			return result
 		}
 	}
 }
@@ -179,6 +188,27 @@ func (c *Command) setChecksCritical(consulClient *api.Client, taskID string, ser
 	}
 
 	return result
+}
+
+func (c *Command) logout(tokenFile string) error {
+	cfg := api.DefaultConfig()
+	if c.config.ConsulHTTPAddr != "" {
+		cfg.Address = c.config.ConsulHTTPAddr
+	}
+	if c.config.ConsulCACertFile != "" {
+		cfg.TLSConfig.CAFile = c.config.ConsulCACertFile
+	}
+	cfg.TokenFile = tokenFile
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return fmt.Errorf("creating client for logout: %w", err)
+	}
+	_, err = client.ACL().Logout(nil)
+	if err != nil {
+		return fmt.Errorf("logout failed: %w", err)
+	}
+	return nil
 }
 
 func findContainersToSync(containerNames []string, taskMeta awsutil.ECSTaskMeta) ([]awsutil.ECSTaskMetaContainer, []string) {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -357,7 +357,8 @@ func TestLogoutSuccess(t *testing.T) {
 
 	ui := cli.NewMockUi()
 	cmd := &Command{
-		UI: ui,
+		UI:  ui,
+		log: hclog.NewNullLogger(),
 		config: &config.Config{
 			BootstrapDir:     bootstrapDir,
 			ConsulHTTPAddr:   cfg.Address,
@@ -384,7 +385,8 @@ func TestLogoutFailure(t *testing.T) {
 
 	cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
 	cmd := &Command{
-		UI: cli.NewMockUi(),
+		UI:  cli.NewMockUi(),
+		log: hclog.NewNullLogger(),
 		config: &config.Config{
 			BootstrapDir:     bootstrapDir,
 			ConsulHTTPAddr:   cfg.Address,

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -2,7 +2,6 @@ package meshinit
 
 import (
 	"fmt"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -15,7 +14,6 @@ import (
 	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul-ecs/testutil"
-	"github.com/hashicorp/consul-ecs/testutil/iamauthtest"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
@@ -211,7 +209,7 @@ func TestRun(t *testing.T) {
 			testutil.TaskMetaServer(t, testutil.TaskMetaHandler(t, taskMetadataResponse))
 
 			if c.consulLogin.Enabled {
-				fakeAws := authMethodInit(t, consulClient, expectedServiceName)
+				fakeAws := testutil.AuthMethodInit(t, consulClient, expectedServiceName)
 
 				// Point `consul login` at the local fake AWS server.
 				c.consulLogin.ExtraLoginFlags = append(c.consulLogin.ExtraLoginFlags,
@@ -333,63 +331,6 @@ func TestRun(t *testing.T) {
 		})
 	}
 }
-
-// authMethodInit sets up necessary pieces for the IAM auth method:
-// - Start a fake AWS server. This responds an IAM role tagged with expectedServiceName.
-// - Configures an auth method + binding rule uses the tagged service name from the IAM
-//   role for the service identity.
-//
-// When using this, you will also need to point the login command at the fake AWS server:
-//
-//    fakeAws := authMethodInit(...)
-//    consulLogin.ExtraLoginFlags = []string{"-aws-sts-endpoint", fakeAws.URL + "/sts"}
-func authMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName string) *httptest.Server {
-	arn := "arn:aws:iam::1234567890:role/my-role"
-	uniqueId := "AAAsomeuniqueid"
-
-	// Start a fake AWS API server for STS and IAM.
-	fakeAws := iamauthtest.NewTestServer(t, &iamauthtest.Server{
-		GetCallerIdentityResponse: iamauthtest.MakeGetCallerIdentityResponse(
-			arn, uniqueId, "1234567890",
-		),
-		GetRoleResponse: iamauthtest.MakeGetRoleResponse(
-			arn, uniqueId, iamauthtest.Tags{
-				Members: []iamauthtest.TagMember{
-					{Key: "service-name", Value: expectedServiceName},
-				},
-			},
-		),
-	})
-
-	method, _, err := consulClient.ACL().AuthMethodCreate(&api.ACLAuthMethod{
-		Name:        config.DefaultAuthMethodName,
-		Type:        "aws-iam",
-		Description: "aws auth method for unit test",
-		Config: map[string]interface{}{
-			// Trust the role to login.
-			"BoundIAMPrincipalARNs": []string{arn},
-			// Enable fetching the IAM role
-			"EnableIAMEntityDetails": true,
-			// Make this tag available to the binding rule: `entity_tags.service_name`
-			"IAMEntityTags": []string{"service-name"},
-			// Point the auth method at the local fake AWS server.
-			"STSEndpoint": fakeAws.URL + "/sts",
-			"IAMEndpoint": fakeAws.URL + "/iam",
-		},
-	}, nil)
-	require.NoError(t, err)
-
-	_, _, err = consulClient.ACL().BindingRuleCreate(&api.ACLBindingRule{
-		AuthMethod: method.Name,
-		BindType:   api.BindingRuleBindTypeService,
-		// Pull the service name from the IAM role `service-name` tag.
-		BindName: "${entity_tags.service-name}",
-	}, nil)
-	require.NoError(t, err)
-
-	return fakeAws
-}
-
 func TestConstructChecks(t *testing.T) {
 	// Bunch of test data.
 	serviceID := "serviceID"


### PR DESCRIPTION
## Changes proposed in this PR:
This updates health-sync to do a `consul logout` during shutdown.

## How I've tested this PR:
- Unit tests

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
