### PR TITLE
acl-controller: Set cross-namespace policy on default namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BUF FIXES
+* Fix issue where the `acl-controller` did not update the default namespace with the cross-namespace policy.
+  [[GH-104](https://github.com/hashicorp/consul-ecs/pull/104)]
+
 ## 0.5.0-beta1 (Jun 06, 2022)
 
 BREAKING CHANGES

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -434,18 +434,42 @@ func TestReconcileNamespaces(t *testing.T) {
 			require.NoError(t, s.ReconcileNamespaces(c.resources))
 			require.Equal(t, c.expNS, listNamespaces(t, consulClient))
 
-			// check cross namespace policy is created (or not)
-			policy, _, err := consulClient.ACL().PolicyReadByName(
+			// check cross namespace xnsPolicy is created (or not)
+			xnsPolicy, _, err := consulClient.ACL().PolicyReadByName(
 				xnsPolicyName,
 				&api.QueryOptions{Partition: c.partition},
 			)
 			if c.expXnsPolicy {
 				require.NoError(t, err)
-				require.NotNil(t, policy)
-				require.Equal(t, fmt.Sprintf(xnsPolicyTpl, c.partition), policy.Rules)
+				require.NotNil(t, xnsPolicy)
+				require.Equal(t, xnsPolicyName, xnsPolicy.Name)
+				require.Equal(t, fmt.Sprintf(xnsPolicyTpl, c.partition), xnsPolicy.Rules)
+
+				// check which namespaces have the cross-namespace policy assigned.
+				xnsLink := api.ACLLink{ID: xnsPolicy.ID, Name: xnsPolicy.Name}
+				for ptn, namespaces := range c.expNS {
+					for _, nsName := range namespaces {
+						ns, _, err := consulClient.Namespaces().Read(
+							nsName, &api.QueryOptions{Partition: ptn},
+						)
+						require.NoError(t, err)
+						require.NotNil(t, ns)
+						if ptn == c.partition {
+							// namespaces in the controller's assigned partition (c.partition) should have
+							// the cross-namespace policy as a default policy.
+							require.NotNil(t, ns.ACLs)
+							require.Contains(t, ns.ACLs.PolicyDefaults, xnsLink)
+						} else if ns.ACLs != nil {
+							// namespaces outside the controller's assigned partition should not have the xnsPolicy
+							for _, link := range ns.ACLs.PolicyDefaults {
+								require.NotEqual(t, xnsLink.Name, link.Name)
+							}
+						}
+					}
+				}
 			} else {
 				require.Error(t, err)
-				require.Nil(t, policy)
+				require.Nil(t, xnsPolicy)
 			}
 		})
 	}


### PR DESCRIPTION
## Changes proposed in this PR:
This updates the acl-controller to set the cross-namespace policy as a default policy on the default namespace.

## How I've tested this PR:
- Unit tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
