### PR TITLE
Update doc generation script

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -24,6 +24,7 @@
       "type": ["string", "null"]
     },
     "consulLogin": {
+      "description": "Configuration for login to the AWS IAM auth method.",
       "type": ["object", "null"],
       "properties": {
         "enabled": {
@@ -423,9 +424,9 @@
           }
         }
       },
-      "required": ["kind"]
-    },
-    "additionalProperties": false
+      "required": ["kind"],
+      "additionalProperties": false
+    }
   },
   "required": ["bootstrapDir"],
   "additionalProperties": false

--- a/hack/generate-config-reference/properties.tpl
+++ b/hack/generate-config-reference/properties.tpl
@@ -1,12 +1,12 @@
-{{ .Description }}
+{{ .DescriptionStr }}
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
 {{- range $key, $val := .Properties }}
 {{- with $anchor := $.PropertyAnchor $key }}
-| [`{{ $key }}`](#{{ $anchor }}) | `{{ index $val.Type 0 }}` | {{ $.RequiredStr $key }} | {{ $val.Description }} {{ $val.EnumStr }} |
+| [`{{ $key }}`](#{{ $anchor }}) | `{{ index $val.Type 0 }}` | {{ $.RequiredStr $key }} | {{ $val.DescriptionStr }} {{ $val.EnumStr }} |
 {{- else }}
-| `{{ $key }}` | `{{ index $val.Type 0 }}` | {{ $.RequiredStr $key }} | {{ $val.Description }} {{ $val.EnumStr }} |
+| `{{ $key }}` | `{{ index $val.Type 0 }}` | {{ $.RequiredStr $key }} | {{ $val.DescriptionStr }} {{ $val.EnumStr }} |
 {{- end }}
 {{- end }}
 

--- a/hack/generate-config-reference/schema.go
+++ b/hack/generate-config-reference/schema.go
@@ -26,6 +26,16 @@ type Schema struct {
 	Path string `json:"-"`
 }
 
+// DescriptionStr returns the description modified for consul.io docs:
+// - Remove "[Consul Enterprise]" and prefix a "<EnterpriseAlert inline />".
+func (s *Schema) DescriptionStr() string {
+	modified := strings.ReplaceAll(s.Description, "[Consul Enterprise]", "")
+	if modified != s.Description {
+		modified = "<EnterpriseAlert inline /> " + modified
+	}
+	return modified
+}
+
 // RequiredStr returns "required" or "optional" if the given
 // field is in the list of required fields for this schema.
 func (s *Schema) RequiredStr(field string) string {
@@ -52,6 +62,8 @@ func (s *Schema) EnumStr() string {
 
 		if val == nil {
 			result += "`null`"
+		} else if *val == "" {
+			result += "`\"\"`"
 		} else {
 			result += "`" + *val + "`"
 		}


### PR DESCRIPTION
## Changes proposed in this PR:
This improves a few things in our generated reference config

- Fix an `additionalProperties` in the wrong place
- Add a description
- Generate the nice enterprise badge on consul.io for Consul Enterprise fields
- Display a `""` in cases where an enum value is an empty string

## How I've tested this PR:
- Included generated output here: https://github.com/hashicorp/consul/pull/13222
- Preview: https://consul-ijerapkhg-hashicorp.vercel.app/docs/ecs/configuration-reference

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
