### PR TITLE
Always configure anonymous token in primary DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Unreleased
 
-BUF FIXES
+BUG FIXES
 * Fix issue where the `acl-controller` did not update the default namespace with the cross-namespace policy.
   [[GH-104](https://github.com/hashicorp/consul-ecs/pull/104)]
 * Fix token cleanup in the `acl-controller` when Consul Enterprise admin partitions are enabled.
   [[GH-105](https://github.com/hashicorp/consul-ecs/pull/105)]
+* The `acl-controller` configures the anonymous token with `service:read` and `node:read`
+  permissions to support cross-dc or cross-partition traffic through mesh gateways.
+  [[GH-103](https://github.com/hashicorp/consul-ecs/pull/103)]
+  [[GH-106](https://github.com/hashicorp/consul-ecs/pull/106)]
 
 ## 0.5.0-beta1 (Jun 06, 2022)
 

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -516,13 +516,17 @@ func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client, agentConf
 	// the anonymous token won't be configured correctly. In order to ensure that,
 	// we will always configure the anonymous token in the default partition so that
 	// mesh gateways actually work across partitions.
-	qopts := &api.QueryOptions{
-		Namespace: controller.DefaultPartition,
-		Partition: controller.DefaultNamespace,
-	}
-	wopts := &api.WriteOptions{
-		Namespace: controller.DefaultPartition,
-		Partition: controller.DefaultNamespace,
+	var qopts *api.QueryOptions
+	var wopts *api.WriteOptions
+	if c.flagPartitionsEnabled {
+		qopts = &api.QueryOptions{
+			Namespace: controller.DefaultPartition,
+			Partition: controller.DefaultNamespace,
+		}
+		wopts = &api.WriteOptions{
+			Namespace: controller.DefaultPartition,
+			Partition: controller.DefaultNamespace,
+		}
 	}
 
 	// Read the anonymous token. We don't pass query options here because the token is global.

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -616,9 +616,8 @@ type AgentConfig struct {
 }
 
 type Config struct {
-	Datacenter                      string `mapstructure:"Datacenter"`
-	PrimaryDatacenter               string `mapstructure:"PrimaryDatacenter"`
-	MeshGatewayWANFederationEnabled bool   `mapstructure:"ConnectMeshGatewayWANFederationEnabled"`
+	Datacenter        string `mapstructure:"Datacenter"`
+	PrimaryDatacenter string `mapstructure:"PrimaryDatacenter"`
 }
 
 type templateData struct {

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -489,9 +489,9 @@ func (c *Command) upsertBindingRule(consulClient *api.Client, bindingRule *api.A
 }
 
 // upsertAnonymousTokenPolicy ensures that the anonymous ACL token has the correct permissions
-// to allow for WAN federation via mesh gateways.
-// If mesh gateway WAN federation is enabled and the ACL controller is in the primary
-// datacenter then we need to update the anonymous token with service:read and node:read.
+// to allow cross-DC communication via mesh gateways.
+// If the ACL controller is in the primary datacenter then we need to update the anonymous token
+// with service:read and node:read.
 // Tokens are stripped from cross DC API calls so cross DC API calls use the anonymous
 // token. Mesh gateway proxies use the anonymous token to talk cross-DC and they require
 // service:read and node:read.
@@ -503,7 +503,9 @@ func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client, agentConf
 		return fmt.Errorf("failed to list Consul datacenters: %w", err)
 	}
 
-	if !agentConfig.DebugConfig.MeshGatewayWANFederationEnabled || consulDC != primaryDC {
+	// Always configure the anonymous token. This is required for mesh-gateway traffic.
+	// For simplicity we configure this even if there are no mesh gateways in the datacenter.
+	if consulDC != primaryDC {
 		return nil
 	}
 

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -36,3 +36,19 @@ func TestUpsertConsulResourcesEnt(t *testing.T) {
 		},
 	})
 }
+
+func TestUpsertAnonymousTokenPolicyEnt(t *testing.T) {
+	testUpsertAnonymousTokenPolicy(t, map[string]anonTokenTest{
+		"mgw WAN fed enabled, primary DC, create policy": {
+			agentConfig: AgentConfig{
+				Config: Config{Datacenter: "dc1"},
+				DebugConfig: Config{
+					PrimaryDatacenter:               "dc1",
+					MeshGatewayWANFederationEnabled: true,
+				},
+			},
+			partitionsEnabled: true,
+			expPolicy:         expEntAnonTokenPolicy,
+		},
+	})
+}

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -39,7 +39,7 @@ func TestUpsertConsulResourcesEnt(t *testing.T) {
 
 func TestUpsertAnonymousTokenPolicyEnt(t *testing.T) {
 	testUpsertAnonymousTokenPolicy(t, map[string]anonTokenTest{
-		"mgw WAN fed enabled, primary DC, create policy": {
+		"primary datacenter": {
 			agentConfig: AgentConfig{
 				Config: Config{Datacenter: "dc1"},
 				DebugConfig: Config{

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -41,11 +41,8 @@ func TestUpsertAnonymousTokenPolicyEnt(t *testing.T) {
 	testUpsertAnonymousTokenPolicy(t, map[string]anonTokenTest{
 		"primary datacenter": {
 			agentConfig: AgentConfig{
-				Config: Config{Datacenter: "dc1"},
-				DebugConfig: Config{
-					PrimaryDatacenter:               "dc1",
-					MeshGatewayWANFederationEnabled: true,
-				},
+				Config:      Config{Datacenter: "dc1"},
+				DebugConfig: Config{PrimaryDatacenter: "dc1"},
 			},
 			partitionsEnabled: true,
 			expPolicy:         expEntAnonTokenPolicy,

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -465,8 +465,9 @@ func TestUpsertAnonymousTokenPolicy(t *testing.T) {
 		},
 		"mgw WAN fed not enabled": {
 			agentConfig: AgentConfig{Config: Config{Datacenter: "dc1", PrimaryDatacenter: "dc1"}},
+			expPolicy:   expOSSAnonTokenPolicy,
 		},
-		"mgw WAN fed enabled, not primary DC": {
+		"mgw WAN fed not enabled, not primary DC": {
 			agentConfig: AgentConfig{Config: Config{Datacenter: "dc2"}, DebugConfig: Config{PrimaryDatacenter: "dc1"}},
 		},
 		"mgw WAN fed enabled, primary DC, policy attached": {

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -496,11 +496,8 @@ func TestUpsertAnonymousTokenPolicy(t *testing.T) {
 		},
 		"primary datacenter, policy exists": {
 			agentConfig: AgentConfig{
-				Config: Config{Datacenter: "dc1"},
-				DebugConfig: Config{
-					PrimaryDatacenter:               "dc1",
-					MeshGatewayWANFederationEnabled: true,
-				},
+				Config:      Config{Datacenter: "dc1"},
+				DebugConfig: Config{PrimaryDatacenter: "dc1"},
 			},
 			existingPolicy: true,
 			expPolicy:      expOSSAnonTokenPolicy,


### PR DESCRIPTION
## Changes proposed in this PR:
This changes the acl-controller to always configure the anonymous token in the primary datacenter, and in the default partition.

## How I've tested this PR:
Unit tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
