### PR TITLE
Enforce lowercase service names

### DIFF
--- a/config/resources/test_config_empty_fields.json
+++ b/config/resources/test_config_empty_fields.json
@@ -15,5 +15,16 @@
     "namespace": "",
     "partition": ""
   },
+  "gateway": {
+    "kind": "mesh-gateway",
+    "lanAddress": {},
+    "wanAddress": {},
+    "name": "",
+    "tags": [],
+    "meta": {},
+    "namespace": "",
+    "partition": "",
+    "proxy": {}
+  },
   "proxy": {}
 }

--- a/config/resources/test_config_null_nested_fields.json
+++ b/config/resources/test_config_null_nested_fields.json
@@ -43,6 +43,26 @@
     ],
     "namespace": null
   },
+  "gateway": {
+    "kind": "mesh-gateway",
+    "lanAddress": {
+      "address": null,
+      "port": null
+    },
+    "wanAddress": {
+      "source": null,
+      "address": null,
+      "port": null
+    },
+    "name": null,
+    "tags": null,
+    "meta": null,
+    "namespace": null,
+    "partition": null,
+    "proxy": {
+      "config": null
+    }
+  },
   "proxy": {
     "config": null,
     "upstreams": [

--- a/config/resources/test_config_null_top_level_fields.json
+++ b/config/resources/test_config_null_top_level_fields.json
@@ -16,5 +16,16 @@
     "namespace": null,
     "partition": null
   },
+  "gateway": {
+    "kind": "mesh-gateway",
+    "lanAddress": null,
+    "wanAddress": null,
+    "name": null,
+    "tags": null,
+    "meta": null,
+    "namespace": null,
+    "partition": null,
+    "proxy": null
+  },
   "proxy": null
 }

--- a/config/resources/test_config_uppercase_service_names.json
+++ b/config/resources/test_config_uppercase_service_names.json
@@ -1,0 +1,28 @@
+{
+  "service": {
+    "name": "SERVICE-NAME",
+    "tags": [
+      "tag1"
+    ],
+    "meta": {
+      "a": "1"
+    },
+    "port": 1234
+  },
+  "gateway": {
+    "kind": "mesh-gateway",
+    "name": "GATEWAY-NAME"
+  },
+  "proxy": {
+    "upstreams": [
+      {
+        "destinationName": "asdf",
+        "localBindPort": 543
+      }
+    ]
+  },
+  "healthSyncContainers": [
+    "container1"
+  ],
+  "bootstrapDir": "/consul/"
+}

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -84,6 +84,32 @@
     "namespace": "test-ns",
     "partition": "test-partition"
   },
+  "gateway": {
+    "kind": "mesh-gateway",
+    "lanAddress": {
+      "address": "10.0.0.1",
+      "port": 8443
+    },
+    "wanAddress": {
+      "source": "publicIP",
+      "address": "172.16.0.0",
+      "port": 443
+    },
+    "name": "ecs-mesh-gateway",
+    "tags": ["a", "b"],
+    "meta": {
+      "env": "test",
+      "version": "x.y.z"
+    },
+    "namespace": "ns1",
+    "partition": "ptn1",
+    "proxy": {
+      "config": {
+        "data": "some-config-data"
+      }
+    }
+  },
+
   "proxy": {
     "config": {
       "data": "some-config-data"

--- a/config/schema.json
+++ b/config/schema.json
@@ -62,7 +62,8 @@
       "properties": {
         "name": {
           "description": "The name the service will be registered as in Consul. Defaults to the Task family name if empty or null.",
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "(^$)|(^[a-z0-9]([a-z0-9-_]*[a-z0-9])?$)"
         },
         "tags": {
           "description": "List of string values that can be used to add service-level labels.",
@@ -357,37 +358,38 @@
         },
         "lanAddress": {
           "description": "LAN address and port for the gateway. If not specified, defaults to the task/node address.",
-          "type": "object",
+          "type": ["object", "null"],
           "properties": {
             "address": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "port": {
-              "type": "integer"
+              "type": ["integer", "null"]
             }
           },
           "additionalProperties": false
         },
         "wanAddress": {
           "description": "WAN address and port for the gateway. If not specified, defaults to the task/node address.",
-          "type": "object",
+          "type": ["object", "null"],
           "properties": {
             "source": {
-              "type": "string",
-              "enum": ["publicIP", "loadBalancerDNS", ""]
+              "type": ["string", "null"],
+              "enum": ["publicIP", "loadBalancerDNS", "", null]
             },
             "address": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "port": {
-              "type": "integer"
+              "type": ["integer", "null"]
             }
           },
           "additionalProperties": false
         },
         "name": {
           "description": "The name the gateway will be registered as in Consul. Defaults to the Task family name.",
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "(^$)|(^[a-z0-9]([a-z0-9-_]*[a-z0-9])?$)"
         },
         "tags": {
           "description": "List of string values that can be used to add labels to the gateway.",

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -260,8 +261,7 @@ func (c *Command) constructServiceName(family string) string {
 	if serviceName := c.config.Service.Name; serviceName != "" {
 		return serviceName
 	}
-
-	return family
+	return strings.ToLower(family)
 }
 
 func (c *Command) Synopsis() string {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -56,7 +57,7 @@ func TestRunWithContainerNames(t *testing.T) {
 	taskID := "TaskID"
 	ecsServiceMetadata := ecsServiceMetadata{
 		family:    family,
-		serviceID: fmt.Sprintf("%s-%s", family, taskID),
+		serviceID: fmt.Sprintf("%s-%s", strings.ToLower(family), taskID),
 		taskID:    taskID,
 		taskARN:   fmt.Sprintf("asdf/%s", taskID),
 	}
@@ -195,7 +196,7 @@ func TestRunWithContainerNames(t *testing.T) {
 	for name, c := range cases {
 		c := c
 		t.Run(name, func(t *testing.T) {
-			expectedServiceName := family
+			expectedServiceName := strings.ToLower(family)
 			if c.serviceName != "" {
 				expectedServiceName = c.serviceName
 			}
@@ -499,6 +500,9 @@ func TestConstructServiceName(t *testing.T) {
 	family := "family"
 
 	serviceName := cmd.constructServiceName(family)
+	require.Equal(t, family, serviceName)
+
+	serviceName = cmd.constructServiceName("FAMILY")
 	require.Equal(t, family, serviceName)
 
 	expectedServiceName := "service-name"

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -324,10 +324,17 @@ func constructChecks(serviceID string, checks []config.AgentServiceCheck, health
 	return checks, nil
 }
 
+// constructServiceName returns the service name for registration with Consul.
+// This will use the config-provided name or, if not specified, default to the task family name.
+// A lower case service name is required since the auth method relies on tokens with a service identity,
+// and Consul service identities must be lower case:
+//
+// - The config-provided is validated by jsonschema to be lower case
+// - When defaulting to the task family, this automatically lowercases the task family name
 func (c *Command) constructServiceName(family string) string {
 	configName := c.config.Service.Name
 	if configName == "" {
-		return family
+		return strings.ToLower(family)
 	}
 	return configName
 }

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -53,7 +53,7 @@ func TestConfigValidation(t *testing.T) {
 // because it sets environment variables (e.g. ECS metadata URI and Consul's HTTP addr)
 // that could not be shared if another test were to run in parallel.
 func TestRun(t *testing.T) {
-	family := "family-service-name"
+	family := "family-SERVICE-name"
 	serviceName := "service-name"
 
 	cases := map[string]struct {
@@ -161,7 +161,7 @@ func TestRun(t *testing.T) {
 					"task-arn": taskARN,
 					"source":   "consul-ecs",
 				}
-				expectedServiceName = family
+				expectedServiceName = strings.ToLower(family)
 				expectedPartition   = ""
 				expectedNamespace   = ""
 			)
@@ -588,6 +588,9 @@ func TestConstructServiceName(t *testing.T) {
 	family := "family"
 
 	serviceName := cmd.constructServiceName(family)
+	require.Equal(t, family, serviceName)
+
+	serviceName = cmd.constructServiceName("FAMILY")
 	require.Equal(t, family, serviceName)
 
 	expectedServiceName := "service-name"


### PR DESCRIPTION
## Changes proposed in this PR:
With the auth method, the service token relies on a service identity, which requires a lowercase name. This updates the binary to:

- Validate service names are lowercase in the schema.json. Actually, require they match the [service identity regex](https://github.com/hashicorp/consul/blob/93b164aac37f83863707f05284b868dc8ea57719/acl/validation.go#L11). I also handled this for the gateway service name and update schema validation for this.
- When no service name is specified, fall back to the lowercase family name.

## How I've tested this PR:
Unit and acceptance tests

## How I expect reviewers to test this PR:
:eyes:

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
