### PR TITLE
Backport anonymous token policy fix to 0.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+BUG FIXES:
+* Fix the description of the anonymous token policy so that it exactly matches the description
+  created by `consul-k8s`. This fixes a connectivity issue that occurs when `consul-k8s` and
+  `consul-ecs` deployments are connected to the same Consul datacenter.
+  [[GH-114](https://github.com/hashicorp/consul-ecs/pull/114)]
+
 ## 0.5.0 (June 21, 2022)
 
 BREAKING CHANGES

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/consul-ecs
 go 1.16
 
 require (
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/aws/aws-sdk-go v1.38.2
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/deckarep/golang-set v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -36,6 +36,7 @@ const (
 	// anonTokenID is the well-known ID for the anonymous ACL token.
 	anonTokenID    = "00000000-0000-0000-0000-000000000002"
 	anonPolicyName = "anonymous-token-policy"
+	anonPolicyDesc = "Anonymous token Policy"
 )
 
 type Command struct {
@@ -558,7 +559,7 @@ func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client, agentConf
 		}
 		policy, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{
 			Name:        anonPolicyName,
-			Description: "Anonymous token policy",
+			Description: anonPolicyDesc,
 			Rules:       rules,
 		}, wopts)
 		if err != nil {

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -524,7 +524,7 @@ func testUpsertAnonymousTokenPolicy(t *testing.T, cases map[string]anonTokenTest
 			if c.existingPolicy {
 				_, _, err := consulClient.ACL().PolicyCreate(&api.ACLPolicy{
 					Name:        anonPolicyName,
-					Description: "Anonymous token policy",
+					Description: anonPolicyDesc,
 					Rules:       c.expPolicy,
 				}, nil)
 				require.NoError(t, err)
@@ -552,6 +552,8 @@ func testUpsertAnonymousTokenPolicy(t *testing.T, cases map[string]anonTokenTest
 					// it was and that it matches the expected
 					obsAnonTokenPolicy, _, err := consulClient.ACL().PolicyReadByName(anonPolicyName, nil)
 					require.NoError(t, err)
+					require.Equal(t, anonPolicyName, obsAnonTokenPolicy.Name)
+					require.Equal(t, anonPolicyDesc, obsAnonTokenPolicy.Description)
 					require.Equal(t, c.expPolicy, obsAnonTokenPolicy.Rules)
 
 					// expect that the policy is now attached to the anonymous token.


### PR DESCRIPTION
## Changes proposed in this PR:
- Change the `Description` of the anonymous token policy so that it is exactly the same as the one created by the `consul-k8s` ACL controller.
- Addressed dependabot security alert for `Masterminds/goutils` module

## How I've tested this PR:
- Updated unit test

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::

