### PR TITLE
Mitigate against token replication lag

### DIFF
--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -639,8 +639,10 @@ func TestWaitForTokenReplication(t *testing.T) {
 				require.NoError(t, err)
 
 				// Token should exist.
-				_, _, err = tokenClient.ACL().TokenReadSelf(nil)
+				token, _, err := tokenClient.ACL().TokenReadSelf(nil)
 				require.NoError(t, err)
+				require.Equal(t, accessorID, token.AccessorID)
+				require.Equal(t, secretID, token.SecretID)
 			}
 
 		})

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -599,7 +599,6 @@ func TestWaitForTokenReplication(t *testing.T) {
 			require.NoError(t, err)
 
 			tokenCfg := api.DefaultConfig()
-			tokenCfg.Address = cfg.Address
 			tokenCfg.Token = secretID
 
 			tokenClient, err := api.NewClient(tokenCfg)
@@ -626,8 +625,14 @@ func TestWaitForTokenReplication(t *testing.T) {
 			t.Cleanup(func() { timer.Stop() })
 
 			// Wait for the token to "replicate".
-			cmd := &Command{log: hclog.NewNullLogger()}
-			err = cmd.waitForTokenReplication(tokenClient)
+			cmd := &Command{
+				log: hclog.NewNullLogger(),
+				config: &config.Config{
+					ConsulHTTPAddr:   cfg.Address,
+					ConsulCACertFile: cfg.TLSConfig.CAFile,
+				},
+			}
+			err = cmd.waitForTokenReplication(tokenCfg)
 			if c.expError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Changes proposed in this PR:
Copy the [consul-k8s approach](https://github.com/hashicorp/consul-k8s/pull/887) for dealing with inherent token replication lag.

## How I've tested this PR:
- Unit test

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] ~CHANGELOG entry added~ n/a, part of unreleased auth method changes which are already logged

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
