### PR TITLE
Support Consul 1.15.0

### DIFF
--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -53,12 +53,12 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.12.7
-        - 1.12.7+ent
-        - 1.13.4
-        - 1.13.4+ent
-        - 1.14.2
-        - 1.14.2+ent
+        - 1.13.6
+        - 1.13.6+ent
+        - 1.14.4
+        - 1.14.4+ent
+        - 1.15.0
+        - 1.15.0+ent
     env:
       TEST_RESULTS_DIR: /tmp/test-results
       GOTESTSUM_VERSION: 1.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 FEATURES
+* acl-controller: Add support for Consul 1.15.x.
+  [[GH-133]](https://github.com/hashicorp/consul-ecs/pull/133)
 * mesh-init: Add `proxy.publicListenerPort` config option to set Envoy's public listener port.
 
 BREAKING CHANGES

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -345,7 +345,6 @@ func TestTaskStateReconcile(t *testing.T) {
 					Partition: exp.Partition,
 				})
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "403 (ACL not found)")
 				require.Nil(t, tok)
 			}
 			for _, exp := range c.expExist {
@@ -473,7 +472,6 @@ func TestReconcileNamespaces(t *testing.T) {
 					}
 				}
 			} else {
-				require.Error(t, err)
 				require.Nil(t, xnsPolicy)
 			}
 		})

--- a/controller/resource_test.go
+++ b/controller/resource_test.go
@@ -345,6 +345,7 @@ func TestTaskStateReconcile(t *testing.T) {
 					Partition: exp.Partition,
 				})
 				require.Error(t, err)
+				require.Contains(t, err.Error(), "ACL not found")
 				require.Nil(t, tok)
 			}
 			for _, exp := range c.expExist {


### PR DESCRIPTION
## Changes proposed in this PR:
Some of the APIs in Consul 1.15 have been updated to return a `nil` error and an empty resource in the case of a not found scenario. Previous versions of Consul returned an error containing the string `403 (ACL not found)`. These difference caused startup failures in the `acl-controller`.

This PR adds support for Consul 1.15 while maintaining compatibility with the existing supported Consul versions.

## How I've tested this PR:
Unit tests

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests updated
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
