### PR TITLE
Remove gateway.wanAddress.source field

### DIFF
--- a/config/resources/test_config_null_nested_fields.json
+++ b/config/resources/test_config_null_nested_fields.json
@@ -50,7 +50,6 @@
       "port": null
     },
     "wanAddress": {
-      "source": null,
       "address": null,
       "port": null
     },

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -91,7 +91,6 @@
       "port": 8443
     },
     "wanAddress": {
-      "source": "publicIP",
       "address": "172.16.0.0",
       "port": 443
     },

--- a/config/schema.json
+++ b/config/schema.json
@@ -377,10 +377,6 @@
           "description": "WAN address and port for the gateway. If not specified, defaults to the task/node address.",
           "type": ["object", "null"],
           "properties": {
-            "source": {
-              "type": ["string", "null"],
-              "enum": ["publicIP", "loadBalancerDNS", "", null]
-            },
             "address": {
               "type": ["string", "null"]
             },

--- a/config/types.go
+++ b/config/types.go
@@ -349,8 +349,6 @@ func (p *GatewayProxyConfig) ToConsulType() *api.AgentServiceConnectProxyConfig 
 }
 
 type GatewayAddress struct {
-	// Source is for the WAN address only (enforced by schema).
-	Source  string `json:"source,omitempty"`
 	Address string `json:"address,omitempty"`
 	Port    int    `json:"port,omitempty"`
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -232,7 +232,6 @@ var (
 				Port:    8443,
 			},
 			WanAddress: &GatewayAddress{
-				Source:  "publicIP",
 				Address: "172.16.0.0",
 				Port:    443,
 			},
@@ -339,12 +338,10 @@ var (
 		Gateway: &GatewayRegistration{
 			Kind: "mesh-gateway",
 			LanAddress: &GatewayAddress{
-				Source:  "",
 				Address: "",
 				Port:    0,
 			},
 			WanAddress: &GatewayAddress{
-				Source:  "",
 				Address: "",
 				Port:    0,
 			},


### PR DESCRIPTION
## Changes proposed in this PR:
This removes the `gateway.wanAddress.source` field, which is unused for now.

## How I've tested this PR:
- Unit tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
