### PR TITLE
Remove promote-production-packaging step

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -186,16 +186,3 @@ event "promote-production-docker" {
     on = "always"
   }
 }
-
-event "promote-production-packaging" {
-  depends = ["promote-production-docker"]
-  action "promote-production-packaging" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-production-packaging"
-  }
-
-  notification {
-    on = "always"
-  }
-}


### PR DESCRIPTION
## Changes proposed in this PR:
We don't publish Linux packages, so we don't need this step.

## How I've tested this PR:


## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
