### PR TITLE
Backport: Add proxy.publicListenerPort config option [0.5.x]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 *
 */*
-!pkg/bin/linux_amd64/consul-ecs
 !dist/*

--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -75,15 +75,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    # This is broken I guess:
-    #   Error: Failed to fetch version metadata file HttpClientError: unsupported media type
-    #   requested, only [application/vnd+hashicorp.releases-api.v0+json
-    #   application/vnd+hashicorp.releases-api.v1+json] are available
-    #- name: Install Consul
-    #  uses: nickethier/action-setup-hashicorp-tool@main #TODO: update action when migrated to hc org
-    #  with:
-    #    product: consul
-    #    version: ${{ matrix.consul-version }}
     - name: Install Consul
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+FEATURES
+* mesh-init: Add `proxy.publicListenerPort` config option to set Envoy's public listener port.
+
 ## 0.5.1 (July 28, 2022)
 
 BUG FIXES:

--- a/config/resources/test_config_null_nested_fields.json
+++ b/config/resources/test_config_null_nested_fields.json
@@ -64,6 +64,7 @@
   },
   "proxy": {
     "config": null,
+    "publicListenerPort": null,
     "upstreams": [
       {
         "destinationType": null,

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -108,8 +108,8 @@
       }
     }
   },
-
   "proxy": {
+    "publicListenerPort": 21000,
     "config": {
       "data": "some-config-data"
     },

--- a/config/schema.json
+++ b/config/schema.json
@@ -245,6 +245,10 @@
           "description": "Object value that specifies an opaque JSON configuration. The JSON is stored and returned along with the service instance when called from the API.",
           "type": ["object", "null"]
         },
+        "publicListenerPort": {
+          "description": "The public listener port for Envoy used for service-to-service communication. Defaults to 20000.",
+          "type": ["integer", "null"]
+        },
         "upstreams": {
           "description": "The list of the upstream services that the proxy should create listeners for.",
           "type": ["array", "null"],

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -253,6 +253,7 @@ var (
 			Config: map[string]interface{}{
 				"data": "some-config-data",
 			},
+			PublicListenerPort: 21000,
 			Upstreams: []Upstream{
 				{
 					DestinationType:      api.UpstreamDestTypeService,
@@ -392,7 +393,8 @@ var (
 			Partition: "",
 		},
 		Proxy: &AgentServiceConnectProxyConfig{
-			Config: nil,
+			Config:             nil,
+			PublicListenerPort: 0,
 			Upstreams: []Upstream{
 				{
 					DestinationType:      "",
@@ -443,10 +445,11 @@ var (
 			Partition:         "",
 		},
 		Proxy: &AgentServiceConnectProxyConfig{
-			Config:      nil,
-			Upstreams:   nil,
-			MeshGateway: nil,
-			Expose:      nil,
+			Config:             nil,
+			PublicListenerPort: 0,
+			Upstreams:          nil,
+			MeshGateway:        nil,
+			Expose:             nil,
 		},
 	}
 )

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -387,7 +387,7 @@ func (c *Command) constructProxyRegistration(serviceRegistration *api.AgentServi
 	proxyRegistration.ID = fmt.Sprintf("%s-sidecar-proxy", serviceRegistration.ID)
 	proxyRegistration.Name = fmt.Sprintf("%s-sidecar-proxy", serviceRegistration.Name)
 	proxyRegistration.Kind = api.ServiceKindConnectProxy
-	proxyRegistration.Port = 20000
+	proxyRegistration.Port = c.config.Proxy.GetPublicListenerPort()
 	proxyRegistration.Meta = serviceRegistration.Meta
 	proxyRegistration.Tags = serviceRegistration.Tags
 	proxyRegistration.Proxy = c.config.Proxy.ToConsulType()
@@ -397,7 +397,7 @@ func (c *Command) constructProxyRegistration(serviceRegistration *api.AgentServi
 	proxyRegistration.Checks = []*api.AgentServiceCheck{
 		{
 			Name:                           "Proxy Public Listener",
-			TCP:                            "127.0.0.1:20000",
+			TCP:                            fmt.Sprintf("127.0.0.1:%d", proxyRegistration.Port),
 			Interval:                       "10s",
 			DeregisterCriticalServiceAfter: "10m",
 		},


### PR DESCRIPTION
## Changes proposed in this PR:

This backports https://github.com/hashicorp/consul-ecs/pull/118 to 0.5.x

## How I've tested this PR:

- [x] CI tests
- [x] Pending acceptance tests in https://github.com/hashicorp/terraform-aws-consul-ecs/pull/143

## How I expect reviewers to test this PR:

👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
