### PR TITLE
Enable race detector during CI tests

### DIFF
--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -220,6 +220,8 @@ func TestTaskStateListerList(t *testing.T) {
 
 	for name, c := range cases {
 		c := c
+		sortTaskStates(c.expResources)
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			consulClient := initConsul(t)
@@ -243,7 +245,6 @@ func TestTaskStateListerList(t *testing.T) {
 			resources, err := lister.List()
 			require.NoError(t, err)
 
-			sortTaskStates(c.expResources)
 			sortTaskStates(resources)
 
 			require.Empty(t, cmp.Diff(c.expResources, resources, tokenIgnoreFields, taskStateIgnoreFields))

--- a/testutil/fake-command.go
+++ b/testutil/fake-command.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-// fakeCommand is a command/script to be run by tests for "entrypoint" commands. Each command touches
-// a "ready file" when the command has started and done any setup. This is important for the tests
-// to ensure the command subcommand has started to avoid races. For example, certain tests should not
-// proceed until traps for sigint and sigterm have been setup.
+// FakeCommand is a command/script to be run by tests for "entrypoint" commands. Each command touches
+// a "ready file" after the command has started and completed setup. This enables the tests to ensure
+// the command has started in order to avoid race conditions. For example, certain tests should not
+// proceed until signal handling has been set up.
 type FakeCommand struct {
 	// The command to run.
 	Command string
@@ -17,7 +17,8 @@ type FakeCommand struct {
 	ReadyFile string
 }
 
-// FakeCommandWithTraps a script used to validate our "entrypoint" commands:
+// FakeCommandWithTraps is a script used to validate our "entrypoint" commands.
+// This script does the following:
 // * When a sigint is received, it exits with code 42
 // * When a sigterm is received, it exits with code 55
 // * It sleeps for 120 seconds (long enough for tests, but not so long that it holds up CI)

--- a/testutil/fake-command.go
+++ b/testutil/fake-command.go
@@ -1,0 +1,54 @@
+package testutil
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// fakeCommand is a command/script to be run by tests for "entrypoint" commands. Each command touches
+// a "ready file" when the command has started and done any setup. This is important for the tests
+// to ensure the command subcommand has started to avoid races. For example, certain tests should not
+// proceed until traps for sigint and sigterm have been setup.
+type FakeCommand struct {
+	// The command to run.
+	Command string
+	// Check this file exists to check the command is ready.
+	ReadyFile string
+}
+
+// FakeCommandWithTraps a script used to validate our "entrypoint" commands:
+// * When a sigint is received, it exits with code 42
+// * When a sigterm is received, it exits with code 55
+// * It sleeps for 120 seconds (long enough for tests, but not so long that it holds up CI)
+//
+// Why not just a simple 'sleep 120'?
+// * Bash actually ignores SIGINT by default (note: CTRL-C sends SIGINT to the process group, not just the parent)
+// * Tests can be run in different places, so /bin/sh could be any shell with different behavior.
+// Why a background process + wait? Why not just a trap + sleep?
+// * The sleep blocks the trap. Traps are not executed until the current command completes, except for `wait`.
+func FakeCommandWithTraps(t *testing.T, sleep int) FakeCommand {
+	dir := TempDir(t)
+	readyFile := filepath.Join(dir, "proc-ready")
+	return FakeCommand{
+		ReadyFile: readyFile,
+		Command: fmt.Sprintf(`sleep %d &
+export SLEEP_PID=$!
+trap "{ echo 'target command was interrupted'; kill $SLEEP_PID; exit 42; }" INT
+trap "{ echo 'target command was terminated'; kill $SLEEP_PID; exit 55; }" TERM
+touch %s
+wait $SLEEP_PID
+`, sleep, readyFile),
+	}
+}
+
+// SimpleFakeCommand sleeps for a given number of seconds.
+func SimpleFakeCommand(t *testing.T, sleep int) FakeCommand {
+	dir := TempDir(t)
+	readyFile := filepath.Join(dir, "proc-ready")
+	return FakeCommand{
+		Command: fmt.Sprintf(`touch %s
+sleep %d`, readyFile, sleep),
+		ReadyFile: readyFile,
+	}
+}


### PR DESCRIPTION
## Changes proposed in this PR:
This enables the race detector and fixes the test issues that trigger it.

## How I've tested this PR:
* CI checks
* Running tests a bunch of times locally with `-race`:

```
gotestsum --format=short-verbose --jsonfile ./go-test-race.log --junitfile ./gotestsum-report.xml -- -race ./... -count=10 -tags=enterprise -- -enterprise
```

## How I expect reviewers to test this PR:
👀

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
