### PR TITLE
Update controller to cleanup tokens from auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+BREAKING CHANGES
+* Update `acl-controller` to cleanup ACL tokens created from Consul's AWS IAM auth method. Remove
+  `-secret-name-prefix` and `-consul-client-secret-arn` flags. The controller no longer creates ACL
+  tokens. [[GH-82](https://github.com/hashicorp/consul-ecs/pull/82)]
+
 BUG FIXES:
 * Fix issue in the `acl-controller` command where namespaces are not created in the correct
   partition when using Consul 1.12. [[GH-72](https://github.com/hashicorp/consul-ecs/pull/72)]
@@ -19,9 +24,6 @@ FEATURES
 * Update `acl-controller` to configure Consul's AWS IAM auth method at startup.
   Add `-iam-role-path` flag to specify the path of IAM roles permitted to login.
   [[GH-71](https://github.com/hashicorp/consul-ecs/pull/71)]
-* Update `acl-controller` to cleanup ACL tokens created from Consul's AWS IAM auth method. Remove
-  `-secret-name-prefix` and `-consul-client-secret-arn` flags. The controller no longer creates ACL
-  tokens. [[GH-82](https://github.com/hashicorp/consul-ecs/pull/82)]
 
 ## 0.4.1 (April 08, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ FEATURES
 * Update `acl-controller` to configure Consul's AWS IAM auth method at startup.
   Add `-iam-role-path` flag to specify the path of IAM roles permitted to login.
   [[GH-71](https://github.com/hashicorp/consul-ecs/pull/71)]
+* Update `acl-controller` to cleanup ACL tokens created from Consul's AWS IAM auth method. Remove
+  `-secret-name-prefix` and `-consul-client-secret-arn` flags. The controller no longer creates ACL
+  tokens. [[GH-82](https://github.com/hashicorp/consul-ecs/pull/82)]
 
 ## 0.4.1 (April 08, 2022)
 

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -42,6 +42,19 @@ func (e ECSTaskMeta) TaskID() string {
 	return ParseTaskID(e.TaskARN)
 }
 
+func (e ECSTaskMeta) ClusterARN() (string, error) {
+	if strings.HasPrefix(e.Cluster, "arn:") {
+		return e.Cluster, nil
+	}
+	// On EC2, the "Cluster" field is the name, not the ARN.
+	clusterArn := strings.Replace(e.TaskARN, ":task/", ":cluster/", 1)
+	index := strings.LastIndex(clusterArn, "/")
+	if index < 0 {
+		return "", fmt.Errorf("unable to determine cluster ARN from task ARN %q", e.TaskARN)
+	}
+	return clusterArn[:index], nil
+}
+
 func ParseTaskID(taskArn string) string {
 	split := strings.Split(taskArn, "/")
 	if len(split) == 0 {

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -39,7 +39,11 @@ type ECSTaskMetaHealth struct {
 }
 
 func (e ECSTaskMeta) TaskID() string {
-	split := strings.Split(e.TaskARN, "/")
+	return ParseTaskID(e.TaskARN)
+}
+
+func ParseTaskID(taskArn string) string {
+	split := strings.Split(taskArn, "/")
 	if len(split) == 0 {
 		return ""
 	}

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -97,6 +97,10 @@ func TestECSTaskMeta(t *testing.T) {
 	account, err := ecsMeta.AccountID()
 	require.NoError(t, err)
 	require.Equal(t, "123456789", account)
+
+	clusterArn, err := ecsMeta.ClusterARN()
+	require.NoError(t, err)
+	require.Equal(t, clusterArn, "arn:aws:ecs:us-east-1:123456789:cluster/test")
 }
 
 // Helper to restore the environment after a test.

--- a/controller/policy.go
+++ b/controller/policy.go
@@ -1,37 +1,5 @@
 package controller
 
-// Service policy constants
-
-const ossServicePolicyTpl = `service "%s" {
-  policy = "write"
-}
-service "%s-sidecar-proxy" {
-  policy = "write"
-}
-service_prefix "" {
-  policy = "read"
-}
-node_prefix "" {
-  policy = "read"
-}`
-
-const entServicePolicyTpl = `partition "%s" {
-  namespace "%s" {
-    service "%s" {
-      policy = "write"
-    }
-    service "%s-sidecar-proxy" {
-      policy = "write"
-    }
-    service_prefix "" {
-      policy = "read"
-    }
-    node_prefix "" {
-      policy = "read"
-    }
-  }
-}`
-
 // Cross namespace policy constants
 const xnsPolicyName = "cross-namespace-read"
 const xnsPolicyDesc = "Allow service and node reads across namespaces within the partition"

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -79,15 +79,10 @@ type TaskStateLister struct {
 // - Tokens whcih may need to be cleaned up
 func (s TaskStateLister) List() ([]Resource, error) {
 	var resources []Resource
-	buildingResources := make(map[TaskID]*TaskState)
 
-	tasks, err := s.fetchECSTasks()
+	buildingResources, err := s.fetchECSTasks()
 	if err != nil {
 		return nil, err
-	}
-
-	for id, task := range tasks {
-		buildingResources[id] = task
 	}
 
 	aclState, err := s.fetchACLState()
@@ -208,7 +203,7 @@ func (s TaskStateLister) fetchACLState() (map[TaskID]*TaskState, error) {
 				s.Log.Debug("ignoring token", "token", token.AccessorID, "description", token.Description, "err", err)
 				continue
 			}
-			if s.ClusterARN != state.ClusterARN { // TODO: Be sure this is always either ARN or the cluster name.
+			if s.ClusterARN != state.ClusterARN {
 				continue
 			}
 			if found, ok := aclState[state.TaskID]; ok {

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -8,21 +8,19 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
+	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-uuid"
 )
 
 // Tag definitions
 const (
-	meshTag        = "consul.hashicorp.com/mesh"
-	serviceNameTag = "consul.hashicorp.com/service-name"
+	meshTag = "consul.hashicorp.com/mesh"
 
 	// Included in ACL token description.
 	clusterTag = "consul.hashicorp.com/cluster"
+	taskIdTag  = "consul.hashicorp.com/task-id"
 
 	// Consul Enterprise support for partitions and namespaces
 	partitionTag = "consul.hashicorp.com/partition"
@@ -36,17 +34,7 @@ const (
 	DefaultNamespace = "default"
 )
 
-// ServiceName is a type that represents a fully qualified service.
-type ServiceName struct {
-	// Name of the service.
-	Name string
-	// Partition that the service belongs to (Consul Enterprise).
-	Partition string
-	// Namespace that the service belongs to (Consul Enterprise).
-	Namespace string
-	// ACLNamespace defines the namespace that ACL tokens and policies are scoped to (Consul Enterprise).
-	ACLNamespace string
-}
+type TaskID string
 
 // ResourceLister is an interface for listing Resources.
 type ResourceLister interface {
@@ -63,23 +51,20 @@ type Resource interface {
 	// It returns the empty string if namespaces are not enabled.
 	Namespace() string
 
-	// Reconcile offers Upsert and Delete functions to reconcile itself with an external state.
+	// Reconcile offers functions to reconcile itself with an external state.
 	Reconcile() error
 }
 
-// ServiceStateLister is an implementation of ResourceLister that constructs ServiceInfo
-type ServiceStateLister struct {
+// TaskStateLister is an implementation of ResourceLister.
+type TaskStateLister struct {
 	// ECSClient is the AWS ECS client to be used by the ServiceStateLister.
 	ECSClient ecsiface.ECSAPI
-	// SecretsManagerClient is the AWS Secrets Manager client to be used by the ServiceStateLister.
-	SecretsManagerClient secretsmanageriface.SecretsManagerAPI
+
 	// ConsulClient is the Consul client to be used by the ServiceStateLister.
 	ConsulClient *api.Client
 
 	// Cluster is the name or the ARN of the ECS cluster.
 	Cluster string
-	// SecretPrefix is the prefix to determine names of resources in Consul or AWS.
-	SecretPrefix string
 
 	// Partition is the partition that is used by the ServiceStateLister [Consul Enterprise].
 	// If partition and namespace support are not enabled then this is set to the empty string.
@@ -89,23 +74,20 @@ type ServiceStateLister struct {
 	Log hclog.Logger
 }
 
-// List returns a mapping from inferred service names to the ACL tokens, ECS
-// tasks and existence of a Consul service.
-func (s ServiceStateLister) List() ([]Resource, error) {
+// List returns resources to be reconciled.
+// - Namespaces which may need to be created
+// - Tokens whcih may need to be cleaned up
+func (s TaskStateLister) List() ([]Resource, error) {
 	var resources []Resource
-	buildingResources := make(map[ServiceName]*ServiceInfo)
+	buildingResources := make(map[TaskID]*TaskState)
 
 	tasks, err := s.fetchECSTasks()
 	if err != nil {
 		return nil, err
 	}
 
-	for name := range tasks {
-		if _, ok := buildingResources[name]; !ok {
-			buildingResources[name] = s.newServiceInfo(name, ServiceState{ConsulECSTasks: true})
-		} else {
-			buildingResources[name].ServiceState.ConsulECSTasks = true
-		}
+	for id, task := range tasks {
+		buildingResources[id] = task
 	}
 
 	aclState, err := s.fetchACLState()
@@ -113,15 +95,13 @@ func (s ServiceStateLister) List() ([]Resource, error) {
 		return resources, err
 	}
 
-	for name, state := range aclState {
-		if _, ok := buildingResources[name]; !ok {
-			buildingResources[name] = s.newServiceInfo(
-				name,
-				ServiceState{ACLPolicies: state.ACLPolicies, ACLTokens: state.ACLTokens},
-			)
+	for id, state := range aclState {
+		// Each task may have two tokens, client and service. The client token is in the default
+		// namespace, while the service token may be in any namespace.
+		if _, ok := buildingResources[id]; !ok {
+			buildingResources[id] = state
 		} else {
-			buildingResources[name].ServiceState.ACLPolicies = state.ACLPolicies
-			buildingResources[name].ServiceState.ACLTokens = state.ACLTokens
+			buildingResources[id].ACLTokens = append(buildingResources[id].ACLTokens, state.ACLTokens...)
 		}
 	}
 
@@ -133,10 +113,11 @@ func (s ServiceStateLister) List() ([]Resource, error) {
 }
 
 // fetchECSTasks retrieves all of the ECS tasks that are managed by consul-ecs
-// for the given cluster and returns a mapping that shows if a task is running
-// for each qualified service name.
-func (s ServiceStateLister) fetchECSTasks() (map[ServiceName]struct{}, error) {
-	resources := make(map[ServiceName]struct{})
+// for the current cluster (s.Cluster) and returns a set of tasks found. Tasks which are not
+// tagged with the current partition (s.Partition) are ignored.
+func (s TaskStateLister) fetchECSTasks() (map[TaskID]*TaskState, error) {
+	resources := make(map[TaskID]*TaskState)
+
 	// nextToken is to handle paginated responses from AWS.
 	var nextToken *string
 
@@ -171,19 +152,18 @@ func (s ServiceStateLister) fetchECSTasks() (map[ServiceName]struct{}, error) {
 				continue
 			}
 
-			serviceName, err := s.serviceNameForTask(task)
-
+			state, err := s.taskStateFromTask(task)
 			if err != nil {
-				s.Log.Error("couldn't get service name from task", "task-arn", task.TaskArn, "tags", task.Tags, "err", err)
+				s.Log.Error("skipping task", "task-arn", *task.TaskArn, "tags", task.Tags, "err", err)
 				continue
 			}
 
-			if serviceName.Partition != s.Partition {
-				s.Log.Debug("skipping task in external partition", "partition", serviceName.Partition, "task-arn", *task.TaskArn)
+			if state.Partition != s.Partition {
+				s.Log.Debug("skipping task in external partition", "partition", state.Partition, "task-arn", *task.TaskArn)
 				continue
 			}
 
-			resources[serviceName] = struct{}{}
+			resources[state.TaskID] = state
 		}
 		if nextToken == nil {
 			break
@@ -192,21 +172,20 @@ func (s ServiceStateLister) fetchECSTasks() (map[ServiceName]struct{}, error) {
 	return resources, nil
 }
 
-// fetchACLState retrieves all of the ACL policies and tokens from Consul and
-// returns a mapping from service name to the ACL tokens that service has.
-func (s ServiceStateLister) fetchACLState() (map[ServiceName]*ServiceState, error) {
-	aclState := make(map[ServiceName]*ServiceState)
+// fetchACLState retrieves all of the ACL tokens from Consul (in this partition)
+// and returns a mapping from task id to the ACL tokens created by the task.
+func (s TaskStateLister) fetchACLState() (map[TaskID]*TaskState, error) {
+	aclState := make(map[TaskID]*TaskState)
 
 	var err error
-	namespaces := make([]*api.Namespace, 0)
+	var namespaces []*api.Namespace
 
 	opts := &api.QueryOptions{Partition: s.Partition}
-
 	if PartitionsEnabled(s.Partition) {
 		// if partitions are enabled then list the namespaces.
 		namespaces, _, err = s.ConsulClient.Namespaces().List(opts)
 		if err != nil {
-			return aclState, err
+			return nil, err
 		}
 	} else {
 		// partitions aren't enabled so just use an empty namespace when listing ACL info.
@@ -214,40 +193,30 @@ func (s ServiceStateLister) fetchACLState() (map[ServiceName]*ServiceState, erro
 		namespaces = append(namespaces, &api.Namespace{})
 	}
 
-	// list ACL policies and tokens from all namespaces and map them to qualified service name
+	// list tokens from all namespaces and map them by task id
 	for _, ns := range namespaces {
 		opts.Namespace = ns.Name
 
-		policyList, _, err := s.ConsulClient.ACL().PolicyList(opts)
-		if err != nil {
-			return aclState, err
-		}
-
-		for _, policy := range policyList {
-			if isInCluster(s.Cluster, policy.Description) {
-				serviceName := s.serviceNameFromDescription(policy.Description)
-				if state, ok := aclState[serviceName]; ok {
-					state.ACLPolicies = append(state.ACLPolicies, policy)
-				} else {
-					aclState[serviceName] = &ServiceState{ACLPolicies: []*api.ACLPolicyListEntry{policy}}
-				}
-			}
-		}
-
 		tokenList, _, err := s.ConsulClient.ACL().TokenList(opts)
 		if err != nil {
-			return aclState, err
+			return nil, err
 		}
 
 		for _, token := range tokenList {
-			if isInCluster(s.Cluster, token.Description) {
-				serviceName := s.serviceNameFromDescription(token.Description)
-				if state, ok := aclState[serviceName]; ok {
-					state.ACLTokens = append(state.ACLTokens, token)
-				} else {
-					aclState[serviceName] = &ServiceState{ACLTokens: []*api.ACLTokenListEntry{token}}
-				}
+			state, err := s.taskStateFromToken(token)
+			if err != nil {
+				s.Log.Debug("ignoring token", "token", token.AccessorID, "description", token.Description, "err", err)
+				continue
 			}
+			if s.Cluster != state.Cluster { // TODO: Be sure this is always either ARN or the cluster name.
+				continue
+			}
+			if found, ok := aclState[state.TaskID]; ok {
+				found.ACLTokens = append(found.ACLTokens, token)
+			} else {
+				aclState[state.TaskID] = state
+			}
+
 		}
 	}
 
@@ -256,7 +225,7 @@ func (s ServiceStateLister) fetchACLState() (map[ServiceName]*ServiceState, erro
 
 // ReconcileNamespaces ensures that for every service in the cluster the namespace
 // exists and the cross-partition/cross-namespace read policy exists.
-func (s ServiceStateLister) ReconcileNamespaces(resources []Resource) error {
+func (s TaskStateLister) ReconcileNamespaces(resources []Resource) error {
 	if !PartitionsEnabled(s.Partition) {
 		return nil
 	}
@@ -276,7 +245,7 @@ func (s ServiceStateLister) ReconcileNamespaces(resources []Resource) error {
 
 // upsertCrossNSPolicy creates the cross-namespace read policy in the local
 // partition and default namespace, if it does not already exist.
-func (s ServiceStateLister) upsertCrossNSPolicy() error {
+func (s TaskStateLister) upsertCrossNSPolicy() error {
 	policy, _, err := s.ConsulClient.ACL().PolicyReadByName(
 		xnsPolicyName,
 		&api.QueryOptions{Partition: s.Partition, Namespace: DefaultNamespace},
@@ -311,7 +280,7 @@ func (s ServiceStateLister) upsertCrossNSPolicy() error {
 // each token created in the namespace inherits that policy.
 //
 // It does nothing for namespaces that already exist.
-func (s ServiceStateLister) createNamespaces(resources []Resource) error {
+func (s TaskStateLister) createNamespaces(resources []Resource) error {
 
 	// create the set of all namespaces in the list of resources.
 	ns := make(map[string]struct{})
@@ -346,24 +315,18 @@ func (s ServiceStateLister) createNamespaces(resources []Resource) error {
 	return result
 }
 
-func (s ServiceStateLister) newServiceInfo(serviceName ServiceName, serviceState ServiceState) *ServiceInfo {
-	return &ServiceInfo{
-		SecretsManagerClient: s.SecretsManagerClient,
-		ConsulClient:         s.ConsulClient,
-		Cluster:              s.Cluster,
-		Log:                  s.Log,
-		SecretPrefix:         s.SecretPrefix,
-		ServiceName:          serviceName,
-		ServiceState:         serviceState,
+func (s TaskStateLister) newTaskState(taskId TaskID, clusterArn string) *TaskState {
+	return &TaskState{
+		ConsulClient: s.ConsulClient,
+		Log:          s.Log,
+		TaskID:       TaskID(taskId),
+		Cluster:      clusterArn,
 	}
 }
 
-// Task definition ARN looks like this: arn:aws:ecs:us-east-1:1234567890:task-definition/service:1
-func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error) {
-	var partition, namespace, aclNamespace string
+func (s TaskStateLister) taskStateFromTask(t *ecs.Task) (*TaskState, error) {
+	var partition, namespace string
 	if PartitionsEnabled(s.Partition) {
-		// ACLs are always created in the default namespace.
-		aclNamespace = DefaultNamespace
 		partition = tagValue(t.Tags, partitionTag)
 		namespace = tagValue(t.Tags, namespaceTag)
 		if partition == "" && namespace == "" {
@@ -372,313 +335,107 @@ func (s ServiceStateLister) serviceNameForTask(t *ecs.Task) (ServiceName, error)
 			namespace = DefaultNamespace
 		} else if (partition == "" && namespace != "") || (partition != "" && namespace == "") {
 			// both partition and namespace tags must be provided
-			return ServiceName{}, fmt.Errorf("task definition requires both partition and namespace tags")
+			return nil, fmt.Errorf("task definition requires both partition and namespace tags")
 		}
 	}
-	if serviceName := tagValue(t.Tags, serviceNameTag); serviceName != "" {
-		return ServiceName{
-			Name:         serviceName,
-			Partition:    partition,
-			Namespace:    namespace,
-			ACLNamespace: aclNamespace}, nil
+	taskId := awsutil.ParseTaskID(*t.TaskArn)
+	if taskId == "" {
+		return nil, fmt.Errorf("cannot determine task id from task arn")
 	}
-	taskDefArn := *t.TaskDefinitionArn
-	splits := strings.Split(taskDefArn, "/")
-	if len(splits) != 2 {
-		return ServiceName{}, fmt.Errorf("cannot determine task family from task definition ARN: %q", taskDefArn)
-	}
-	taskFamilyAndRevision := splits[1]
-	splits = strings.Split(taskFamilyAndRevision, ":")
-	if len(splits) != 2 {
-		return ServiceName{}, fmt.Errorf("cannot determine task family from task definition ARN: %q", taskDefArn)
-	}
-	return ServiceName{
-		Name:         splits[0],
-		Partition:    partition,
-		Namespace:    namespace,
-		ACLNamespace: aclNamespace}, nil
+
+	ts := s.newTaskState(TaskID(taskId), *t.ClusterArn)
+	ts.ECSTaskFound = true
+	ts.Partition = partition
+	ts.NS = namespace
+	return ts, nil
 }
 
-// serviceNameFromDescription returns the fully qualified service name from the
-// description field of a token or policy created by the ACL controller.
-// If a valid name can't be determined from the input an empty name is returned.
-func (s ServiceStateLister) serviceNameFromDescription(d string) ServiceName {
-	// description is of the form: "<Policy|Token> for <name> service..."
-	var n int
-	var err error
-	var key, name, cluster, partition, namespace, aclNamespace string
-
-	if PartitionsEnabled(s.Partition) {
-		aclNamespace = DefaultNamespace
-		scanFmt := fmt.Sprintf("%%s for %%s service\n%s: %%s\n%s: %%s\n%s: %%s",
-			clusterTag,
-			partitionTag,
-			namespaceTag)
-		n, err = fmt.Sscanf(d, scanFmt, &key, &name, &cluster, &partition, &namespace)
-	} else {
-		n, err = fmt.Sscanf(d, "%s for %s service\n", &key, &name)
+func (s TaskStateLister) taskStateFromToken(token *api.ACLTokenListEntry) (*TaskState, error) {
+	meta, err := parseTokenDescription(token.Description)
+	if err != nil {
+		return nil, err
 	}
 
-	if err != nil || n < 2 {
-		return ServiceName{}
+	ts := s.newTaskState(meta.TaskID, meta.Cluster)
+	ts.ACLTokens = []*api.ACLTokenListEntry{token}
+	// Do not set the partition or namespace based on the token.
+	// We don't create namespaces based on the token, and the token struct
+	// includes the partition/namespace if the token needs to be deleted.
+	return ts, nil
+}
+
+// parseTokenDescription parses a Consul ACL token description.
+// This parses "metadata" set by `consul login -meta` which is included
+// as a JSON object in the the token description, ex:
+//
+//   token created via login: {"consul.hashicorp.com/cluster":"my-cluster","consul.hashicorp.com/task-id":"123456"}
+func parseTokenDescription(d string) (tokenMeta, error) {
+	var meta tokenMeta
+	jsonStr := strings.Replace(d, "token created via login:", "", 1)
+	err := json.Unmarshal([]byte(jsonStr), &meta)
+	if err != nil {
+		return tokenMeta{}, err
 	}
-
-	return ServiceName{Name: name, Partition: partition, Namespace: namespace, ACLNamespace: aclNamespace}
+	if meta.TaskID == "" || meta.Cluster == "" {
+		return tokenMeta{}, fmt.Errorf("task or cluster missing from token description")
+	}
+	return meta, nil
 }
 
-// ServiceState contains all of the information needed to determine if an ACL
-// token should be created for a Consul service or if an ACL token should be
-// deleted.
-type ServiceState struct {
-	ConsulECSTasks bool
-	ACLTokens      []*api.ACLTokenListEntry
-	ACLPolicies    []*api.ACLPolicyListEntry
+type tokenMeta struct {
+	TaskID  TaskID `json:"consul.hashicorp.com/task-id"`
+	Cluster string `json:"consul.hashicorp.com/cluster"`
 }
 
-type ServiceInfo struct {
-	SecretsManagerClient secretsmanageriface.SecretsManagerAPI
-	ConsulClient         *api.Client
+// TaskState contains the information needed to reconcile a task.
+type TaskState struct {
+	ConsulClient *api.Client
 
-	Cluster      string
-	SecretPrefix string
-	ServiceName  ServiceName
-	ServiceState ServiceState
+	// TaskID is the id of the ECS task.
+	TaskID TaskID
+	// Cluster is the ECS cluster.
+	Cluster string
+	// Partition that the task belongs to [Consul Enterprise].
+	Partition string
+	// Namespace that the task belongs to [Consul Enterprise].
+	NS string
+
+	// ECSTaskFound indicates whether an ECS task was found for this task id.
+	ECSTaskFound bool
+	// ACLTokens are the Consul ACL tokens found for this task id.
+	ACLTokens []*api.ACLTokenListEntry
 
 	Log hclog.Logger
 }
 
-// TokenSecretJSON is the struct that represents JSON of the token secrets
-// stored in Secrets Manager.
-type TokenSecretJSON struct {
-	AccessorID string `json:"accessor_id"`
-	Token      string `json:"token"`
-}
-
-// Reconcile inserts or deletes ACL tokens based on their ServiceState.
-func (s *ServiceInfo) Reconcile() error {
-	state := s.ServiceState
-	if (len(state.ACLTokens) == 0 || len(state.ACLPolicies) == 0) && state.ConsulECSTasks {
-		return s.Upsert()
+// Reconcile deletes ACL tokens based on their ServiceState.
+func (t *TaskState) Reconcile() error {
+	if !t.ECSTaskFound && len(t.ACLTokens) > 0 {
+		return t.Delete()
 	}
-
-	if !state.ConsulECSTasks && (len(state.ACLTokens) > 0 || len(state.ACLPolicies) > 0) {
-		return s.Delete()
-	}
-
 	return nil
 }
 
-// Upsert creates a service policy and token for the task if one doesn't already exist
-// and updates the secret with the contents of the token.
-func (s *ServiceInfo) Upsert() error {
-	opts := &api.QueryOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.ACLNamespace}
-
-	// upsert policy
-	currPolicy, _, err := s.ConsulClient.ACL().PolicyReadByName(s.policyName(), opts)
-	if err != nil && !IsACLNotFoundError(err) {
-		return fmt.Errorf("reading service policy: %w", err)
-	}
-
-	// if the policy doesn't already exist, create it.
-	if currPolicy == nil {
-		if err = s.createServicePolicy(); err != nil {
-			return fmt.Errorf("creating service policy: %w", err)
-		}
-	}
-
-	// upsert token
-	currSecret, err := s.upsertSecret()
-	if err != nil {
-		return fmt.Errorf("upserting secret: %w", err)
-	}
-
-	currToken, _, err := s.ConsulClient.ACL().TokenRead(currSecret.AccessorID, opts)
-
-	if err != nil && !IsACLNotFoundError(err) {
-		return fmt.Errorf("reading existing token: %w", err)
-	}
-
-	// If there is already a token for this service in Consul, exit early.
-	if currToken != nil {
-		s.Log.Info("token already exists; skipping token creation", "id", s.ServiceName)
-		return nil
-	}
-
-	// Otherwise, create one.
-	if err = s.createServiceToken(currSecret); err != nil {
-		return fmt.Errorf("creating service token: %w", err)
-	}
-
-	return nil
-}
-
-// Delete removes the service policy and token for the given ServiceInfo.
-func (s *ServiceInfo) Delete() error {
-	opts := &api.WriteOptions{Partition: s.ServiceName.Partition, Namespace: s.ServiceName.ACLNamespace}
-
-	for _, token := range s.ServiceState.ACLTokens {
-		_, err := s.ConsulClient.ACL().TokenDelete(token.AccessorID, opts)
+// Delete removes the service token for the given ServiceInfo.
+func (t *TaskState) Delete() error {
+	for _, token := range t.ACLTokens {
+		opts := &api.WriteOptions{Partition: token.Partition, Namespace: token.Namespace}
+		_, err := t.ConsulClient.ACL().TokenDelete(token.AccessorID, opts)
 		if err != nil {
 			return fmt.Errorf("deleting token: %w", err)
 		}
-		s.Log.Info("token deleted successfully", "service", s.ServiceName)
+		t.Log.Info("token deleted successfully", "token", token.Description)
 	}
-
-	for _, policy := range s.ServiceState.ACLPolicies {
-		_, err := s.ConsulClient.ACL().PolicyDelete(policy.ID, opts)
-		if err != nil {
-			return fmt.Errorf("deleting policy: %w", err)
-		}
-		s.Log.Info("policy deleted successfully", "policy", s.policyName())
-	}
-
 	return nil
 }
 
 // Namespace returns the namespace that the service belongs to.
 // It returns the empty string if namespaces are not enabled.
-func (s *ServiceInfo) Namespace() string {
-	return s.ServiceName.Namespace
-}
-
-// upsertSecret updates the AWS secret for the given service has a Token and
-// AccessorID if it is unset. If the secret is already set, this does nothing.
-func (s *ServiceInfo) upsertSecret() (TokenSecretJSON, error) {
-	var currSecret TokenSecretJSON
-	secretName := s.secretName()
-
-	// Get current secret from AWS.
-	currSecretValue, err := s.SecretsManagerClient.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretId: aws.String(secretName)})
-	if err != nil {
-		return currSecret, fmt.Errorf("retrieving secret %s: %w", secretName, err)
+func (t *TaskState) Namespace() string {
+	if t.ECSTaskFound {
+		return t.NS
 	}
-	err = json.Unmarshal([]byte(*currSecretValue.SecretString), &currSecret)
-	if err != nil {
-		return currSecret, fmt.Errorf("unmarshalling secret value: %w", err)
-	}
-
-	if len(currSecret.AccessorID) > 0 && len(currSecret.Token) > 0 {
-		return currSecret, nil
-	}
-
-	accessorID, err := uuid.GenerateUUID()
-	if err != nil {
-		return currSecret, err
-	}
-
-	secretID, err := uuid.GenerateUUID()
-	if err != nil {
-		return currSecret, err
-	}
-
-	newSecret := TokenSecretJSON{Token: secretID, AccessorID: accessorID}
-	serviceSecretValue, err := json.Marshal(newSecret)
-	if err != nil {
-		return newSecret, err
-	}
-
-	s.Log.Info("updating secret", "name", secretName)
-	_, err = s.SecretsManagerClient.UpdateSecret(&secretsmanager.UpdateSecretInput{
-		SecretId:     aws.String(s.secretName()),
-		SecretString: aws.String(string(serviceSecretValue)),
-	})
-	if err != nil {
-		return newSecret, fmt.Errorf("updating secret: %s", err)
-	}
-	s.Log.Info("secret successfully set", "name", secretName)
-
-	return newSecret, err
-}
-
-// createServicePolicy
-func (s *ServiceInfo) createServicePolicy() error {
-	s.Log.Info("creating service policy", "name", s.policyName())
-	_, _, err := s.ConsulClient.ACL().PolicyCreate(&api.ACLPolicy{
-		Name:        s.policyName(),
-		Description: s.aclDescription("Policy"),
-		Partition:   s.ServiceName.Partition,
-		Namespace:   s.ServiceName.ACLNamespace,
-		Rules:       s.policy(),
-	}, nil)
-	if err != nil {
-		return fmt.Errorf("creating service policy: %w", err)
-	}
-	s.Log.Info("created service policy", "name", s.policyName())
-	return nil
-}
-
-// createServiceToken inserts an ACL token into Consul. The AccessorID and
-// SecretID are set based on the AWS secret.
-func (s *ServiceInfo) createServiceToken(secret TokenSecretJSON) error {
-	s.Log.Info("creating service token", "id", s.ServiceName)
-	policies := []*api.ACLTokenPolicyLink{&api.ACLLink{Name: s.policyName()}}
-	if PartitionsEnabled(s.ServiceName.Partition) {
-		// Include the cross-namespace read policy when partitions are enabled.
-		policies = append(policies, &api.ACLLink{Name: xnsPolicyName})
-	}
-
-	// Create ACL token for envoy to register the service.
-	_, _, err := s.ConsulClient.ACL().TokenCreate(&api.ACLToken{
-		AccessorID:  secret.AccessorID,
-		SecretID:    secret.Token,
-		Description: s.aclDescription("Token"),
-		Policies:    policies,
-		Partition:   s.ServiceName.Partition,
-		Namespace:   s.ServiceName.ACLNamespace,
-	}, nil)
-	if err != nil {
-		return fmt.Errorf("creating ACL token: %s", err)
-	}
-	s.Log.Info("service token created successfully", "service", s.ServiceName)
-
-	return nil
-}
-
-func (s *ServiceInfo) secretName() string {
-	if PartitionsEnabled(s.ServiceName.Partition) {
-		return fmt.Sprintf("%s-%s-%s-%s",
-			s.SecretPrefix,
-			s.ServiceName.Name,
-			s.ServiceName.Namespace,
-			s.ServiceName.Partition)
-	} else {
-		return fmt.Sprintf("%s-%s", s.SecretPrefix, s.ServiceName.Name)
-	}
-}
-
-func (s *ServiceInfo) aclDescription(d string) string {
-	desc := fmt.Sprintf("%s for %s service\n%s: %s", d, s.ServiceName.Name, clusterTag, s.Cluster)
-	if PartitionsEnabled(s.ServiceName.Partition) {
-		desc = fmt.Sprintf("%s\n%s: %s\n%s: %s",
-			desc,
-			partitionTag, s.ServiceName.Partition,
-			namespaceTag, s.ServiceName.Namespace)
-	}
-	return desc
-}
-
-func (s *ServiceInfo) policyName() string {
-	if PartitionsEnabled(s.ServiceName.Partition) {
-		return fmt.Sprintf("%s-%s-service", s.ServiceName.Name, s.ServiceName.Namespace)
-	} else {
-		return fmt.Sprintf("%s-service", s.ServiceName.Name)
-	}
-}
-
-func (s *ServiceInfo) policy() string {
-	if PartitionsEnabled(s.ServiceName.Partition) {
-		return fmt.Sprintf(entServicePolicyTpl,
-			s.ServiceName.Partition,
-			s.ServiceName.Namespace,
-			s.ServiceName.Name,
-			s.ServiceName.Name)
-	} else {
-		return fmt.Sprintf(ossServicePolicyTpl, s.ServiceName.Name, s.ServiceName.Name)
-	}
-}
-
-func isInCluster(clusterName, description string) bool {
-	return strings.Contains(description, fmt.Sprintf("%s: %s", clusterTag, clusterName))
+	return ""
 }
 
 func isMeshTask(t *ecs.Task) bool {

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -57,7 +57,7 @@ func makeECSTask(t *testing.T, taskId string, tags ...string) *ecs.Task {
 func makeTaskState(taskId string, taskFound bool, tokens []*api.ACLTokenListEntry) *TaskState {
 	t := &TaskState{
 		TaskID:       TaskID(taskId),
-		Cluster:      testClusterArn,
+		ClusterARN:   testClusterArn,
 		ECSTaskFound: taskFound,
 		ACLTokens:    tokens,
 	}
@@ -296,7 +296,7 @@ func TestTaskStateListerList(t *testing.T) {
 			lister := TaskStateLister{
 				ECSClient:    &mocks.ECSClient{Tasks: c.initTasks},
 				ConsulClient: consulClient,
-				Cluster:      testClusterArn,
+				ClusterARN:   testClusterArn,
 				Log:          hclog.Default().Named("lister"),
 			}
 

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -17,16 +17,17 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-ecs/controller/mocks"
 	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
@@ -35,709 +36,456 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServiceStateLister_List(t *testing.T) {
-	t.Parallel()
-	enterprise := enterpriseFlag()
-	cluster := "cluster"
-	meshKey := "consul.hashicorp.com/mesh"
-	meshValue := "true"
-	partitionKey := "consul.hashicorp.com/partition"
-	namespaceKey := "consul.hashicorp.com/namespace"
-	namespaces := []string{"default", "namespace-1"}
-	meshTag := &ecs.Tag{Key: &meshKey, Value: &meshValue}
-	nonMeshTag := &ecs.Tag{}
+const testClusterArn = "arn:aws:ecs:bogus-east-1:000000000000:cluster/my-cluster"
 
-	makeTask := func(taskName, serviceName, partition, namespace string, tags ...*ecs.Tag) (ecs.Task, ServiceName, *api.ACLToken, *api.ACLTokenListEntry) {
-		if enterprise {
-			tags = append(tags, &ecs.Tag{Key: &partitionKey, Value: &partition})
-			tags = append(tags, &ecs.Tag{Key: &namespaceKey, Value: &namespace})
-		}
-		task := ecs.Task{
-			TaskArn:           aws.String(taskName),
-			TaskDefinitionArn: aws.String(fmt.Sprintf("arn:aws:ecs:us-east-1:1234567890:task-definition/%s:1", serviceName)),
-			Tags:              tags,
-		}
-		name := ServiceName{Name: serviceName}
-		token := &api.ACLToken{}
-		tokenListEntry := &api.ACLTokenListEntry{}
-		if enterprise {
-			name.Partition = partition
-			name.Namespace = namespace
-			name.ACLNamespace = DefaultNamespace
-			token.Partition = partition
-			token.Namespace = DefaultNamespace
-			tokenListEntry.Partition = partition
-			tokenListEntry.Namespace = DefaultNamespace
-		}
-		info := ServiceInfo{Cluster: cluster, ServiceName: name}
-		token.Description = info.aclDescription("Token")
-		tokenListEntry.Description = info.aclDescription("Token")
-		return task, name, token, tokenListEntry
-	}
-	task1, task1Name, aclToken1, aclTokenListEntry1 := makeTask("task1", "service1", "default", "default", meshTag)
-	task2, task2Name, aclToken2, aclTokenListEntry2 := makeTask("task2", "service1", "default", "namespace-1", meshTag)
-	nonMeshTask, _, _, _ := makeTask("nonMeshTask", "service1", "default", "default", nonMeshTag)
-	_, task3Name, aclToken3, aclTokenListEntry3 := makeTask("task3", "service3", "default", "default", nonMeshTag)
-	task4, _, _, _ := makeTask("task4", "service4", "external-partition", "default", meshTag)
-	cases := map[string]struct {
-		paginateResults bool
-		tasks           []ecs.Task
-		expected        map[ServiceName]ServiceState
-		aclTokens       []*api.ACLToken
-		partition       string
-	}{
-		"no overlap between tasks, services and tokens": {
-			tasks:     []ecs.Task{task1, task2},
-			partition: "default",
-			aclTokens: []*api.ACLToken{aclToken3},
-			expected: map[ServiceName]ServiceState{
-				task1Name: {
-					ConsulECSTasks: true,
-				},
-				task3Name: {
-					ACLTokens: []*api.ACLTokenListEntry{aclTokenListEntry3},
-				},
-			},
-		},
-		"all overlap between tasks, services and tokens": {
-			tasks:     []ecs.Task{task1, task2},
-			partition: "default",
-			aclTokens: []*api.ACLToken{aclToken1, aclToken2},
-			expected: map[ServiceName]ServiceState{
-				task1Name: {
-					ConsulECSTasks: true,
-					ACLTokens:      []*api.ACLTokenListEntry{aclTokenListEntry1},
-				},
-				task2Name: {
-					ConsulECSTasks: true,
-					ACLTokens:      []*api.ACLTokenListEntry{aclTokenListEntry2},
-				},
-			},
-		},
-		"with pagination": {
-			tasks:           []ecs.Task{task1, task2},
-			partition:       "default",
-			paginateResults: true,
-			expected: map[ServiceName]ServiceState{
-				task1Name: {
-					ConsulECSTasks: true,
-				},
-			},
-		},
-		"with non-mesh tasks": {
-			tasks:     []ecs.Task{nonMeshTask},
-			partition: "default",
-			aclTokens: []*api.ACLToken{aclToken1},
-			expected: map[ServiceName]ServiceState{
-				task1Name: {
-					ConsulECSTasks: false,
-					ACLTokens:      []*api.ACLTokenListEntry{aclTokenListEntry1},
-				},
-			},
-		},
-	}
-
-	if enterprise {
-		// in the enterprise case the services are qualified by their partition and namespace
-		// and thus become unique entries.. add the missing expected service states.
-		e := cases["no overlap between tasks, services and tokens"].expected
-		e[task2Name] = ServiceState{ConsulECSTasks: true}
-		e = cases["with pagination"].expected
-		e[task2Name] = ServiceState{ConsulECSTasks: true}
-	}
-
-	for name, c := range cases {
-		// Necessary to avoid sharing `c` across subtest functions,
-		// which would cause issues when running those functions in parallel.
-		c := c
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			consulClient := initConsul(t)
-
-			if enterprise {
-				for _, ns := range namespaces {
-					_, _, err := consulClient.Namespaces().Create(&api.Namespace{Name: ns}, nil)
-					require.NoError(t, err)
-				}
-			}
-
-			createdTokens := make(map[string]struct{})
-			for _, aclToken := range c.aclTokens {
-				id := fmt.Sprintf("%s/%s/%s", aclToken.Partition, aclToken.Namespace, aclToken.Description)
-				if _, exists := createdTokens[id]; !exists {
-					_, _, err := consulClient.ACL().TokenCreate(aclToken,
-						&api.WriteOptions{Partition: aclToken.Partition, Namespace: aclToken.Namespace})
-					require.NoError(t, err)
-					createdTokens[id] = struct{}{}
-				}
-			}
-
-			var tasks []*ecs.Task
-
-			for i := range c.tasks {
-				tasks = append(tasks, &c.tasks[i])
-			}
-
-			var partition string
-			if enterprise {
-				// for the enterprise case, set the partition and add in the task that
-				// belongs to an external partition.
-				partition = c.partition
-				tasks = append(tasks, &task4)
-			}
-
-			s := ServiceStateLister{
-				SecretPrefix: "test",
-				Log:          hclog.NewNullLogger(),
-				ConsulClient: consulClient,
-				ECSClient: &mocks.ECSClient{
-					Tasks:           tasks,
-					PaginateResults: c.paginateResults,
-				},
-				Partition: partition,
-			}
-
-			resources, err := s.List()
-			require.NoError(t, err)
-
-			serviceStates := make(map[ServiceName]ServiceState)
-
-			for _, resource := range resources {
-				serviceInfo := resource.(*ServiceInfo)
-
-				// only set the expected acl token fields
-				var tokens []*api.ACLTokenListEntry
-				for _, token := range serviceInfo.ServiceState.ACLTokens {
-					entry := &api.ACLTokenListEntry{
-						Description: token.Description,
-						Policies:    token.Policies,
-						Partition:   token.Partition,
-						Namespace:   token.Namespace,
-					}
-					tokens = append(tokens, entry)
-				}
-				serviceInfo.ServiceState.ACLTokens = tokens
-				serviceStates[serviceInfo.ServiceName] = serviceInfo.ServiceState
-			}
-
-			require.Equal(t, c.expected, serviceStates)
+func makeECSTask(t *testing.T, taskId string, tags ...string) *ecs.Task {
+	require.Equal(t, 0, len(tags)%2, "tags must be even length")
+	var ecsTags []*ecs.Tag
+	for i := 0; i < len(tags); i += 2 {
+		ecsTags = append(ecsTags, &ecs.Tag{
+			Key:   aws.String(tags[i]),
+			Value: aws.String(tags[i+1]),
 		})
+	}
+	return &ecs.Task{
+		ClusterArn: aws.String(testClusterArn),
+		TaskArn:    aws.String("arn:aws:ecs:bogus-east-1:000000000000:task/my-cluster/" + taskId),
+		Tags:       ecsTags,
 	}
 }
 
-func TestReconcile(t *testing.T) {
-	t.Parallel()
-	cluster := "test-cluster"
-	aclToken1 := &api.ACLToken{}
-	aclPolicy1 := &api.ACLPolicy{Name: "service1-service"}
-	cases := map[string]struct {
-		tasks            bool
-		aclTokens        []*api.ACLToken
-		aclPolicies      []*api.ACLPolicy
-		sutServiceName   ServiceName
-		expectedTokens   []*api.ACLToken
-		expectedPolicies []*api.ACLPolicy
-	}{
-		"ACLs should be deleted": {
-			tasks:            false,
-			aclTokens:        []*api.ACLToken{aclToken1},
-			aclPolicies:      []*api.ACLPolicy{aclPolicy1},
-			sutServiceName:   ServiceName{Name: "service1"},
-			expectedTokens:   nil,
-			expectedPolicies: nil,
-		},
-		"ACLs should be added": {
-			tasks:            true,
-			aclTokens:        []*api.ACLToken{},
-			aclPolicies:      []*api.ACLPolicy{},
-			sutServiceName:   ServiceName{Name: "service1"},
-			expectedTokens:   []*api.ACLToken{aclToken1},
-			expectedPolicies: []*api.ACLPolicy{aclPolicy1},
-		},
-		"Does nothing when a task is running and ACLs exists for a given service": {
-			tasks:            true,
-			aclTokens:        []*api.ACLToken{aclToken1},
-			aclPolicies:      []*api.ACLPolicy{aclPolicy1},
-			sutServiceName:   ServiceName{Name: "service1"},
-			expectedTokens:   []*api.ACLToken{aclToken1},
-			expectedPolicies: []*api.ACLPolicy{aclPolicy1},
-		},
-		"Does nothing when there are no tasks or tokens": {
-			tasks:          false,
-			sutServiceName: ServiceName{Name: "service1"},
-		},
+func makeTaskState(taskId string, taskFound bool, tokens []*api.ACLTokenListEntry) *TaskState {
+	t := &TaskState{
+		TaskID:       TaskID(taskId),
+		Cluster:      testClusterArn,
+		ECSTaskFound: taskFound,
+		ACLTokens:    tokens,
 	}
-
-	for name, c := range cases {
-		c := c
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			smClient := &mocks.SMClient{Secret: &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)}}
-			consulClient := initConsul(t)
-
-			writeOpts := &api.WriteOptions{}
-			if enterpriseFlag() {
-				c.sutServiceName.Partition = "default"
-				c.sutServiceName.Namespace = "default"
-				c.sutServiceName.ACLNamespace = "default"
-
-				aclToken1.Partition = "default"
-				aclToken1.Namespace = "default"
-
-				aclPolicy1.Partition = "default"
-				aclPolicy1.Namespace = "default"
-
-				writeOpts.Partition = "default"
-				writeOpts.Namespace = "default"
-			}
-
-			info := ServiceInfo{Cluster: cluster, ServiceName: c.sutServiceName}
-			aclToken1.Description = info.aclDescription("Token")
-			aclPolicy1.Name = info.policyName()
-			aclPolicy1.Description = info.aclDescription("Policy")
-
-			var beforePolicies []*api.ACLPolicyListEntry
-			for _, aclPolicy := range c.aclPolicies {
-				policy, _, err := consulClient.ACL().PolicyCreate(aclPolicy, writeOpts)
-				require.NoError(t, err)
-				beforePolicies = append(beforePolicies, &api.ACLPolicyListEntry{
-					ID: policy.ID,
-				})
-			}
-			var beforeTokens []*api.ACLTokenListEntry
-			for _, aclToken := range c.aclTokens {
-				token, _, err := consulClient.ACL().TokenCreate(aclToken, writeOpts)
-				require.NoError(t, err)
-				beforeTokens = append(beforeTokens, &api.ACLTokenListEntry{
-					AccessorID: token.AccessorID,
-				})
-			}
-
-			log := hclog.NewNullLogger()
-			serviceStateLister := ServiceStateLister{
-				ConsulClient: consulClient,
-				Partition:    c.sutServiceName.Partition,
-				Log:          log,
-			}
-
-			serviceInfo := ServiceInfo{
-				SecretsManagerClient: smClient,
-				ConsulClient:         consulClient,
-				Cluster:              cluster,
-				SecretPrefix:         "test",
-				ServiceName:          c.sutServiceName,
-				ServiceState: ServiceState{
-					ConsulECSTasks: c.tasks,
-					ACLPolicies:    beforePolicies,
-					ACLTokens:      beforeTokens,
-				},
-				Log: log,
-			}
-
-			if enterpriseFlag() {
-				// for enterprise testing we need to create the cross-namespace policy
-				require.NoError(t, serviceStateLister.ReconcileNamespaces([]Resource{&serviceInfo}))
-			}
-
-			err := serviceInfo.Reconcile()
-			require.NoError(t, err)
-
-			aclState, err := serviceStateLister.fetchACLState()
-			require.NoError(t, err)
-
-			var policies []*api.ACLPolicy
-			var tokens []*api.ACLToken
-			if state, ok := aclState[c.sutServiceName]; ok {
-				for _, policy := range state.ACLPolicies {
-					policies = append(policies, &api.ACLPolicy{
-						Name:        policy.Name,
-						Description: policy.Description,
-						Partition:   policy.Partition,
-						Namespace:   policy.Namespace,
-					})
-				}
-				for _, token := range state.ACLTokens {
-					tokens = append(tokens, &api.ACLToken{
-						Partition:   token.Partition,
-						Namespace:   token.Namespace,
-						Description: token.Description,
-					})
-				}
-			}
-			require.Equal(t, len(c.expectedPolicies), len(policies))
-			require.Equal(t, len(c.expectedTokens), len(tokens))
-			require.Equal(t, c.expectedPolicies, policies)
-			require.Equal(t, c.expectedTokens, tokens)
-		})
+	if enterpriseFlag() && taskFound {
+		t.Partition = DefaultPartition
+		t.NS = DefaultNamespace
 	}
-
+	return t
 }
 
-func TestRecreatingAToken(t *testing.T) {
-	t.Parallel()
-	smClient := &mocks.SMClient{Secret: &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)}}
-	consulClient := initConsul(t)
+func makeTaskStateEnt(taskId string, taskFound bool, tokens []*api.ACLTokenListEntry, partition, namespace string) *TaskState {
+	t := makeTaskState(taskId, taskFound, tokens)
+	t.Partition = partition
+	t.NS = namespace
+	return t
+}
 
-	taskTokens := ServiceInfo{
-		SecretsManagerClient: smClient,
-		ConsulClient:         consulClient,
-		Cluster:              "test-cluster",
-		SecretPrefix:         "test",
-		ServiceName:          ServiceName{Name: "service"},
-		ServiceState: ServiceState{
-			ConsulECSTasks: true,
-		},
-		Log: hclog.NewNullLogger(),
-	}
-
-	getSecretValue := func() TokenSecretJSON {
-		var secret TokenSecretJSON
-		err := json.Unmarshal([]byte(*smClient.Secret.SecretString), &secret)
-		require.NoError(t, err)
-		return secret
-	}
-
-	tokenMatchesSecret := func(secret TokenSecretJSON) {
-		currToken, _, err := consulClient.ACL().TokenRead(secret.AccessorID, nil)
-		require.NoError(t, err)
-		require.Equal(t, secret.AccessorID, currToken.AccessorID)
-		require.Equal(t, secret.Token, currToken.SecretID)
-	}
-
-	err := taskTokens.Upsert()
+func makeToken(t *testing.T, taskId string, isLogin bool) *api.ACLTokenListEntry {
+	accessor, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	secret, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 
-	originalSecret := getSecretValue()
-	tokenMatchesSecret(originalSecret)
-
-	err = taskTokens.Delete()
-	require.NoError(t, err)
-	require.Equal(t, originalSecret, getSecretValue(), "The secret isn't deleted")
-
-	// Inserting a token with the same AccessorID and SecretID as the original
-	// one works.
-	err = taskTokens.Upsert()
-	require.NoError(t, err)
-	require.Equal(t, originalSecret, getSecretValue(), "The secret isn't changed")
-	tokenMatchesSecret(originalSecret)
-}
-
-func TestTask_Upsert(t *testing.T) {
-	t.Parallel()
-	cases := map[string]struct {
-		createExistingToken bool
-		existingSecret      *secretsmanager.GetSecretValueOutput
-		expectTokenToExist  bool
-		expectedError       string
-	}{
-		"task with mesh tag": {
-			existingSecret:     &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)},
-			expectTokenToExist: true,
-		},
-		"when there is an existing token for the service, we don't create a new one": {
-			// When createExistingToken is true, existingSecret will be updated with the value of the created token.
-			existingSecret:      &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)},
-			createExistingToken: true,
-			expectTokenToExist:  true,
-		},
-		"when the token in the secret doesn't exist in Consul, the secret is updated with the new value": {
-			existingSecret: &secretsmanager.GetSecretValueOutput{
-				Name:         aws.String("test-service"),
-				SecretString: aws.String(`{"accessor_id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","token":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}`),
-			},
-			expectTokenToExist: true,
-		},
+	description := "non login token"
+	if isLogin {
+		description = fmt.Sprintf(
+			`token created via login: {"%s":"%s","%s":"%s"}`,
+			clusterTag, testClusterArn, taskIdTag, taskId,
+		)
 	}
-
-	for name, c := range cases {
-		c := c
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			smClient := &mocks.SMClient{Secret: c.existingSecret}
-			consulClient := initConsul(t)
-
-			taskTokens := ServiceInfo{
-				SecretsManagerClient: smClient,
-				ConsulClient:         consulClient,
-				Cluster:              "test-cluster",
-				SecretPrefix:         "test",
-				ServiceName:          ServiceName{Name: "service"},
-				ServiceState: ServiceState{
-					ConsulECSTasks: true,
-				},
-				Log: hclog.NewNullLogger(),
-			}
-
-			// Create existing token in consul and update existing secret.
-			if c.createExistingToken {
-				// Create token in Consul.
-				token, _, err := consulClient.ACL().TokenCreate(&api.ACLToken{Description: taskTokens.aclDescription("Token")}, nil)
-				require.NoError(t, err)
-				secretValue, err := json.Marshal(TokenSecretJSON{AccessorID: token.AccessorID, Token: token.SecretID})
-				require.NoError(t, err)
-				c.existingSecret.SecretString = aws.String(string(secretValue))
-			}
-
-			err := taskTokens.Upsert()
-			if c.expectedError != "" {
-				require.EqualError(t, err, c.expectedError)
-			} else {
-				require.NoError(t, err)
-
-				// Check the token in Consul.
-				tokens, _, err := consulClient.ACL().TokenList(nil)
-				require.NoError(t, err)
-				var serviceTokens []*api.ACLToken
-				for _, token := range tokens {
-					if token.Description == taskTokens.aclDescription("Token") {
-						token, _, err := consulClient.ACL().TokenRead(token.AccessorID, nil)
-						require.NoError(t, err)
-						serviceTokens = append(serviceTokens, token)
-					}
-				}
-				if c.expectTokenToExist {
-					require.Len(t, serviceTokens, 1)
-
-					// Check the secret in SM has the contents of the consul ACL token.
-					var tokenSecret TokenSecretJSON
-					err = json.Unmarshal([]byte(*smClient.Secret.SecretString), &tokenSecret)
-					require.NoError(t, err)
-					require.Equal(t, serviceTokens[0].AccessorID, tokenSecret.AccessorID)
-					require.Equal(t, serviceTokens[0].SecretID, tokenSecret.Token)
-				} else {
-					require.Len(t, serviceTokens, 0)
-					// Expect the secret to not have changed.
-					require.Equal(t, c.existingSecret, smClient.Secret)
-				}
-			}
-		})
-	}
-}
-
-func TestTask_Delete(t *testing.T) {
-	t.Parallel()
-	cases := map[string]struct {
-		createExistingToken   bool
-		updateExistingSecret  bool
-		registerConsulService bool
-	}{
-		"the token for service doesn't exist in consul and the secret is empty": {
-			createExistingToken:  false,
-			updateExistingSecret: false,
-		},
-		"the token for service doesn't exist in consul and the secret has some value": {
-			createExistingToken:  false,
-			updateExistingSecret: true,
-		},
-	}
-
-	for name, c := range cases {
-		c := c
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			existingSecret := &secretsmanager.GetSecretValueOutput{Name: aws.String("test-service"), SecretString: aws.String(`{}`)}
-			smClient := &mocks.SMClient{Secret: existingSecret}
-			consulClient := initConsul(t)
-
-			taskTokens := ServiceInfo{
-				SecretsManagerClient: smClient,
-				ConsulClient:         consulClient,
-				Cluster:              "test-cluster",
-				SecretPrefix:         "test",
-				ServiceName:          ServiceName{Name: "service"},
-				ServiceState: ServiceState{
-					ConsulECSTasks: true,
-				},
-				Log: hclog.NewNullLogger(),
-			}
-
-			// Create existing token in consul and update existing secret.
-			var err error
-			var token *api.ACLToken
-			if c.createExistingToken {
-				token, _, err = consulClient.ACL().TokenCreate(&api.ACLToken{Description: taskTokens.aclDescription("Token")}, nil)
-				require.NoError(t, err)
-			}
-			if c.updateExistingSecret {
-				if token != nil {
-					secretValue, err := json.Marshal(TokenSecretJSON{AccessorID: token.AccessorID, Token: token.SecretID})
-					require.NoError(t, err)
-					existingSecret.SecretString = aws.String(string(secretValue))
-				} else {
-					secretValue, err := json.Marshal(TokenSecretJSON{AccessorID: "some-accessor-id", Token: "some-secret-id"})
-					require.NoError(t, err)
-					existingSecret.SecretString = aws.String(string(secretValue))
-				}
-			}
-
-			anotherToken, _, err := consulClient.ACL().TokenCreate(&api.ACLToken{
-				ServiceIdentities: []*api.ACLServiceIdentity{{ServiceName: "another-service"}},
-			}, nil)
-			require.NoError(t, err)
-
-			if c.registerConsulService {
-				err := consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
-					Name: "service",
-				})
-				require.NoError(t, err)
-			}
-
-			err = taskTokens.Delete()
-			require.NoError(t, err)
-
-			if c.createExistingToken {
-				// Check that the token is deleted from Consul.
-				_, _, err = consulClient.ACL().TokenRead(token.AccessorID, nil)
-				require.EqualError(t, err, "Unexpected response code: 403 (ACL not found)")
-			}
-
-			require.Equal(t, *existingSecret.SecretString, *smClient.Secret.SecretString)
-
-			// Check that the other token is not affected.
-			_, _, err = consulClient.ACL().TokenRead(anotherToken.AccessorID, nil)
-			require.NoError(t, err)
-		})
-	}
-}
-
-func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
-	t.Parallel()
-	validARN := "arn:aws:ecs:us-east-1:1234567890:task-definition/service:1"
-	cases := map[string]struct {
-		task        ecs.Task
-		serviceName ServiceName
-		partition   string
-	}{
-		"invalid ARN": {
-			task: ecs.Task{
-				TaskDefinitionArn: aws.String("invalid"),
-			},
-			serviceName: ServiceName{},
-		},
-		"parsing from the ARN": {
-			task: ecs.Task{
-				TaskDefinitionArn: aws.String(validARN),
-			},
-			serviceName: ServiceName{Name: "service"},
-		},
-		"from the tags": {
-			task: ecs.Task{
-				TaskDefinitionArn: aws.String(validARN),
-				Tags: []*ecs.Tag{
-					{
-						Key:   aws.String(serviceNameTag),
-						Value: aws.String("real-service-name"),
-					},
-				},
-			},
-			serviceName: ServiceName{Name: "real-service-name"},
-		},
+	tok := &api.ACLTokenListEntry{
+		AccessorID:        accessor,
+		SecretID:          secret,
+		Description:       description,
+		ServiceIdentities: []*api.ACLServiceIdentity{{ServiceName: "test-service"}},
 	}
 	if enterpriseFlag() {
-		c := cases["add"]
-		c.partition = "test-partition"
-		c.serviceName = ServiceName{Name: "real-service-name", Partition: "test-partition", Namespace: "test-namespace", ACLNamespace: "default"}
-		c.task = ecs.Task{
-			TaskDefinitionArn: aws.String(validARN),
-			Tags: []*ecs.Tag{
-				{
-					Key:   aws.String(serviceNameTag),
-					Value: aws.String("real-service-name"),
-				},
-				{
-					Key:   aws.String(partitionTag),
-					Value: aws.String("test-partition"),
-				},
-				{
-					Key:   aws.String(namespaceTag),
-					Value: aws.String("test-namespace"),
-				},
-			},
-		}
-		cases["from the tags with partitions and namespaces"] = c
+		tok.Partition = DefaultPartition
+		tok.Namespace = DefaultNamespace
+	}
+	return tok
+}
 
-		c = cases["add"]
-		c.partition = "default"
-		c.serviceName = ServiceName{Name: "real-service-name", Partition: "default", Namespace: "default", ACLNamespace: "default"}
-		c.task = ecs.Task{
-			TaskDefinitionArn: aws.String(validARN),
-			Tags: []*ecs.Tag{
-				{
-					Key:   aws.String(serviceNameTag),
-					Value: aws.String("real-service-name"),
-				},
-			},
-		}
-		cases["from the tags with default partition and default namespace"] = c
+func makeTokenEnt(t *testing.T, taskId string, isLogin bool, partition, namespace string) *api.ACLTokenListEntry {
+	tok := makeToken(t, taskId, isLogin)
+	tok.Partition = partition
+	tok.Namespace = namespace
+	return tok
+}
 
-		c = cases["add"]
-		c.serviceName = ServiceName{Name: "real-service-name"}
-		c.task = ecs.Task{
-			TaskDefinitionArn: aws.String(validARN),
-			Tags: []*ecs.Tag{
-				{
-					Key:   aws.String(serviceNameTag),
-					Value: aws.String("real-service-name"),
-				},
-				{
-					Key:   aws.String(partitionTag),
-					Value: aws.String("test-partition"),
-				},
-				{
-					Key:   aws.String(namespaceTag),
-					Value: aws.String("test-namespace"),
-				},
-			},
-		}
-		cases["from the tags with partitions disabled"] = c
+func TestTaskStateListerList(t *testing.T) {
+	t.Parallel()
+	meshTasks := []*ecs.Task{
+		makeECSTask(t, "mesh-task-id-1", meshTag, "true"),
+		makeECSTask(t, "mesh-task-id-2", meshTag, "true"),
+		makeECSTask(t, "mesh-task-id-3", meshTag, "true"),
+	}
+	nonMeshTasks := []*ecs.Task{
+		makeECSTask(t, "non-mesh-task-id-1"),
+		makeECSTask(t, "non-mesh-task-id-2"),
+		makeECSTask(t, "non-mesh-task-id-3"),
+	}
+	allTasks := append(meshTasks, nonMeshTasks...)
 
-		c = cases["add"]
-		c.partition = "default"
-		c.task = ecs.Task{
-			TaskDefinitionArn: aws.String(validARN),
-			Tags: []*ecs.Tag{
-				{
-					Key:   aws.String(serviceNameTag),
-					Value: aws.String("real-service-name"),
-				},
-				{
-					Key:   aws.String(partitionTag),
-					Value: aws.String("test-partition"),
-				},
-			},
-		}
-		cases["error when only partition tag provided"] = c
+	loginTokens := []*api.ACLTokenListEntry{
+		makeToken(t, "mesh-task-id-1", true), makeToken(t, "mesh-task-id-1", true),
+		makeToken(t, "mesh-task-id-2", true), makeToken(t, "mesh-task-id-2", true),
+		makeToken(t, "mesh-task-id-3", true), makeToken(t, "mesh-task-id-3", true),
+	}
+	nonLoginTokens := []*api.ACLTokenListEntry{
+		makeToken(t, "non-mesh-task-id-1", false), makeToken(t, "mesh-task-id-1", false),
+		makeToken(t, "non-mesh-task-id-2", false), makeToken(t, "mesh-task-id-2", false),
+		makeToken(t, "non-mesh-task-id-3", false), makeToken(t, "mesh-task-id-3", false),
+	}
+	allTokens := append(loginTokens, nonLoginTokens...)
 
-		c = cases["add"]
-		c.partition = "default"
-		c.task = ecs.Task{
-			TaskDefinitionArn: aws.String(validARN),
-			Tags: []*ecs.Tag{
-				{
-					Key:   aws.String(serviceNameTag),
-					Value: aws.String("real-service-name"),
-				},
-				{
-					Key:   aws.String(namespaceTag),
-					Value: aws.String("test-namespace"),
-				},
+	tokenIgnoreFields := cmpopts.IgnoreFields(
+		api.ACLTokenListEntry{}, "CreateIndex", "ModifyIndex", "CreateTime", "Hash",
+	)
+	taskStateIgnoreFields := cmpopts.IgnoreFields(TaskState{}, "ConsulClient", "Log")
+
+	type testCase struct {
+		// tasks to setup in ECS for the test
+		initTasks []*ecs.Task
+		// tokens to setup in Consul for the test
+		initTokens []*api.ACLTokenListEntry
+		// setup partitions + namespaces in Consul
+		initPartitions map[string][]string
+		// the controller's configured partition
+		partition string
+
+		expResources []Resource
+	}
+	cases := map[string]testCase{
+		"no tasks and no tokens": {},
+		"no mesh tasks and no login tokens": {
+			initTokens: nonLoginTokens,
+			initTasks:  nonMeshTasks,
+			// TaskStateLister finds no resources.
+		},
+		"no mesh tasks with login tokens": {
+			initTokens: allTokens,
+			initTasks:  nonMeshTasks,
+			expResources: []Resource{
+				// TaskStateLister finds the tokens but does not find the task
+				makeTaskState("mesh-task-id-1", false, loginTokens[0:2]),
+				makeTaskState("mesh-task-id-2", false, loginTokens[2:4]),
+				makeTaskState("mesh-task-id-3", false, loginTokens[4:6]),
+			},
+		},
+		"mesh tasks without tokens": {
+			initTokens: nonLoginTokens,
+			initTasks:  allTasks,
+			expResources: []Resource{
+				// TaskStateLister finds the tasks but does not find the tokens
+				makeTaskState("mesh-task-id-1", true, nil),
+				makeTaskState("mesh-task-id-2", true, nil),
+				makeTaskState("mesh-task-id-3", true, nil),
+			},
+		},
+		"mesh tasks with tokens": {
+			initTokens: allTokens,
+			initTasks:  allTasks,
+			expResources: []Resource{
+				// TaskStateLister finds the tasks and tokens
+				makeTaskState("mesh-task-id-1", true, loginTokens[0:2]),
+				makeTaskState("mesh-task-id-2", true, loginTokens[2:4]),
+				makeTaskState("mesh-task-id-3", true, loginTokens[4:6]),
+			},
+		},
+	}
+
+	const (
+		testPtn  = "test-ptn"
+		otherPtn = "other-ptn"
+		testNs   = "test-ns"
+	)
+	allPartitions := map[string][]string{
+		DefaultPartition: {testNs},
+		otherPtn:         {testNs},
+		testPtn:          {testNs},
+	}
+
+	if enterpriseFlag() {
+		tags := []string{meshTag, "true", partitionTag, testPtn, namespaceTag, testNs}
+		entMeshTasks := []*ecs.Task{
+			makeECSTask(t, "partition-task-1", tags...),
+			makeECSTask(t, "partition-task-2", tags...),
+			makeECSTask(t, "partition-task-3", tags...),
+		}
+		entOtherTasks := []*ecs.Task{
+			// missing mesh tag
+			makeECSTask(t, "other-task-1", partitionTag, testPtn, namespaceTag, testNs),
+			// different partition
+			makeECSTask(t, "other-task-2", meshTag, "true", partitionTag, otherPtn, namespaceTag, testNs),
+			// missing namespace
+			makeECSTask(t, "other-task-3", meshTag, "true", partitionTag, testPtn),
+			// missing partition
+			makeECSTask(t, "other-task-4", meshTag, "true", namespaceTag, testNs),
+			// missing all tags
+			makeECSTask(t, "other-task-5"),
+		}
+		entAllTasks := append(entMeshTasks, entOtherTasks...)
+
+		entLoginTokens := []*api.ACLTokenListEntry{
+			makeTokenEnt(t, "partition-task-1", true, testPtn, testNs),
+			makeTokenEnt(t, "partition-task-1", true, testPtn, "default"),
+			makeTokenEnt(t, "partition-task-2", true, testPtn, testNs),
+			makeTokenEnt(t, "partition-task-2", true, testPtn, "default"),
+			makeTokenEnt(t, "partition-task-3", true, testPtn, testNs),
+			makeTokenEnt(t, "partition-task-3", true, testPtn, "default"),
+		}
+		entOtherTokens := []*api.ACLTokenListEntry{
+			// not login tokens
+			makeTokenEnt(t, "other-task-1", false, testPtn, testNs),
+			makeTokenEnt(t, "other-task-2", false, testPtn, testNs),
+			// in other partition
+			makeTokenEnt(t, "other-task-1", true, otherPtn, testNs),
+			makeTokenEnt(t, "other-task-2", true, DefaultPartition, testNs),
+		}
+		entAllTokens := append(entLoginTokens, entOtherTokens...)
+
+		cases["no tasks or tokens in partition"] = testCase{
+			initPartitions: allPartitions,
+			partition:      testPtn,
+		}
+		cases["no mesh tasks or login tokens in partition"] = testCase{
+			initTasks:      entOtherTasks,
+			initTokens:     entOtherTokens,
+			initPartitions: allPartitions,
+			partition:      testPtn,
+		}
+		cases["mesh tasks without tokens in partition"] = testCase{
+			initTasks:      entAllTasks,
+			initTokens:     entOtherTokens,
+			initPartitions: allPartitions,
+			partition:      testPtn,
+			expResources: []Resource{
+				// Finds tasks but no tokens.
+				makeTaskStateEnt("partition-task-1", true, nil, testPtn, testNs),
+				makeTaskStateEnt("partition-task-2", true, nil, testPtn, testNs),
+				makeTaskStateEnt("partition-task-3", true, nil, testPtn, testNs),
 			},
 		}
-		cases["error when only namespace tag provided"] = c
+		cases["no mesh tasks with tokens in partition"] = testCase{
+			initTasks:      entOtherTasks,
+			initTokens:     entAllTokens,
+			initPartitions: allPartitions,
+			partition:      testPtn,
+			expResources: []Resource{
+				// Partition and Namespace are not set from the ACL token.
+				makeTaskStateEnt("partition-task-1", false, entLoginTokens[0:2], "", ""),
+				makeTaskStateEnt("partition-task-2", false, entLoginTokens[2:4], "", ""),
+				makeTaskStateEnt("partition-task-3", false, entLoginTokens[4:6], "", ""),
+			},
+		}
+		cases["mesh tasks with tokens in partition"] = testCase{
+			initTasks:      entAllTasks,
+			initTokens:     entAllTokens,
+			initPartitions: allPartitions,
+			partition:      testPtn,
+			expResources: []Resource{
+				// Partition and Namespace are not set from the ACL token.
+				makeTaskStateEnt("partition-task-1", true, entLoginTokens[0:2], testPtn, testNs),
+				makeTaskStateEnt("partition-task-2", true, entLoginTokens[2:4], testPtn, testNs),
+				makeTaskStateEnt("partition-task-3", true, entLoginTokens[4:6], testPtn, testNs),
+			},
+		}
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			consulClient := initConsul(t)
+			lister := TaskStateLister{
+				ECSClient:    &mocks.ECSClient{Tasks: c.initTasks},
+				ConsulClient: consulClient,
+				Cluster:      testClusterArn,
+				Log:          hclog.Default().Named("lister"),
+			}
+
+			if enterpriseFlag() {
+				lister.Partition = DefaultPartition
+				if c.partition != "" {
+					lister.Partition = c.partition
+				}
+				createPartitions(t, consulClient, c.initPartitions)
+			}
+
+			createTokens(t, consulClient, c.initTokens...)
+
+			resources, err := lister.List()
+			require.NoError(t, err)
+
+			sortTaskStates(c.expResources)
+			sortTaskStates(resources)
+
+			for _, r := range resources {
+				t.Logf("resource: %+v", r)
+				state := r.(*TaskState)
+				for _, tok := range state.ACLTokens {
+					t.Logf("  token: %+v", tok)
+				}
+			}
+			for _, r := range c.expResources {
+				t.Logf("expResource: %+v", r)
+				state := r.(*TaskState)
+				for _, tok := range state.ACLTokens {
+					t.Logf("  token: %+v", tok)
+				}
+			}
+
+			require.Empty(t, cmp.Diff(c.expResources, resources, tokenIgnoreFields, taskStateIgnoreFields))
+		})
+	}
+}
+
+func createPartitions(t *testing.T, client *api.Client, partitions map[string][]string) {
+	ctx := context.Background()
+	for ptn, namespaces := range partitions {
+		opts := &api.WriteOptions{Partition: ptn}
+		_, _, err := client.Partitions().Create(ctx, &api.Partition{Name: ptn}, opts)
+		require.NoError(t, err)
+
+		for _, ns := range namespaces {
+			_, _, err = client.Namespaces().Create(&api.Namespace{Name: ns}, opts)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func createTokens(t *testing.T, client *api.Client, tokens ...*api.ACLTokenListEntry) {
+	for _, tok := range tokens {
+		_, _, err := client.ACL().TokenCreate(
+			&api.ACLToken{
+				AccessorID:        tok.AccessorID,
+				SecretID:          tok.SecretID,
+				Description:       tok.Description,
+				ServiceIdentities: tok.ServiceIdentities,
+			},
+			&api.WriteOptions{
+				Partition: tok.Partition,
+				Namespace: tok.Namespace,
+			},
+		)
+		require.NoError(t, err)
+	}
+}
+
+func sortTaskStates(states []Resource) {
+	// Sort by TaskID
+	sort.Slice(states, func(i, j int) bool {
+		a := states[i].(*TaskState)
+		b := states[j].(*TaskState)
+		return a.TaskID < b.TaskID
+	})
+
+	// Sort ACLTokens by AccessorID
+	for _, r := range states {
+		state := r.(*TaskState)
+		sort.Slice(state.ACLTokens, func(i, j int) bool {
+			return state.ACLTokens[i].AccessorID < state.ACLTokens[j].AccessorID
+		})
+	}
+}
+
+func TestTaskStateReconcile(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		initTokens     []*api.ACLTokenListEntry
+		initPartitions map[string][]string
+		state          *TaskState
+		expExist       []*api.ACLTokenListEntry
+		expDeleted     []*api.ACLTokenListEntry
+	}
+
+	tokens := []*api.ACLTokenListEntry{
+		makeToken(t, "test-task", true),
+	}
+	cases := map[string]testCase{
+		"task not found and tokens not found": {
+			initTokens: tokens,
+			state:      makeTaskState("test-task", false, nil),
+			expExist:   tokens,
+		},
+		"task found but tokens not found": {
+			initTokens: tokens,
+			state:      makeTaskState("test-task", true, nil),
+			expExist:   tokens,
+		},
+		"task found and tokens found": {
+			initTokens: tokens,
+			state:      makeTaskState("test-task", true, tokens),
+			expExist:   tokens,
+		},
+		"task not found but tokens found": {
+			initTokens: tokens,
+			state:      makeTaskState("test-task", false, tokens),
+			expDeleted: tokens,
+		},
+	}
+
+	if enterpriseFlag() {
+		entTokens := []*api.ACLTokenListEntry{
+			makeTokenEnt(t, "test-task", true, "test-ptn", "test-ns"),
+		}
+		partitions := map[string][]string{
+			"test-ptn": {"test-ns"},
+		}
+		cases["task not found and tokens not found in partition"] = testCase{
+			initTokens:     entTokens,
+			initPartitions: partitions,
+			state:          makeTaskStateEnt("test-task", false, nil, "test-ptn", "test-ns"),
+			expExist:       entTokens,
+		}
+		cases["task found but tokens not found in partition"] = testCase{
+			initTokens:     entTokens,
+			initPartitions: partitions,
+			state:          makeTaskStateEnt("test-task", true, nil, "test-ptn", "test-ns"),
+			expExist:       entTokens,
+		}
+		cases["task found and tokens found in partition"] = testCase{
+			initTokens:     entTokens,
+			initPartitions: partitions,
+			state:          makeTaskStateEnt("test-task", true, entTokens, "test-ptn", "test-ns"),
+			expExist:       entTokens,
+		}
+		cases["task not found but tokens found in partition"] = testCase{
+			initTokens:     entTokens,
+			initPartitions: partitions,
+			state:          makeTaskStateEnt("test-task", false, entTokens, "test-ptn", "test-ns"),
+			expDeleted:     entTokens,
+		}
 	}
 	for name, c := range cases {
 		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			l := ServiceStateLister{
-				Partition: c.partition,
+			client := initConsul(t)
+
+			if enterpriseFlag() {
+				createPartitions(t, client, c.initPartitions)
 			}
-			serviceName, err := l.serviceNameForTask(&c.task)
-			if c.serviceName.Name == "" {
+			createTokens(t, client, c.initTokens...)
+
+			c.state.ConsulClient = client
+			c.state.Log = hclog.NewNullLogger()
+			require.NoError(t, c.state.Reconcile())
+
+			for _, exp := range c.expDeleted {
+				tok, _, err := client.ACL().TokenRead(exp.AccessorID, &api.QueryOptions{
+					Namespace: exp.Namespace,
+					Partition: exp.Partition,
+				})
 				require.Error(t, err)
-			} else {
+				require.Contains(t, err.Error(), "403 (ACL not found)")
+				require.Nil(t, tok)
+			}
+			for _, exp := range c.expExist {
+				tok, _, err := client.ACL().TokenRead(exp.AccessorID, &api.QueryOptions{
+					Namespace: exp.Namespace,
+					Partition: exp.Partition,
+				})
 				require.NoError(t, err)
-				require.Equal(t, c.serviceName, serviceName)
+				require.NotNil(t, tok)
+				require.Equal(t, exp.AccessorID, tok.AccessorID)
 			}
 		})
 	}
@@ -745,450 +493,127 @@ func TestParseServiceNameFromTaskDefinitionARN(t *testing.T) {
 
 func TestReconcileNamespaces(t *testing.T) {
 	t.Parallel()
-	cases := map[string]struct {
+	type testCase struct {
 		partition string
-		expNS     map[string][]string
-		resources map[string]*ServiceInfo
-	}{
+		resources []Resource
+
+		expNS        map[string][]string
+		expXnsPolicy bool
+	}
+
+	cases := map[string]*testCase{
 		"with partitions disabled": {
-			expNS: map[string][]string{"default": {"default"}},
-			resources: map[string]*ServiceInfo{
-				"resource1": {ServiceName: ServiceName{Name: "service", Partition: "default", Namespace: "test-namespace"}},
+			expNS: map[string][]string{},
+			resources: []Resource{
+				makeTaskStateEnt("some-task-id", true, nil, "default", "test-ns"),
 			},
 		},
-		"with resources in default namespace": {
+	}
+
+	if enterpriseFlag() {
+		cases["with partitions disabled"].expNS = map[string][]string{"default": {"default"}}
+
+		cases["with resources in default namespace"] = &testCase{
 			partition: "default",
 			expNS:     map[string][]string{"default": {"default"}},
-			resources: map[string]*ServiceInfo{
-				"resource1": {ServiceName: ServiceName{Name: "service", Partition: "default", Namespace: "default"}},
+			resources: []Resource{
+				makeTaskStateEnt("some-task-id", true, nil, "default", "default"),
 			},
-		},
-		"with resources in different namespaces": {
+			expXnsPolicy: true,
+		}
+		cases["with resources in different namespaces"] = &testCase{
 			partition: "default",
 			expNS: map[string][]string{
 				"default": {"default", "namespace-1", "namespace-2"},
 			},
-			resources: map[string]*ServiceInfo{
-				"resource1": {ServiceName: ServiceName{Name: "service-1", Partition: "default", Namespace: "default"}},
-				"resource2": {ServiceName: ServiceName{Name: "service-1", Partition: "default", Namespace: "namespace-1"}},
-				"resource3": {ServiceName: ServiceName{Name: "service-2", Partition: "default", Namespace: "namespace-1"}},
-				"resource4": {ServiceName: ServiceName{Name: "service-1", Partition: "default", Namespace: "namespace-2"}},
+			resources: []Resource{
+				makeTaskStateEnt("task-1", true, nil, "default", "default"),
+				makeTaskStateEnt("task-2", true, nil, "default", "namespace-1"),
+				makeTaskStateEnt("task-3", true, nil, "default", "namespace-1"),
+				makeTaskStateEnt("task-4", true, nil, "default", "namespace-2"),
 			},
-		},
-		"with resources in non-default partition": {
+			expXnsPolicy: true,
+		}
+		cases["with resources in non-default partition"] = &testCase{
 			partition: "part-1",
 			expNS: map[string][]string{
 				"default": {"default"},
 				"part-1":  {"default", "namespace-1", "namespace-2"},
 			},
-			resources: map[string]*ServiceInfo{
-				"resource1": {ServiceName: ServiceName{Name: "service-1", Partition: "part-1", Namespace: "default"}},
-				"resource2": {ServiceName: ServiceName{Name: "service-1", Partition: "part-1", Namespace: "namespace-1"}},
-				"resource3": {ServiceName: ServiceName{Name: "service-2", Partition: "part-1", Namespace: "namespace-1"}},
-				"resource4": {ServiceName: ServiceName{Name: "service-1", Partition: "part-1", Namespace: "namespace-2"}},
+			resources: []Resource{
+				makeTaskStateEnt("task-1", true, nil, "part-1", "default"),
+				makeTaskStateEnt("task-2", true, nil, "part-1", "namespace-1"),
+				makeTaskStateEnt("task-3", true, nil, "part-1", "namespace-1"),
+				makeTaskStateEnt("task-4", true, nil, "part-1", "namespace-2"),
 			},
-		},
+			expXnsPolicy: true,
+		}
 	}
 	for name, c := range cases {
 		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			consulClient := initConsul(t)
-
-			if !enterpriseFlag() {
-				c.partition = ""
-				c.expNS = make(map[string][]string)
-			} else if c.partition != "" && c.partition != "default" {
-				_, _, err := consulClient.Partitions().Create(context.Background(), &api.Partition{
-					Name: c.partition,
-				}, nil)
-				require.NoError(t, err)
-			}
-
-			s := ServiceStateLister{
+			s := TaskStateLister{
 				Log:          hclog.NewNullLogger(),
 				ConsulClient: consulClient,
 				Partition:    c.partition,
 			}
 
-			if c.partition == "" {
-				// list all existing namespaces and ensure that no new ones are created
-				c.expNS = listNamespaces(t, consulClient)
+			if enterpriseFlag() && c.partition != "" {
+				createPartitions(t, consulClient, map[string][]string{c.partition: nil})
 			}
 
-			resourcesIF := make([]Resource, 0, len(c.resources))
-			for _, r := range c.resources {
-				resourcesIF = append(resourcesIF, r)
-			}
+			require.NoError(t, s.ReconcileNamespaces(c.resources))
+			require.Equal(t, c.expNS, listNamespaces(t, consulClient))
 
-			// create the namespaces and cross-namespace policies
-			// this does nothing if enterprise features are not enabled
-			require.NoError(t, s.ReconcileNamespaces(resourcesIF))
-
-			if c.partition != "" {
-				// if partitions are enabled ensure that the cross-namespace read policy exists
-				rules, err := getPolicyRules(t, consulClient, c.partition, DefaultNamespace, xnsPolicyName)
+			// check cross namespace policy is created (or not)
+			policy, _, err := consulClient.ACL().PolicyReadByName(
+				xnsPolicyName,
+				&api.QueryOptions{Partition: c.partition},
+			)
+			if c.expXnsPolicy {
 				require.NoError(t, err)
-				require.Equal(t, fmt.Sprintf(xnsPolicyTpl, c.partition), rules)
+				require.NotNil(t, policy)
+				require.Equal(t, fmt.Sprintf(xnsPolicyTpl, c.partition), policy.Rules)
+			} else {
+				require.Error(t, err)
+				require.Nil(t, policy)
 			}
-
-			obsNS := listNamespaces(t, consulClient)
-			require.Equal(t, c.expNS, obsNS)
 		})
 	}
 }
 
-func TestTaskLifecycle(t *testing.T) {
-	t.Parallel()
-	cluster := "cluster"
-	meshKey := "consul.hashicorp.com/mesh"
-	meshValue := "true"
-	partitionKey := "consul.hashicorp.com/partition"
-	partitionValue := "default"
-	extPartitionValue := "external-partition"
-	namespaceKey := "consul.hashicorp.com/namespace"
-	namespaces := []string{"default", "namespace-1"}
-	meshTag := &ecs.Tag{Key: &meshKey, Value: &meshValue}
-	partitionTag := &ecs.Tag{Key: &partitionKey, Value: &partitionValue}
-	extPartitionTag := &ecs.Tag{Key: &partitionKey, Value: &extPartitionValue}
-	namespace1Tag := &ecs.Tag{Key: &namespaceKey, Value: &namespaces[0]}
-	namespace2Tag := &ecs.Tag{Key: &namespaceKey, Value: &namespaces[1]}
-
-	cases := map[string]struct {
-		partition       string
-		enterpriseOnly  bool
-		paginateResults bool
-		tasks           []*ecs.Task
-		expServices     []*ServiceInfo
-	}{
-		"no tasks": {
-			partition:   "default",
-			tasks:       []*ecs.Task{},
-			expServices: []*ServiceInfo{},
-		},
-		"multiple services": {
-			partition: "default",
-			tasks: []*ecs.Task{
-				{
-					TaskArn:           aws.String("task1"),
-					TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service1:1"),
-					Tags:              []*ecs.Tag{meshTag, partitionTag, namespace1Tag},
-				},
-				{
-					TaskArn:           aws.String("task2"),
-					TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service2:1"),
-					Tags:              []*ecs.Tag{meshTag, partitionTag, namespace1Tag},
-				},
-				{
-					TaskArn:           aws.String("task3"),
-					TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service3:1"),
-					Tags:              []*ecs.Tag{meshTag, partitionTag, namespace2Tag},
-				},
-			},
-			expServices: []*ServiceInfo{
-				{
-					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[0], ACLNamespace: "default"},
-					ServiceState: ServiceState{
-						ConsulECSTasks: true,
-						ACLPolicies: []*api.ACLPolicyListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-								Name:      "service1-service",
-							},
-						},
-						ACLTokens: []*api.ACLTokenListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-							},
-						},
-					},
-				},
-				{
-					ServiceName: ServiceName{Name: "service2", Partition: "default", Namespace: namespaces[0], ACLNamespace: "default"},
-					ServiceState: ServiceState{
-						ConsulECSTasks: true,
-						ACLPolicies: []*api.ACLPolicyListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-								Name:      "service2-service",
-							},
-						},
-						ACLTokens: []*api.ACLTokenListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-							},
-						},
-					},
-				},
-				{
-					ServiceName: ServiceName{Name: "service3", Partition: "default", Namespace: namespaces[1], ACLNamespace: "default"},
-					ServiceState: ServiceState{
-						ConsulECSTasks: true,
-						ACLPolicies: []*api.ACLPolicyListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-								Name:      "service3-service",
-							},
-						},
-						ACLTokens: []*api.ACLTokenListEntry{{
-							Partition: "default",
-							Namespace: "default",
-						},
-						},
-					},
-				},
-			},
-		},
-		"multiple services with the same name in different namespaces": {
-			partition:      "default",
-			enterpriseOnly: true, // services with the same name must be separated by partition/namespace
-			tasks: []*ecs.Task{
-				{
-					TaskArn:           aws.String("task1"),
-					TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service1:1"),
-					Tags:              []*ecs.Tag{meshTag, partitionTag, namespace1Tag},
-				},
-				{
-					TaskArn:           aws.String("task2"),
-					TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service1:1"),
-					Tags:              []*ecs.Tag{meshTag, partitionTag, namespace2Tag},
-				},
-				{
-					TaskArn:           aws.String("external"),
-					TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service1:1"),
-					Tags:              []*ecs.Tag{meshTag, extPartitionTag, namespace2Tag},
-				},
-				{
-					TaskArn:           aws.String("non-mesh"),
-					TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/service1:1"),
-					Tags:              []*ecs.Tag{},
-				},
-			},
-			expServices: []*ServiceInfo{
-				{
-					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[0], ACLNamespace: "default"},
-					ServiceState: ServiceState{
-						ConsulECSTasks: true,
-						ACLPolicies: []*api.ACLPolicyListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-								Name:      "service1-service",
-							},
-						},
-						ACLTokens: []*api.ACLTokenListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-							},
-						},
-					},
-				},
-				{
-					ServiceName: ServiceName{Name: "service1", Partition: "default", Namespace: namespaces[1], ACLNamespace: "default"},
-					ServiceState: ServiceState{
-						ConsulECSTasks: true,
-						ACLPolicies: []*api.ACLPolicyListEntry{
-							{
-								Partition: "default",
-								Namespace: "default",
-								Name:      "service1-service",
-							},
-						},
-						ACLTokens: []*api.ACLTokenListEntry{{
-							Partition: "default",
-							Namespace: "default",
-						},
-						},
-					},
-				},
-			},
-		},
-	}
-	for name, c := range cases {
-		c := c
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			enterprise := enterpriseFlag()
-			if !enterprise {
-				if c.enterpriseOnly {
-					t.Skip("enterprise only test")
-				}
-				c.partition = ""
-			}
-
-			consulClient := initConsul(t)
-
-			lister := ServiceStateLister{
-				ECSClient:    &mocks.ECSClient{Tasks: c.tasks, PaginateResults: c.paginateResults},
-				ConsulClient: consulClient,
-				Cluster:      cluster,
-				SecretPrefix: "prefix",
-				Partition:    c.partition,
-				Log:          hclog.NewNullLogger(),
-			}
-
-			for _, service := range c.expServices {
-				// set expected values for inherited service fields
-				service.SecretsManagerClient = lister.SecretsManagerClient
-				service.ConsulClient = lister.ConsulClient
-				service.Cluster = lister.Cluster
-				service.SecretPrefix = lister.SecretPrefix
-				service.Log = lister.Log
-
-				// if this is not an enterprise test then zero out partition and namespaces
-				if !enterprise {
-					lister.Partition = ""
-					service.ServiceName.Partition = ""
-					service.ServiceName.Namespace = ""
-					service.ServiceName.ACLNamespace = ""
-					for _, policy := range service.ServiceState.ACLPolicies {
-						policy.Partition = ""
-						policy.Namespace = ""
-					}
-					for _, token := range service.ServiceState.ACLTokens {
-						token.Partition = ""
-						token.Namespace = ""
-					}
-				}
-
-				for _, policy := range service.ServiceState.ACLPolicies {
-					policy.Name = service.policyName()
-					policy.Description = service.aclDescription("Policy")
-				}
-				for _, token := range service.ServiceState.ACLTokens {
-					token.Description = service.aclDescription("Token")
-				}
-			}
-
-			// get cluster ACL state before the test
-			beforePolicies, beforeTokens, err := listACLs(consulClient, c.partition)
-			require.NoError(t, err)
-
-			// list all resources
-			resources, err := lister.List()
-			require.NoError(t, err)
-
-			// call ReconcileNamespaces to prepare all the namespaces
-			require.NoError(t, lister.ReconcileNamespaces(resources))
-
-			for _, r := range resources {
-				s := r.(*ServiceInfo)
-
-				// use a unique secret for each service
-				accessorID, err := uuid.GenerateUUID()
-				require.NoError(t, err)
-				secretID, err := uuid.GenerateUUID()
-				require.NoError(t, err)
-				s.SecretsManagerClient = &mocks.SMClient{Secret: &secretsmanager.GetSecretValueOutput{
-					Name:         aws.String(s.ServiceName.Name),
-					SecretString: aws.String(fmt.Sprintf(`{"accessor_id":"%s","token":"%s"}`, accessorID, secretID)),
-				}}
-
-				// call Reconcile() to create policies and tokens for each service
-				require.NoError(t, s.Reconcile())
-			}
-
-			// call List() to get updated cluster state
-			resources, err = lister.List()
-			require.NoError(t, err)
-
-			// inspect the state of each service reported by the controller
-			obsServices := make([]*ServiceInfo, 0, len(resources))
-			for _, r := range resources {
-				s := r.(*ServiceInfo)
-
-				// set only the expected ACL fields in the service state
-				var policies []*api.ACLPolicyListEntry
-				for _, policy := range s.ServiceState.ACLPolicies {
-					policies = append(policies, &api.ACLPolicyListEntry{
-						Partition:   policy.Partition,
-						Namespace:   policy.Namespace,
-						Name:        policy.Name,
-						Description: policy.Description,
-					})
-				}
-				s.ServiceState.ACLPolicies = policies
-
-				var tokens []*api.ACLTokenListEntry
-				for _, token := range s.ServiceState.ACLTokens {
-					tokens = append(tokens, &api.ACLTokenListEntry{
-						Partition:   token.Partition,
-						Namespace:   token.Namespace,
-						Description: token.Description,
-					})
-				}
-				s.ServiceState.ACLTokens = tokens
-
-				obsServices = append(obsServices, s)
-			}
-
-			// check for expected services with attached policies and tokens
-			require.Equal(t, len(c.expServices), len(obsServices))
-			require.ElementsMatch(t, c.expServices, obsServices)
-
-			// remove all the ECS tasks
-			lister.ECSClient = &mocks.ECSClient{}
-			resources, err = lister.List()
-			require.NoError(t, err)
-
-			// call Reconcile() to remove policies and tokens
-			for _, r := range resources {
-				s := r.(*ServiceInfo)
-				require.NoError(t, s.Reconcile())
-			}
-
-			// ensure cluster state matches previous
-			newPolicies, afterTokens, err := listACLs(consulClient, c.partition)
-			afterPolicies := make([]*api.ACLPolicyListEntry, 0, len(newPolicies))
-			for _, p := range newPolicies {
-				// we don't (currently) clean up namespaces nor their policies, so ignore them
-				if p.Name != "cross-namespace-read" && p.Name != "namespace-management" {
-					afterPolicies = append(afterPolicies, p)
-				}
-			}
-			require.NoError(t, err)
-			require.Equal(t, beforePolicies, afterPolicies)
-			require.Equal(t, beforeTokens, afterTokens)
-		})
-	}
-}
-
-func TestACLDescriptions(t *testing.T) {
-	t.Parallel()
-	cases := map[string]struct {
-		cluster     string
-		serviceName ServiceName
-	}{
-		"with partitions": {
-			cluster:     "c1",
-			serviceName: ServiceName{Name: "s1", Partition: "p1", Namespace: "n1", ACLNamespace: "default"},
-		},
-		"without partitions": {
-			cluster:     "c1",
-			serviceName: ServiceName{Name: "s1"},
-		},
-	}
-	for name, c := range cases {
-		c := c
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			s := &ServiceInfo{
-				Cluster:     c.cluster,
-				ServiceName: c.serviceName,
-			}
-			desc := s.aclDescription("Token")
-			l := ServiceStateLister{Cluster: c.cluster, Partition: c.serviceName.Partition}
-			require.Equal(t, c.serviceName, l.serviceNameFromDescription(desc))
-		})
-	}
-}
+//func TestACLDescriptions(t *testing.T) {
+//	t.Parallel()
+//	cases := map[string]struct {
+//		cluster     string
+//		serviceName MeshTask
+//	}{
+//		"with partitions": {
+//			cluster:     "c1",
+//			serviceName: MeshTask{Name: "s1", Partition: "p1", Namespace: "n1", ACLNamespace: "default"},
+//		},
+//		"without partitions": {
+//			cluster:     "c1",
+//			serviceName: MeshTask{Name: "s1"},
+//		},
+//	}
+//	for name, c := range cases {
+//		c := c
+//		t.Run(name, func(t *testing.T) {
+//			t.Parallel()
+//			s := &ServiceInfo{
+//				Cluster:     c.cluster,
+//				ServiceName: c.serviceName,
+//			}
+//			desc := s.aclDescription("Token")
+//			l := TaskStateLister{Cluster: c.cluster, Partition: c.serviceName.Partition}
+//			require.Equal(t, c.serviceName, l.serviceNameFromDescription(desc))
+//		})
+//	}
+//}
+//
 
 // helper func that initializes a Consul test server and returns a Consul API client.
 func initConsul(t *testing.T) *api.Client {
@@ -1219,50 +644,40 @@ func listNamespaces(t *testing.T, consulClient *api.Client) map[string][]string 
 	return names
 }
 
-// helper func that lists all policies and tokens within all namespaces in a partition
-func listACLs(consulClient *api.Client, partition string) ([]*api.ACLPolicyListEntry, []*api.ACLTokenListEntry, error) {
-	var err error
-	policies := make([]*api.ACLPolicyListEntry, 0)
-	tokens := make([]*api.ACLTokenListEntry, 0)
-	opts := &api.QueryOptions{Partition: partition}
-	var namespaces []*api.Namespace
-
-	if enterpriseFlag() {
-		// only list namespaces in enterprise tests
-		namespaces, _, err = consulClient.Namespaces().List(opts)
-		if err != nil {
-			return policies, tokens, err
-		}
-	} else {
-		namespaces = append(namespaces, &api.Namespace{})
-	}
-
-	for _, ns := range namespaces {
-		opts.Namespace = ns.Name
-		aclPolicies, _, err := consulClient.ACL().PolicyList(opts)
-		if err != nil {
-			return policies, tokens, err
-		}
-		policies = append(policies, aclPolicies...)
-
-		aclTokens, _, err := consulClient.ACL().TokenList(opts)
-		if err != nil {
-			return policies, tokens, err
-		}
-		tokens = append(tokens, aclTokens...)
-	}
-	return policies, tokens, nil
-}
-
-func getPolicyRules(t *testing.T, consulClient *api.Client, partition, namespace, name string) (string, error) {
-	policy, _, err := consulClient.ACL().PolicyReadByName(name,
-		&api.QueryOptions{Partition: partition, Namespace: namespace})
-	if err != nil || policy == nil {
-		return "", err
-	}
-
-	return policy.Rules, nil
-}
+//// helper func that lists all policies and tokens within all namespaces in a partition
+//func listACLs(consulClient *api.Client, partition string) ([]*api.ACLPolicyListEntry, []*api.ACLTokenListEntry, error) {
+//	var err error
+//	policies := make([]*api.ACLPolicyListEntry, 0)
+//	tokens := make([]*api.ACLTokenListEntry, 0)
+//	opts := &api.QueryOptions{Partition: partition}
+//	var namespaces []*api.Namespace
+//
+//	if enterpriseFlag() {
+//		// only list namespaces in enterprise tests
+//		namespaces, _, err = consulClient.Namespaces().List(opts)
+//		if err != nil {
+//			return policies, tokens, err
+//		}
+//	} else {
+//		namespaces = append(namespaces, &api.Namespace{})
+//	}
+//
+//	for _, ns := range namespaces {
+//		opts.Namespace = ns.Name
+//		aclPolicies, _, err := consulClient.ACL().PolicyList(opts)
+//		if err != nil {
+//			return policies, tokens, err
+//		}
+//		policies = append(policies, aclPolicies...)
+//
+//		aclTokens, _, err := consulClient.ACL().TokenList(opts)
+//		if err != nil {
+//			return policies, tokens, err
+//		}
+//		tokens = append(tokens, aclTokens...)
+//	}
+//	return policies, tokens, nil
+//}
 
 func enterpriseFlag() bool {
 	re := regexp.MustCompile("^-+enterprise$")

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -75,8 +75,11 @@ func (c *Command) run() error {
 	if err != nil {
 		return err
 	}
-	cluster := ecsMeta.Cluster
-	c.log.Info("cluster name determined", "cluster", cluster)
+	clusterArn, err := ecsMeta.ClusterARN()
+	if err != nil {
+		return err
+	}
+	c.log.Info("cluster arn determined", "cluster-arn", clusterArn)
 
 	clientSession, err := awsutil.NewSession(ecsMeta, "controller")
 	if err != nil {
@@ -105,7 +108,7 @@ func (c *Command) run() error {
 	taskStateLister := &controller.TaskStateLister{
 		ECSClient:    ecsClient,
 		ConsulClient: consulClient,
-		Cluster:      cluster,
+		ClusterARN:   clusterArn,
 		Partition:    c.flagPartition,
 		Log:          c.log,
 	}

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -2,17 +2,13 @@ package aclcontroller
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul-ecs/controller"
 	"github.com/hashicorp/consul-ecs/logging"
@@ -22,27 +18,22 @@ import (
 )
 
 const (
-	flagIAMRolePath           = "iam-role-path"
-	flagConsulClientSecretARN = "consul-client-secret-arn"
-	flagSecretNamePrefix      = "secret-name-prefix"
-	flagPartition             = "partition"
-	flagPartitionsEnabled     = "partitions-enabled"
+	flagIAMRolePath       = "iam-role-path"
+	flagPartition         = "partition"
+	flagPartitionsEnabled = "partitions-enabled"
 
 	consulCACertEnvVar = "CONSUL_CACERT_PEM"
 
-	// Binding rules don't support a '/' character, so we need compatible IAM role
-	// tag names for the auth method until we can address this in Consul.
+	// Binding rules don't support a '/' character, so we need compatible IAM role tag names.
 	authMethodServiceNameTag = "consul.hashicorp.com.service-name"
 	authMethodNamespaceTag   = "consul.hashicorp.com.namespace"
 )
 
 type Command struct {
-	UI                        cli.Ui
-	flagIAMRolePath           string
-	flagConsulClientSecretARN string
-	flagSecretNamePrefix      string
-	flagPartition             string
-	flagPartitionsEnabled     bool
+	UI                    cli.Ui
+	flagIAMRolePath       string
+	flagPartition         string
+	flagPartitionsEnabled bool
 
 	log     hclog.Logger
 	flagSet *flag.FlagSet
@@ -55,8 +46,6 @@ type Command struct {
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flagSet.StringVar(&c.flagIAMRolePath, flagIAMRolePath, "", "IAM roles at this path will be trusted by the IAM Auth method created by the controller")
-	c.flagSet.StringVar(&c.flagConsulClientSecretARN, flagConsulClientSecretARN, "", "ARN of AWS Secrets Manager secret for Consul client")
-	c.flagSet.StringVar(&c.flagSecretNamePrefix, flagSecretNamePrefix, "", "The prefix for secret names stored in AWS Secrets Manager")
 	c.flagSet.StringVar(&c.flagPartition, flagPartition, "", "The Consul partition name that the ACL controller will use for ACL resources. If not provided will default to the `default` partition [Consul Enterprise]")
 	c.flagSet.BoolVar(&c.flagPartitionsEnabled, flagPartitionsEnabled, false, "Enables support for Consul partitions and namespaces [Consul Enterprise]")
 
@@ -108,43 +97,20 @@ func (c *Command) run() error {
 	if err != nil {
 		return err
 	}
-	smClient := secretsmanager.New(clientSession, nil)
 
-	if c.flagIAMRolePath != "" {
-		if err := c.upsertConsulResources(consulClient, ecsMeta); err != nil {
-			return err
-		}
-	} else {
-		// TODO: Remove this old behavior once fully switched to the auth method.
-		if c.flagPartitionsEnabled {
-			if c.flagPartition == "" {
-				// if an explicit partition was not provided use the default partition.
-				c.flagPartition = controller.DefaultPartition
-			}
-			if err = c.upsertPartition(consulClient); err != nil {
-				return err
-			}
-		} else if c.flagPartition != "" {
-			return fmt.Errorf("partition flag provided without partitions-enabled flag")
-		}
-
-		err = c.upsertConsulClientToken(consulClient, smClient)
-		if err != nil {
-			return err
-		}
+	if err := c.upsertConsulResources(consulClient, ecsMeta); err != nil {
+		return err
 	}
 
-	serviceStateLister := &controller.ServiceStateLister{
-		ECSClient:            ecsClient,
-		SecretsManagerClient: smClient,
-		ConsulClient:         consulClient,
-		Cluster:              cluster,
-		SecretPrefix:         c.flagSecretNamePrefix,
-		Partition:            c.flagPartition,
-		Log:                  c.log,
+	taskStateLister := &controller.TaskStateLister{
+		ECSClient:    ecsClient,
+		ConsulClient: consulClient,
+		Cluster:      cluster,
+		Partition:    c.flagPartition,
+		Log:          c.log,
 	}
 	ctrl := controller.Controller{
-		Resources:       serviceStateLister,
+		Resources:       taskStateLister,
 		PollingInterval: controller.DefaultPollingInterval,
 		Log:             c.log,
 	}
@@ -417,97 +383,6 @@ func (c *Command) upsertBindingRule(consulClient *api.Client, bindingRule *api.A
 	c.log.Info("ACL binding rule created successfully", "method", method,
 		"bind-type", rule.BindType, "bind-name", rule.BindName)
 
-	return nil
-}
-
-// upsertConsulClientToken creates or updates ACL policy and token for the Consul client in Consul.
-// It then saves the created token in AWS Secrets Manager in the secret provided by secretARN from the Command.
-func (c *Command) upsertConsulClientToken(consulClient *api.Client, smClient secretsmanageriface.SecretsManagerAPI) error {
-	// Read the secret from AWS.
-	currSecretValue, err := smClient.GetSecretValue(&secretsmanager.GetSecretValueInput{
-		SecretId: aws.String(c.flagConsulClientSecretARN),
-	})
-	if err != nil {
-		return fmt.Errorf("retrieving Consul client secret: %w", err)
-	}
-
-	// Unmarshal the secret value JSON.
-	var currSecret controller.TokenSecretJSON
-	err = json.Unmarshal([]byte(*currSecretValue.SecretString), &currSecret)
-	if err != nil {
-		return fmt.Errorf("unmarshalling Consul client secret value JSON: %w", err)
-	}
-
-	var currToken *api.ACLToken
-
-	// If the secret is not empty, check if Consul already has a token with this AccessorID.
-	if currSecret.AccessorID != "" {
-		currToken, _, err = consulClient.ACL().TokenRead(currSecret.AccessorID, c.queryOptions())
-		if err != nil && !controller.IsACLNotFoundError(err) {
-			return fmt.Errorf("reading token: %w", err)
-		}
-	}
-
-	// Exit if current token is found in Consul.
-	if currToken != nil {
-		return nil
-	}
-	// Otherwise, we need to create one.
-	// First, we need to check if the policy for the Consul client already exists.
-	// If it does, we will skip policy creation.
-	policyName := fmt.Sprintf("%s-consul-client-policy", c.flagSecretNamePrefix)
-	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
-
-	// When policy is not found, Consul returns ACL not found error.
-	if controller.IsACLNotFoundError(err) {
-		// Create a policy for the Consul clients.
-		c.log.Info("creating ACL policy", "name", policyName)
-
-		rules := ossClientPolicy
-		if c.flagPartitionsEnabled {
-			// If partitions are enabled then create a policy that supports partitions
-			rules = fmt.Sprintf(partitionedClientPolicyTpl, c.flagPartition)
-		}
-		policy, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{
-			Name:        policyName,
-			Description: "Consul Client Token Policy for ECS",
-			Rules:       rules,
-		}, c.writeOptions())
-		if err != nil {
-			return fmt.Errorf("creating Consul client ACL policy: %w", err)
-		}
-		c.log.Info("ACL policy created successfully", "name", policyName)
-	} else if err != nil {
-		return fmt.Errorf("reading Consul client ACL policy: %w", err)
-	} else {
-		c.log.Info("ACL policy already exists; skipping policy creation", "name", policyName)
-	}
-
-	c.log.Info("creating Consul client ACL token")
-	token, _, err := consulClient.ACL().TokenCreate(&api.ACLToken{
-		Description: "ECS Consul client Token",
-		Policies:    []*api.ACLTokenPolicyLink{{Name: policy.Name}},
-	}, c.writeOptions())
-	if err != nil {
-		return fmt.Errorf("creating Consul client ACL token: %w", err)
-	}
-	c.log.Info("Consul client ACL token created successfully")
-
-	clientSecret, err := json.Marshal(controller.TokenSecretJSON{Token: token.SecretID, AccessorID: token.AccessorID})
-	if err != nil {
-		return fmt.Errorf("marshalling Consul client token: %w", err)
-	}
-
-	// Finally, update the AWS Secret with the new values of the token.
-	c.log.Info("updating secret", "arn", c.flagConsulClientSecretARN)
-	_, err = smClient.UpdateSecret(&secretsmanager.UpdateSecretInput{
-		SecretId:     aws.String(c.flagConsulClientSecretARN),
-		SecretString: aws.String(string(clientSecret)),
-	})
-	if err != nil {
-		return fmt.Errorf("updating secret: %s", err)
-	}
-	c.log.Info("secret updated successfully", "arn", c.flagConsulClientSecretARN)
 	return nil
 }
 

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -5,9 +5,6 @@ package aclcontroller
 import (
 	"fmt"
 	"testing"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
 var expPartitionedClientPolicy = fmt.Sprintf(`partition "%s" {
@@ -38,19 +35,4 @@ func TestUpsertConsulResourcesEnt(t *testing.T) {
 			expPolicyRules:     expPartitionedClientPolicy,
 		},
 	})
-}
-
-func TestUpsertConsulClientTokenEnt(t *testing.T) {
-	cases := testCases{
-		"when partitions are enabled with no token or policy": {
-			existingSecret: &secretsmanager.GetSecretValueOutput{
-				ARN:          aws.String("test-consul-client-token-arn"),
-				Name:         aws.String("test-consul-client-token"),
-				SecretString: aws.String(`{}`),
-			},
-			partitionsEnabled: true,
-			expPolicyRules:    expPartitionedClientPolicy,
-		},
-	}
-	testUpsertConsulClientToken(t, cases)
 }

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -2,17 +2,12 @@ package aclcontroller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/hashicorp/consul-ecs/awsutil"
-	"github.com/hashicorp/consul-ecs/controller"
-	"github.com/hashicorp/consul-ecs/controller/mocks"
 	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -302,144 +297,5 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules
 		require.NoError(t, err)
 		require.Equal(t, rule.BindType, api.BindingRuleBindTypeService)
 		require.Equal(t, rule.BindName, fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag))
-	}
-}
-
-type testCase struct {
-	existingSecret       *secretsmanager.GetSecretValueOutput
-	createExistingToken  bool
-	createExistingPolicy bool
-	partitionsEnabled    bool
-	expPolicyRules       string
-}
-
-type testCases map[string]testCase
-
-func TestUpsertConsulClientToken(t *testing.T) {
-	cases := testCases{
-		"when there is no token or policy": {
-			existingSecret: &secretsmanager.GetSecretValueOutput{
-				ARN:          aws.String("test-consul-client-token-arn"),
-				Name:         aws.String("test-consul-client-token"),
-				SecretString: aws.String(`{}`),
-			},
-			expPolicyRules: expOssClientPolicy,
-		},
-		"when there is an existing token and policy for the Consul client, we don't create a new one": {
-			existingSecret: &secretsmanager.GetSecretValueOutput{
-				ARN:          aws.String("test-consul-client-token-arn"),
-				Name:         aws.String("test-consul-client-token"),
-				SecretString: aws.String(`{}`),
-			},
-			createExistingPolicy: true,
-			createExistingToken:  true,
-			expPolicyRules:       expOssClientPolicy,
-		},
-		"when there is an existing policy but no token for the Consul client, we update the token": {
-			existingSecret: &secretsmanager.GetSecretValueOutput{
-				ARN:          aws.String("test-consul-client-token-arn"),
-				Name:         aws.String("test-consul-client-token"),
-				SecretString: aws.String(`{}`),
-			},
-			createExistingPolicy: true,
-			createExistingToken:  false,
-			expPolicyRules:       expOssClientPolicy,
-		},
-		"when the token in the secret doesn't exist in Consul, the secret is updated with the new value": {
-			existingSecret: &secretsmanager.GetSecretValueOutput{
-				ARN:          aws.String("test-consul-client-token-arn"),
-				Name:         aws.String("test-consul-client-token"),
-				SecretString: aws.String(`{"accessor_id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","token":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}`),
-			},
-			expPolicyRules: expOssClientPolicy,
-		},
-	}
-	testUpsertConsulClientToken(t, cases)
-}
-
-// testUpsertConsulClientToken is a helper func that runs the test cases for
-// validating upsertion of client tokens. It is shared by both the OSS and
-// enterprise tests.
-func testUpsertConsulClientToken(t *testing.T, cases testCases) {
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			smClient := &mocks.SMClient{Secret: c.existingSecret}
-
-			cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
-			if c.partitionsEnabled {
-				cfg.Partition = testPartitionName
-			}
-			consulClient, err := api.NewClient(cfg)
-			require.NoError(t, err)
-
-			if c.partitionsEnabled {
-				_, _, err := consulClient.Partitions().Create(context.Background(), &api.Partition{
-					Name: testPartitionName,
-				}, nil)
-				require.NoError(t, err)
-			}
-
-			cmd := Command{
-				UI:                        cli.NewMockUi(),
-				flagConsulClientSecretARN: *c.existingSecret.ARN,
-				flagSecretNamePrefix:      "test",
-				flagPartitionsEnabled:     c.partitionsEnabled,
-				flagPartition:             testPartitionName,
-				log:                       hclog.NewNullLogger(),
-				ctx:                       context.Background(),
-			}
-
-			policyName := "test-consul-client-policy"
-			if c.createExistingPolicy {
-				policy, _, err := consulClient.ACL().PolicyCreate(&api.ACLPolicy{
-					Name:        policyName,
-					Description: "Consul Client Token Policy for ECS",
-					Rules:       c.expPolicyRules,
-				}, nil)
-				require.NoError(t, err)
-
-				if c.createExistingToken {
-					token, _, err := consulClient.ACL().TokenCreate(&api.ACLToken{
-						Description: "ECS Consul client Token",
-						Policies:    []*api.ACLTokenPolicyLink{{Name: policy.Name}},
-					}, nil)
-					require.NoError(t, err)
-					secretValue, err := json.Marshal(controller.TokenSecretJSON{AccessorID: token.AccessorID, Token: token.SecretID})
-					require.NoError(t, err)
-					c.existingSecret.SecretString = aws.String(string(secretValue))
-				}
-			}
-
-			err = cmd.upsertConsulClientToken(consulClient, smClient)
-			require.NoError(t, err)
-
-			// Check that token and policy exist in Consul.
-			policy, _, err := consulClient.ACL().PolicyReadByName(policyName, nil)
-			require.NoError(t, err)
-			require.NotNil(t, policy)
-			require.Equal(t, c.expPolicyRules, policy.Rules)
-
-			tokenList, _, err := consulClient.ACL().TokenList(nil)
-			require.NoError(t, err)
-			var foundTokens []*api.ACLToken
-			for _, tokenItem := range tokenList {
-				if len(tokenItem.Policies) == 1 {
-					if tokenItem.Policies[0].ID == policy.ID {
-						token, _, err := consulClient.ACL().TokenRead(tokenItem.AccessorID, nil)
-						require.NoError(t, err)
-						foundTokens = append(foundTokens, token)
-					}
-				}
-			}
-			// There should always be only one token for the client.
-			require.Len(t, foundTokens, 1)
-
-			// Check that the secret in AWS SM is the same as the token we found.
-			var tokenSecret controller.TokenSecretJSON
-			err = json.Unmarshal([]byte(*smClient.Secret.SecretString), &tokenSecret)
-			require.NoError(t, err)
-			require.Equal(t, foundTokens[0].AccessorID, tokenSecret.AccessorID)
-			require.Equal(t, foundTokens[0].SecretID, tokenSecret.Token)
-		})
 	}
 }


### PR DESCRIPTION
## Changes proposed in this PR:

This updates the ACL controller to cleanup tokens created by the auth method. The controller's reconcile operation now tracks tasks by task id. It parses the JSON formatted metadata from each ACL token description to determine the task id which created the token. Tokens for which there is no longer an ECS task running are deleted.

This PR also removes the controller's "old" behavior of managing tokens based on service names. The controller no longer creates any tokens, and is only responsible for cleaning up tokens created from a `consul login` command.

In order for the controller to cleanup a token, the token must have been created with metadata when running the `consul login` command, which indicates the task id and cluster:

```
consul login \
    -meta consul.hashicorp.com/task-id=123456 \
    -meta consul.hashicorp.com/cluster=<clusterARN> \
   ...
```

When the token is created, the metadata is placed in the token description as a JSON string:

```
AccessorID:       00000000-0000-c962-66c1-d6a3345df4f9
SecretID:         00000000-0000-2663-f30a-e76300fdae8e
Partition:        default
Namespace:        test-ns
Description:      token created via login: {"consul.hashicorp.com/cluster":"<clusterARN>","consul.hashicorp.com/task-id":"123456"}
...
```

This updates the controller to consistently use the full cluster ARN. The task metadata has a `Cluster` field, which is the cluster ARN on Fargate but is only the cluster name on EC2.

## How I've tested this PR:
- Unit tests
- Acceptance tests in https://github.com/hashicorp/terraform-aws-consul-ecs/pull/107

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
