### PR TITLE
Prep 0.5.x release branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,6 @@ jobs:
           # - https://hashicorp.atlassian.net/wiki/spaces/RDXPOC/pages/2298218311/How+to+Push+a+Docker+image+to+ECR
           tags: |
             docker.io/hashicorp/${{ env.repo }}:${{ env.version }}
-            986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{ env.repo }}:${{ env.version }}
             public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.version }}
           # dev_tags are tags that get automatically pushed whenever successful
           # builds make it to the stable channel. The intention is for these tags

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,7 +9,10 @@ project "consul-ecs" {
   github {
     organization = "hashicorp"
     repository = "consul-ecs"
-    release_branches = ["main"]
+    release_branches = [
+      "main",
+      "release/0.5.x",
+    ]
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## 0.5.0-beta1 (Jun 06, 2022)
 
 BREAKING CHANGES
 * Update `acl-controller` to cleanup ACL tokens created from Consul's AWS IAM auth method. Remove

--- a/version/version.go
+++ b/version/version.go
@@ -13,12 +13,12 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.4.1"
+	Version = "0.5.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = "beta1"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
## Changes proposed in this PR:
Prep for the 0.5.0-beta1 release. This sets the version to 0.5.0-beta1 in version/version.go and in the changelog on the release/0.5.x branch.

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
