### PR TITLE
Mesh gateway support when ACLs are enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/mitchellh/cli v1.1.2
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.6.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v3 v3.0.0 // indirect

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -32,6 +32,10 @@ const (
 	// Binding rules don't support a '/' character, so we need compatible IAM role tag names.
 	authMethodServiceNameTag = "consul.hashicorp.com.service-name"
 	authMethodNamespaceTag   = "consul.hashicorp.com.namespace"
+
+	// anonTokenID is the well-known ID for the anonymous ACL token.
+	anonTokenID    = "00000000-0000-0000-0000-000000000002"
+	anonPolicyName = "anonymous-token-policy"
 )
 
 type Command struct {
@@ -203,6 +207,16 @@ func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsuti
 		BindName:    fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag),
 	}
 
+	agentSelf, err := consulClient.Agent().Self()
+	if err != nil {
+		return fmt.Errorf("failed to get Consul agent self config: %w", err)
+	}
+	var agentConfig AgentConfig
+	err = mapstructure.Decode(agentSelf, &agentConfig)
+	if err != nil {
+		return fmt.Errorf("failed to decode Consul agent self config: %w", err)
+	}
+
 	if c.flagPartitionsEnabled {
 		if c.flagPartition == "" {
 			// if an explicit partition was not provided use the default partition.
@@ -230,7 +244,7 @@ func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsuti
 	if err := c.upsertBindingRule(consulClient, serviceBindingRule); err != nil {
 		return err
 	}
-	if err := c.upsertAnonymousTokenPolicy(consulClient); err != nil {
+	if err := c.upsertAnonymousTokenPolicy(consulClient, agentConfig); err != nil {
 		return err
 	}
 	return nil
@@ -474,17 +488,16 @@ func (c *Command) upsertBindingRule(consulClient *api.Client, bindingRule *api.A
 	return nil
 }
 
-func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client) error {
-	agentCfg, err := consulClient.Agent().Self()
-	if err != nil {
-		return fmt.Errorf("failed to get Consul agent self config: %w", err)
-	}
-	var agentConfig AgentConfig
-	err = mapstructure.Decode(agentCfg, &agentConfig)
-	if err != nil {
-		return fmt.Errorf("failed to decode Consul agent self config: %w", err)
-	}
-
+// upsertAnonymousTokenPolicy ensures that the anonymous ACL token has the correct permissions
+// to allow for WAN federation via mesh gateways.
+// If mesh gateway WAN federation is enabled and the ACL controller is in the primary
+// datacenter then we need to update the anonymous token with service:read and node:read.
+// Tokens are stripped from cross DC API calls so cross DC API calls use the anonymous
+// token. Mesh gateway proxies use the anonymous token to talk cross-DC and they require
+// service:read and node:read.
+// The anonymous token is global so it is replicated from the primary DC to all secondary
+// DCs, which is why we only update it if this is the primary datacenter.
+func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client, agentConfig AgentConfig) error {
 	consulDC, primaryDC, err := c.consulDatacenterList(agentConfig)
 	if err != nil {
 		return fmt.Errorf("failed to list Consul datacenters: %w", err)
@@ -494,43 +507,39 @@ func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client) error {
 		return nil
 	}
 
-	// If mesh gateway WAN federation is enabled and the ACL controller is in the primary
-	// datacenter then we need to update the anonymous token with service:read and node:read.
-	// Tokens are stripped from cross DC API calls so cross DC API calls use the anonymous
-	// token. Mesh gateway proxies use the anonymous token to talk cross-DC and they require
-	// service:read and node:read.
 	c.log.Info("Configuring anonymous token", "datacenter", consulDC, "primary-datacenter", primaryDC)
 
-	policyName := "anonymous-token-policy"
-	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, &api.QueryOptions{})
+	policy, _, err := consulClient.ACL().PolicyReadByName(anonPolicyName, &api.QueryOptions{})
 	if err == nil {
-		c.log.Info("Anonymous token policy already exists, skipping policy creation", "name", policyName)
+		c.log.Info("Anonymous token policy already exists, skipping policy creation", "name", anonPolicyName)
 	} else if err != nil && controller.IsACLNotFoundError(err) {
 		// the policy is not found, so create it.
-		c.log.Info("creating ACL policy", "name", policyName)
+		c.log.Info("creating ACL policy", "name", anonPolicyName)
 		rules, err := c.anonymousPolicyRules()
 		if err != nil {
 			return fmt.Errorf("failed to generate anonymous token policy rules: %w", err)
 		}
 		policy, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{
-			Name:        policyName,
+			Name:        anonPolicyName,
 			Description: "Anonymous token policy",
 			Rules:       rules,
 		}, &api.WriteOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create anonymous token policy: %w", err)
 		}
-		c.log.Info("ACL policy created successfully", "name", policyName)
+		c.log.Info("ACL policy created successfully", "name", anonPolicyName)
 	} else {
 		return fmt.Errorf("failed to read anonymous token policy: %w", err)
 	}
 
 	// The accessor ID for the anonymous token is well-known so we don't need to find it.
-	token := api.ACLToken{
-		AccessorID: "00000000-0000-0000-0000-000000000002",
-		Policies:   []*api.ACLTokenPolicyLink{{Name: policy.Name}},
+	token, _, err := consulClient.ACL().TokenRead(anonTokenID, &api.QueryOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to read anonymous token: %w", err)
 	}
-	_, _, err = consulClient.ACL().TokenUpdate(&token, &api.WriteOptions{})
+	token.Policies = append(token.Policies, &api.ACLTokenPolicyLink{Name: policy.Name})
+
+	_, _, err = consulClient.ACL().TokenUpdate(token, &api.WriteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update anonymous token: %w", err)
 	}
@@ -594,10 +603,10 @@ func (c *Command) anonymousPolicyRules() (string, error) {
 namespace_prefix "" {
 {{- end }}
   node_prefix "" {
-     policy = "read"
+    policy = "read"
   }
   service_prefix "" {
-     policy = "read"
+    policy = "read"
   }
 {{- if .Enterprise }}
 }

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -490,7 +490,7 @@ func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client) error {
 		return fmt.Errorf("failed to list Consul datacenters: %w", err)
 	}
 
-	if !agentConfig.Config.MeshGatewayWANFederationEnabled || consulDC != primaryDC {
+	if !agentConfig.DebugConfig.MeshGatewayWANFederationEnabled || consulDC != primaryDC {
 		return nil
 	}
 

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -299,3 +299,14 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules
 		require.Equal(t, rule.BindName, fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag))
 	}
 }
+
+func TestAnonymousTokenRules(t *testing.T) {
+	a := []bool{false, true}
+	cmd := &Command{}
+	for _, e := range a {
+		cmd.flagPartitionsEnabled = e
+		rules, err := cmd.anonymousPolicyRules()
+		require.NoError(t, err)
+		fmt.Println(rules)
+	}
+}

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -299,17 +299,6 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules
 	}
 }
 
-func TestAnonymousTokenRules(t *testing.T) {
-	a := []bool{false, true}
-	cmd := &Command{}
-	for _, e := range a {
-		cmd.flagPartitionsEnabled = e
-		rules, err := cmd.anonymousPolicyRules()
-		require.NoError(t, err)
-		fmt.Println(rules)
-	}
-}
-
 func TestUpsertAuthMethod(t *testing.T) {
 	t.Parallel()
 	cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
@@ -430,5 +419,16 @@ func makeAuthMethod(principals interface{}) *api.ACLAuthMethod {
 			"BoundIAMPrincipalARNs":  principals,
 			"EnableIAMEntityDetails": true,
 		},
+	}
+}
+
+func TestAnonymousTokenRules(t *testing.T) {
+	a := []bool{false, true}
+	cmd := &Command{}
+	for _, e := range a {
+		cmd.flagPartitionsEnabled = e
+		rules, err := cmd.anonymousPolicyRules()
+		require.NoError(t, err)
+		fmt.Println(rules)
 	}
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Update the `acl-controller` to use the Consul server agent config to detect if mesh gateway WAN federation is enabled and update the anonymous token so that mesh gateways can communicate across datacenters.
- Add unit tests.

## How I've tested this PR:
- Unit tests
- Manually against the mesh-gateway example

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added
