### PR TITLE
Pass -aws-region to fix login on EC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ FEATURES
 * Add `consulHTTPAddr`, `consulCACertFile`, and `consulLogin` fields to config JSON.
   `mesh-init` now does a `consul login` to obtain a token if `consulLogin.enabled = true`.
   [[GH-69](https://github.com/hashicorp/consul-ecs/pull/69)]
+  [[GH-77](https://github.com/hashicorp/consul-ecs/pull/77)]
 * Update `acl-controller` to configure Consul's AWS IAM auth method at startup.
   Add `-iam-role-path` flag to specify the path of IAM roles permitted to login.
   [[GH-71](https://github.com/hashicorp/consul-ecs/pull/71)]

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -54,7 +54,7 @@ func (e ECSTaskMeta) AccountID() (string, error) {
 	return a.AccountID, nil
 }
 
-func (e ECSTaskMeta) region() (string, error) {
+func (e ECSTaskMeta) Region() (string, error) {
 	// Task ARN: "arn:aws:ecs:us-east-1:000000000000:task/cluster/00000000000000000000000000000000"
 	// https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 	// See also: https://github.com/aws/containers-roadmap/issues/337
@@ -111,7 +111,7 @@ func NewSession(meta ECSTaskMeta, userAgentCaller string) (*session.Session, err
 
 	cfg := clientSession.Config
 	if cfg.Region == nil || *cfg.Region == "" {
-		region, err := meta.region()
+		region, err := meta.Region()
 		if err != nil {
 			return nil, err
 		}

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -90,7 +90,7 @@ func TestECSTaskMeta(t *testing.T) {
 		Family:  "task",
 	}
 	require.Equal(t, "abcdef", ecsMeta.TaskID())
-	region, err := ecsMeta.region()
+	region, err := ecsMeta.Region()
 	require.Nil(t, err)
 	require.Equal(t, "us-east-1", region)
 

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -485,7 +485,7 @@ func TestConstructServiceName(t *testing.T) {
 
 func TestConstructLoginCmd(t *testing.T) {
 	var (
-		taskARN = "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+		taskARN = "arn:aws:ecs:bogus-east-1:123456789:task/test/abcdef"
 		meta    = awsutil.ECSTaskMeta{
 			Cluster: "my-cluster",
 			TaskARN: taskARN,
@@ -517,6 +517,7 @@ func TestConstructLoginCmd(t *testing.T) {
 				"-token-sink-file", tokenFile,
 				"-meta", "consul.hashicorp.com/task-id=abcdef",
 				"-meta", "consul.hashicorp.com/cluster=my-cluster",
+				"-aws-region", "bogus-east-1",
 				"-aws-auto-bearer-token", "-aws-include-entity",
 			},
 		},
@@ -534,6 +535,7 @@ func TestConstructLoginCmd(t *testing.T) {
 				"-token-sink-file", tokenFile,
 				"-meta", "consul.hashicorp.com/task-id=abcdef",
 				"-meta", "consul.hashicorp.com/cluster=my-cluster",
+				"-aws-region", "bogus-east-1",
 				"-aws-auto-bearer-token",
 				// no -aws-include-entity
 			},
@@ -545,7 +547,7 @@ func TestConstructLoginCmd(t *testing.T) {
 				ConsulLogin: config.ConsulLogin{
 					Method:          method,
 					IncludeEntity:   true,
-					ExtraLoginFlags: []string{"-aws-region", "fake-region"},
+					ExtraLoginFlags: []string{"-aws-server-id-header-value", "abcd"},
 				},
 			},
 			expCmd: []string{
@@ -555,15 +557,17 @@ func TestConstructLoginCmd(t *testing.T) {
 				"-token-sink-file", tokenFile,
 				"-meta", "consul.hashicorp.com/task-id=abcdef",
 				"-meta", "consul.hashicorp.com/cluster=my-cluster",
+				"-aws-region", "bogus-east-1",
 				"-aws-auto-bearer-token", "-aws-include-entity",
-				"-aws-region", "fake-region",
+				"-aws-server-id-header-value", "abcd",
 			},
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			cmd := &Command{config: c.config}
-			loginOpts := cmd.constructLoginCmd(tokenFile, meta)
+			loginOpts, err := cmd.constructLoginCmd(tokenFile, meta)
+			require.NoError(t, err)
 			require.Equal(t, c.expCmd, loginOpts)
 		})
 	}


### PR DESCRIPTION
## Changes proposed in this PR:
On EC2, the region is not set in the environment (i.e `AWS_REGION` or `AWS_DEFAULT_REGION`), so we have to explicitly discover the region and pass it to the `consul login` command.

## How I've tested this PR:
- Unit tests
- Acceptance tests in https://github.com/hashicorp/terraform-aws-consul-ecs/pull/100

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
