### PR TITLE
Merge changelog from 0.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ BREAKING CHANGES
   `stsEndpoint`, and `serverIdHeaderValue` fields to the `consulLogin` config object.
   [[GH-115](https://github.com/hashicorp/consul-ecs/pull/115)]
 
-BUG FIXES
+## 0.5.1 (July 28, 2022)
+
+BUG FIXES:
 * Fix the description of the anonymous token policy so that it exactly matches the description
   created by `consul-k8s`. This fixes a connectivity issue that occurs when `consul-k8s` and
   `consul-ecs` deployments are connected to the same Consul datacenter.
+  [[GH-114](https://github.com/hashicorp/consul-ecs/pull/114)]
 
 ## 0.5.0 (June 21, 2022)
 


### PR DESCRIPTION
## Changes proposed in this PR:

Update changelog on main to include the [0.5.1 section](https://github.com/hashicorp/consul-ecs/blob/release/0.5.x/CHANGELOG.md#051-july-28-2022) from the 0.5.x release branch

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
