### PR TITLE
Fix namespace reconciliation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 BUF FIXES
 * Fix issue where the `acl-controller` did not update the default namespace with the cross-namespace policy.
   [[GH-104](https://github.com/hashicorp/consul-ecs/pull/104)]
+* Fix token cleanup in the `acl-controller` when Consul Enterprise admin partitions are enabled.
+  [[GH-105](https://github.com/hashicorp/consul-ecs/pull/105)]
 
 ## 0.5.0-beta1 (Jun 06, 2022)
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 )
 
 const DefaultPollingInterval = 10 * time.Second
@@ -45,17 +46,20 @@ func (c *Controller) reconcile() error {
 		return fmt.Errorf("listing resources: %w", err)
 	}
 
+	var merr error
 	if err = c.Resources.ReconcileNamespaces(resources); err != nil {
-		return fmt.Errorf("reconciling namespaces: %w", err)
+		c.Log.Error("error reconciling namespaces", "err", err)
+		merr = multierror.Append(merr, fmt.Errorf("reconciling namespaces: %w", err))
 	}
 
 	for _, resource := range resources {
 		err = resource.Reconcile()
 		if err != nil {
 			c.Log.Error("error reconciling resource", "err", err)
+			merr = multierror.Append(err, fmt.Errorf("reconciling resource: %w", err))
 		}
 	}
 
-	c.Log.Debug("reconcile finished successfully")
-	return nil
+	c.Log.Debug("reconcile finished")
+	return merr
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -48,14 +48,12 @@ func (c *Controller) reconcile() error {
 
 	var merr error
 	if err = c.Resources.ReconcileNamespaces(resources); err != nil {
-		c.Log.Error("error reconciling namespaces", "err", err)
 		merr = multierror.Append(merr, fmt.Errorf("reconciling namespaces: %w", err))
 	}
 
 	for _, resource := range resources {
 		err = resource.Reconcile()
 		if err != nil {
-			c.Log.Error("error reconciling resource", "err", err)
 			merr = multierror.Append(err, fmt.Errorf("reconciling resource: %w", err))
 		}
 	}

--- a/controller/resource.go
+++ b/controller/resource.go
@@ -306,7 +306,11 @@ func (s TaskStateLister) createNamespaces(resources []Resource) error {
 	// create the set of all namespaces in the list of resources.
 	ns := make(map[string]struct{})
 	for _, r := range resources {
-		ns[r.Namespace()] = struct{}{}
+		// Ignore empty string namespaces. This is the case for a Resource constructed from an ACL
+		// token, since tokens should not affect namespace creation.
+		if name := r.Namespace(); name != "" {
+			ns[name] = struct{}{}
+		}
 	}
 
 	// retrieve the list of existing namespaces

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -385,6 +385,8 @@ func TestReconcileNamespaces(t *testing.T) {
 			expNS:     map[string][]string{"default": {"default"}},
 			resources: []Resource{
 				makeTaskStateEnt("some-task-id", true, nil, "default", "default"),
+				// simulate a task state with an empty string for the namespace
+				makeTaskStateEnt("some-task-id", false, nil, "", ""),
 			},
 			expXnsPolicy: true,
 		}


### PR DESCRIPTION
## Changes proposed in this PR:
This fixes an error message in the acl-controller where it was attempting to use the empty string for the namespace when creating a namespace. When this error occurred while reconciling namespaces, the controller would abort reconciliation, which means it would not proceed to cleanup ACL tokens.

To address that, this also changes the controller to attempt to reconcile resources even if a namespace reconciliation error occurred.

## How I've tested this PR:
Unit tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
