### PR TITLE
Fix test flakiness with TaskMetaServer

### DIFF
--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -193,6 +193,7 @@ func TestRunWithContainerNames(t *testing.T) {
 	}
 
 	for name, c := range cases {
+		c := c
 		t.Run(name, func(t *testing.T) {
 			expectedServiceName := family
 			if c.serviceName != "" {


### PR DESCRIPTION
## Changes proposed in this PR:
There's some test flakiness where it appears the fake TaskMetaServer is not ready for requests. See [this job](https://github.com/hashicorp/consul-ecs/runs/6576890687?check_suite_focus=true) and [this job](https://github.com/hashicorp/consul-ecs/runs/6576771628?check_suite_focus=true).

This adds a wait loop to check that the TaskMetaServer server has started before proceeding with tests.

## How I've tested this PR:
CI checks. Retrying the unit tests jobs several times.

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
