### PR TITLE
Fix version string on 0.4.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
             TEST_VERSION="$(docker run "${IMAGE_NAME}" version | awk '{print $2}')"
             echo "TEST_VERSION=${TEST_VERSION}"
             echo "version=${version}"
-            if [ "${TEST_VERSION}" != "${version}" ]; then
+            if [ "${TEST_VERSION}" != "v${version}" ]; then
               echo "Test FAILED"
               exit 1
             fi

--- a/version/version.go
+++ b/version/version.go
@@ -7,8 +7,7 @@ import (
 
 var (
 	// The git commit that was compiled. These will be filled in by the compiler.
-	GitCommit   string
-	GitDescribe string
+	GitCommit string
 
 	// The main version number that is being run at the moment.
 	//
@@ -26,25 +25,14 @@ var (
 // for displaying to humans.
 func GetHumanVersion() string {
 	version := Version
-	if GitDescribe != "" {
-		version = GitDescribe
-	}
 
-	release := VersionPrerelease
-	if GitDescribe == "" && release == "" {
-		release = "dev"
+	if VersionPrerelease != "" {
+		version += fmt.Sprintf("-%s", VersionPrerelease)
 	}
-
-	if release != "" {
-		if !strings.HasSuffix(version, "-"+release) {
-			// if we tagged a prerelease version then the release is in the version already
-			version += fmt.Sprintf("-%s", release)
-		}
-		if GitCommit != "" {
-			version += fmt.Sprintf(" (%s)", GitCommit)
-		}
+	if GitCommit != "" {
+		version += fmt.Sprintf(" (%s)", GitCommit)
 	}
 
 	// Strip off any single quotes added by the git information.
-	return strings.Replace(version, "'", "", -1)
+	return "v" + strings.Replace(version, "'", "", -1)
 }


### PR DESCRIPTION
## Changes proposed in this PR:

With the CRT changes added to 0.4.x, when `PreleaseVersion = ""`, the binary still appended `-dev` to the version string.

To fix this, I copied over the version.go from 0.5.x.

## How I've tested this PR:

CI tests

```
$ make dev
GOARCH=amd64 GOOS=darwin go build -ldflags "-X "github.com/hashicorp/consul-ecs/version.GitCommit=c541927+CHANGES"" -o dist/darwin/amd64/consul-ecs
$ dist/darwin/amd64/consul-ecs version
consul-ecs v0.4.3 (c541927+CHANGES)
$ make version
0.4.3
$ make docker
GOARCH=amd64 GOOS=linux go build -ldflags "-X "github.com/hashicorp/consul-ecs/version.GitCommit=c541927+CHANGES"" -o dist/linux/amd64/consul-ecs
export DOCKER_BUILDKIT=1; docker build --target release-default --platform linux/amd64 --tag consul-ecs/release-default:0.4.3 --build-arg=BIN_NAME=consul-ecs --build-arg=PRODUCT_VERSION=0.4.3 --build-arg=GIT_COMMIT=c541927 --build-arg=GIT_DIRTY=+CHANGES .
...

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
$ docker run consul-ecs/release-default:0.4.3 version
consul-ecs v0.4.3 (c541927+CHANGES)
```

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
