### PR TITLE
Backport: Add proxy.publicListenerPort config option [0.4.x]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 *
 */*
-!dist/linux/*
+!dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+FEATURES
+* mesh-init: Add `proxy.publicListenerPort` config option to set Envoy's public listener port.
+
 ## 0.4.1 (April 08, 2022)
 
 This is a patch release that keeps the consul-ecs project in sync with the
@@ -23,7 +28,7 @@ FEATURES
   shutdown after receing a TERM signal to support graceful shutdown in ECS.
   [[GH-48](https://github.com/hashicorp/consul-ecs/pull/48)]
 * Update `github.com/hashicorp/consul/api` package to `v1.12.0` to support
-  passing service registration fields for admin partitions and h2ping checks. 
+  passing service registration fields for admin partitions and h2ping checks.
   [[GH-59](https://github.com/hashicorp/consul-ecs/pull/59)]
 
 ## 0.2.0 (November 16, 2021)

--- a/config/resources/test_config_null_proxy_and_service_fields.json
+++ b/config/resources/test_config_null_proxy_and_service_fields.json
@@ -39,6 +39,7 @@
   },
   "proxy": {
     "config": null,
+    "publicListenerPort": null,
     "upstreams": [
       {
         "destinationType": null,

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -76,6 +76,7 @@
     "partition": "test-partition"
   },
   "proxy": {
+    "publicListenerPort": 21000,
     "config": {
       "data": "some-config-data"
     },

--- a/config/schema.json
+++ b/config/schema.json
@@ -202,6 +202,10 @@
           "description": "Object value that specifies an opaque JSON configuration. The JSON is stored and returned along with the service instance when called from the API.",
           "type": ["object", "null"]
         },
+        "publicListenerPort": {
+          "description": "The public listener port for Envoy used for service-to-service communication. Defaults to 20000.",
+          "type": ["integer", "null"]
+        },
         "upstreams": {
           "description": "The list of the upstream services that the proxy should create listeners for.",
           "type": ["array", "null"],

--- a/config/types.go
+++ b/config/types.go
@@ -4,6 +4,9 @@ package config
 
 import "github.com/hashicorp/consul/api"
 
+// DefaultPublicListenerPort is the default public listener port for sidecar proxies.
+const DefaultPublicListenerPort = 20000
+
 // Config is the top-level config object.
 type Config struct {
 	BootstrapDir         string                          `json:"bootstrapDir"`
@@ -142,8 +145,7 @@ func (w *AgentWeights) ToConsulType() *api.AgentWeights {
 
 // AgentServiceConnectProxyConfig defines the sidecar proxy configuration.
 //
-// NOTE:
-// For the proxy registration request (api.AgentServiceRegistration in Consul),
+// NOTE: For the proxy registration request (api.AgentServiceRegistration in Consul),
 //   - The Kind and Port are set by mesh-init, so these fields are not configurable.
 //   - The ID, Name, Tags, Meta, EnableTagOverride, and Weights fields are inferred or copied
 //     from the service registration by mesh-init.
@@ -161,10 +163,11 @@ func (w *AgentWeights) ToConsulType() *api.AgentWeights {
 //   - Checks are excluded. mesh-init automatically configures useful checks for the proxy.
 //   - TProxy is not supported on ECS, so the Mode and TransparentProxy fields are excluded.
 type AgentServiceConnectProxyConfig struct {
-	Config      map[string]interface{} `json:"config,omitempty"`
-	Upstreams   []Upstream             `json:"upstreams,omitempty"`
-	MeshGateway *MeshGatewayConfig     `json:"meshGateway,omitempty"`
-	Expose      *ExposeConfig          `json:"expose,omitempty"`
+	Config             map[string]interface{} `json:"config,omitempty"`
+	PublicListenerPort int                    `json:"publicListenerPort,omitempty"`
+	Upstreams          []Upstream             `json:"upstreams,omitempty"`
+	MeshGateway        *MeshGatewayConfig     `json:"meshGateway,omitempty"`
+	Expose             *ExposeConfig          `json:"expose,omitempty"`
 }
 
 func (a *AgentServiceConnectProxyConfig) ToConsulType() *api.AgentServiceConnectProxyConfig {
@@ -184,11 +187,18 @@ func (a *AgentServiceConnectProxyConfig) ToConsulType() *api.AgentServiceConnect
 	return result
 }
 
+func (a *AgentServiceConnectProxyConfig) GetPublicListenerPort() int {
+	if a.PublicListenerPort != 0 {
+		return a.PublicListenerPort
+	}
+	return DefaultPublicListenerPort
+
+}
+
 // Upstream describes an upstream Consul Service.
 //
-// NOTE:
-//   - The LocalBindSocketPath and LocalBindSocketMode are excluded. This level of control/restriction
-//     is not as relevant in ECS since each proxy runs in an isolated Docker container.
+// NOTE: The LocalBindSocketPath and LocalBindSocketMode are excluded. This level of control/restriction
+// is not as relevant in ECS since each proxy runs in an isolated Docker container.
 type Upstream struct {
 	DestinationType      api.UpstreamDestType   `json:"destinationType,omitempty"`
 	DestinationNamespace string                 `json:"destinationNamespace,omitempty"`

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -186,6 +186,7 @@ var (
 			Config: map[string]interface{}{
 				"data": "some-config-data",
 			},
+			PublicListenerPort: 21000,
 			Upstreams: []Upstream{
 				{
 					DestinationType:      api.UpstreamDestTypeService,
@@ -278,7 +279,8 @@ var (
 			Partition: "",
 		},
 		Proxy: &AgentServiceConnectProxyConfig{
-			Config: nil,
+			Config:             nil,
+			PublicListenerPort: 0,
 			Upstreams: []Upstream{
 				{
 					DestinationType:      "",
@@ -312,10 +314,11 @@ var (
 			Partition:         "",
 		},
 		Proxy: &AgentServiceConnectProxyConfig{
-			Config:      nil,
-			Upstreams:   nil,
-			MeshGateway: nil,
-			Expose:      nil,
+			Config:             nil,
+			PublicListenerPort: 0,
+			Upstreams:          nil,
+			MeshGateway:        nil,
+			Expose:             nil,
 		},
 	}
 )

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -215,7 +215,7 @@ func (c *Command) constructProxyRegistration(serviceRegistration *api.AgentServi
 	proxyRegistration.ID = fmt.Sprintf("%s-sidecar-proxy", serviceRegistration.ID)
 	proxyRegistration.Name = fmt.Sprintf("%s-sidecar-proxy", serviceRegistration.Name)
 	proxyRegistration.Kind = api.ServiceKindConnectProxy
-	proxyRegistration.Port = 20000
+	proxyRegistration.Port = c.config.Proxy.GetPublicListenerPort()
 	proxyRegistration.Meta = serviceRegistration.Meta
 	proxyRegistration.Tags = serviceRegistration.Tags
 	proxyRegistration.Proxy = c.config.Proxy.ToConsulType()
@@ -225,7 +225,7 @@ func (c *Command) constructProxyRegistration(serviceRegistration *api.AgentServi
 	proxyRegistration.Checks = []*api.AgentServiceCheck{
 		{
 			Name:                           "Proxy Public Listener",
-			TCP:                            "127.0.0.1:20000",
+			TCP:                            fmt.Sprintf("127.0.0.1:%d", proxyRegistration.Port),
 			Interval:                       "10s",
 			DeregisterCriticalServiceAfter: "10m",
 		},


### PR DESCRIPTION
## Changes proposed in this PR:

This backports https://github.com/hashicorp/consul-ecs/pull/118 to 0.4.x

## How I've tested this PR:

- [x] CI tests
- [x] Pending acceptance test in https://github.com/hashicorp/terraform-aws-consul-ecs/pull/144

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
