### PR TITLE
Fix module caching in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,15 +13,15 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-ecs-modcache-v1-{{ checksum "go.mod" }}
+            - consul-ecs-modcache-v2-{{ checksum "go.mod" }}
 
       - run: go mod download
 
       # Save go module cache if the go.mod file has changed
       - save_cache:
-          key: consul-ecs-modcache-v1-{{ checksum "go.mod" }}
+          key: consul-ecs-modcache-v2-{{ checksum "go.mod" }}
           paths:
-            - "/go/pkg/mod"
+            - "/home/circleci/go/pkg/mod"
 
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
@@ -68,7 +68,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-ecs-modcache-v1-{{ checksum "go.mod" }}
+            - consul-ecs-modcache-v2-{{ checksum "go.mod" }}
 
       # run go tests with gotestsum
       - run: |
@@ -108,7 +108,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-ecs-modcache-v1-{{ checksum "go.mod" }}
+            - consul-ecs-modcache-v2-{{ checksum "go.mod" }}
       - run: XC_OS="<< parameters.OS >>" XC_ARCH="<< parameters.ARCH >>" ./build-support/scripts/build-local.sh
       # persist to downstream job
       - persist_to_workspace:


### PR DESCRIPTION
## Changes proposed in this PR:
Set the correct go pkg path to fix module caching in CI.

## How I've tested this PR:

**Before**
[This job](https://app.circleci.com/pipelines/github/hashicorp/consul-ecs/494/workflows/eb0c96ad-62d8-4784-a453-520dafdb4c2d/jobs/2995) still downloads go modules after restoring from cache: 

![Screen Shot 2022-04-27 at 12 20 29 PM](https://user-images.githubusercontent.com/1077740/165583929-6cf70f77-24b1-4673-8c19-2023ec85d9e7.png)

**After**
[This job](https://app.circleci.com/pipelines/github/hashicorp/consul-ecs/495/workflows/83b77a7a-02a8-4be9-a6bd-20456f161033/jobs/3002) does not download go modules after restoring from cache:

![Screen Shot 2022-04-27 at 12 20 43 PM](https://user-images.githubusercontent.com/1077740/165583973-25e862f2-feb8-4d4f-a1ef-6485f8b111c0.png)

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] ~Tests added~ n/a
- [x] ~CHANGELOG entry added~ n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
