### PR TITLE
Disable cgo during builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,9 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           LDFLAGS: ${{ needs.get-product-version.outputs.ldflags }}
+          CGO_ENABLED: "0"
         run: |
+          go env
           mkdir dist out
           go build -ldflags="$LDFLAGS" -o dist/ .
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH="/bin/consul-inject:${PATH}"
 VOLUME [ "/consul" ]
 
 # Set up certificates, base tools, and software.
-RUN apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils iptables libc6-compat
+RUN apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils iptables
 
 USER $BIN_NAME
 ENTRYPOINT ["/bin/consul-ecs"]


### PR DESCRIPTION
## Changes proposed in this PR:
Disable CGO during builds. This enables us to remove libc6-compat from the image, which is important for our features/workarounds where we copy this binary between containers in ECS at runtime that may not include libc6-compat.

## How I've tested this PR:
* Ran `go test ./... -run 'TestBasic/secure:_true' -v -p 1 -timeout 20m`
* Acceptance tests on this branch: https://github.com/hashicorp/terraform-aws-consul-ecs/compare/pglass/test-cgo-fix

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
