### PR TITLE
Add net-dial subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 FEATURES
+* net-dial: Add new `consul-ecs net-dial` subcommand to support ECS health checks when `nc`
+  is not available in the container image.
+  [[GH-135]](https://github.com/hashicorp/consul-ecs/pull/135)
 * acl-controller: Add support for Consul 1.15.x.
   [[GH-133]](https://github.com/hashicorp/consul-ecs/pull/133)
 * mesh-init: Add `proxy.publicListenerPort` config option to set Envoy's public listener port.

--- a/commands.go
+++ b/commands.go
@@ -11,6 +11,7 @@ import (
 	cmdEnvoyEntrypoint "github.com/hashicorp/consul-ecs/subcommand/envoy-entrypoint"
 	cmdHealthSync "github.com/hashicorp/consul-ecs/subcommand/health-sync"
 	cmdMeshInit "github.com/hashicorp/consul-ecs/subcommand/mesh-init"
+	cmdNetDial "github.com/hashicorp/consul-ecs/subcommand/net-dial"
 	cmdVersion "github.com/hashicorp/consul-ecs/subcommand/version"
 	"github.com/hashicorp/consul-ecs/version"
 	"github.com/mitchellh/cli"
@@ -40,6 +41,9 @@ func init() {
 		},
 		"app-entrypoint": func() (cli.Command, error) {
 			return &cmdAppEntrypoint.Command{UI: ui}, nil
+		},
+		"net-dial": func() (cli.Command, error) {
+			return &cmdNetDial.Command{UI: ui}, nil
 		},
 	}
 }

--- a/subcommand/net-dial/command.go
+++ b/subcommand/net-dial/command.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package netdial
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/mitchellh/cli"
+)
+
+type Command struct {
+	UI cli.Ui
+}
+
+func (c *Command) Run(args []string) int {
+	if len(args) != 2 {
+		c.UI.Error("invalid invocation, expected two positional args: <host> <port>")
+		return 1
+	}
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%s", args[0], args[1]))
+	if err != nil {
+		return 1
+	}
+	conn.Close()
+
+	return 0
+}
+
+func (c *Command) Synopsis() string {
+	return "Performs a simple health check by opening a TCP connection to a host and port"
+}
+
+func (c *Command) Help() string {
+	return `usage: consul-ecs net-dial <host> <port>
+
+Attempts to open a TCP connection to <host>:<port>.
+It returns with an exit code of 0 if the connection succeeds.
+If the connection fails for any reason, an exit code of 1 is returned.
+`
+}

--- a/subcommand/net-dial/command.go
+++ b/subcommand/net-dial/command.go
@@ -4,7 +4,6 @@
 package netdial
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/mitchellh/cli"
@@ -15,14 +14,14 @@ type Command struct {
 }
 
 func (c *Command) Run(args []string) int {
-	if len(args) != 2 {
-		c.UI.Error("invalid invocation, expected two positional args: <host> <port>")
+	if len(args) != 1 {
+		c.UI.Error("invalid invocation, expected one positional argument: <host>:<port>")
 		return 1
 	}
 
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%s", args[0], args[1]))
+	conn, err := net.Dial("tcp", args[0])
 	if err != nil {
-		return 1
+		return 2
 	}
 	conn.Close()
 
@@ -30,14 +29,14 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) Synopsis() string {
-	return "Performs a simple health check by opening a TCP connection to a host and port"
+	return "Checks for a TCP listener on a host"
 }
 
 func (c *Command) Help() string {
-	return `usage: consul-ecs net-dial <host> <port>
+	return `usage: consul-ecs net-dial <host>:<port>
 
 Attempts to open a TCP connection to <host>:<port>.
-It returns with an exit code of 0 if the connection succeeds.
-If the connection fails for any reason, an exit code of 1 is returned.
+An exit code of 0 is returned if the connection succeeds.
+A non zero exit code is returned if the connection fails for any reason.
 `
 }

--- a/subcommand/net-dial/command_test.go
+++ b/subcommand/net-dial/command_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package netdial
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetDial(t *testing.T) {
+	cases := map[string]struct {
+		code int
+	}{
+		"success": {code: 0},
+		"failure": {code: 1},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			cmd := Command{UI: ui}
+
+			l, err := net.Listen("tcp", "localhost:")
+			require.NoError(t, err)
+			args := strings.Split(l.Addr().String(), ":")
+			if c.code != 0 {
+				l.Close()
+			} else {
+				t.Cleanup(func() { l.Close() })
+			}
+
+			require.Equal(t, c.code, cmd.Run(args))
+		})
+	}
+}

--- a/subcommand/net-dial/command_test.go
+++ b/subcommand/net-dial/command_test.go
@@ -5,7 +5,6 @@ package netdial
 
 import (
 	"net"
-	"strings"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -14,23 +13,30 @@ import (
 
 func TestNetDial(t *testing.T) {
 	cases := map[string]struct {
-		code int
+		host   string
+		code   int
+		errStr string
 	}{
-		"success": {code: 0},
-		"failure": {code: 1},
+		"success":              {host: "localhost", code: 0},
+		"failure no listener":  {host: "localhost", code: 2},
+		"failure invalid args": {code: 1},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			ui := cli.NewMockUi()
 			cmd := Command{UI: ui}
 
-			l, err := net.Listen("tcp", "localhost:")
-			require.NoError(t, err)
-			args := strings.Split(l.Addr().String(), ":")
-			if c.code != 0 {
-				l.Close()
-			} else {
-				t.Cleanup(func() { l.Close() })
+			var args []string
+
+			if c.host != "" {
+				l, err := net.Listen("tcp", c.host+":")
+				require.NoError(t, err)
+				args = append(args, l.Addr().String())
+				if c.code != 0 {
+					l.Close()
+				} else {
+					t.Cleanup(func() { l.Close() })
+				}
 			}
 
 			require.Equal(t, c.code, cmd.Run(args))


### PR DESCRIPTION
## Changes proposed in this PR:
This PR adds a `net-dial <host> <port>` subcommand to `consul-ecs`. The Consul ECS `mesh-task` and `gateway-task` previously used `nc` to perform an ECS health check. Newer versions of the `envoy` Docker image do not contain the `nc` command, which causes task startup failures when attempting to upgrade to newer versions of Envoy.

The `consul-ecs` binary is already available to the Envoy `sidecar-proxy` container because it is mounted at `/consul/consul-ecs` and used to generate the Envoy bootstrap config. The new `net-dial` subcommand performs the same check that was previously performed by `nc`; that is, it opens a tcp connection on `localhost:<port>`. If the connection succeeds, it returns 0; otherwise, it returns 1.

## How I've tested this PR:
- New unit tests :heavy_check_mark: 
- Local Consul ECS acceptance tests with:
  - `envoyproxy/envoy:v1.23.1` Docker image :heavy_check_mark: 
  - `envoyproxy/envoy-distroless:v1.23.1` Docker image :heavy_check_mark: 

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
