### PR TITLE
Support to gracefully shutdown control-plane

### DIFF
--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/consul-ecs/version"
 )
 
@@ -100,6 +101,22 @@ func (e ECSTaskMeta) NodeIP() string {
 		ip = e.Containers[0].Networks[0].IPv4Addresses[0]
 	}
 	return ip
+}
+
+func (e ECSTaskMeta) HasContainerStopped(name string) bool {
+	stopped := true
+	for _, c := range e.Containers {
+		if c.Name == name && !c.HasStopped() {
+			stopped = false
+			break
+		}
+	}
+	return stopped
+}
+
+func (c ECSTaskMetaContainer) HasStopped() bool {
+	return c.DesiredStatus == ecs.DesiredStatusStopped &&
+		c.KnownStatus == ecs.DesiredStatusStopped
 }
 
 func ECSTaskMetadata() (ECSTaskMeta, error) {

--- a/subcommand/envoy-entrypoint/task-monitor.go
+++ b/subcommand/envoy-entrypoint/task-monitor.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/go-hclog"
 )
@@ -96,7 +95,7 @@ func (t *AppContainerMonitor) waitForSIGTERM() bool {
 func allAppContainersStopped(taskMeta awsutil.ECSTaskMeta) bool {
 	allStopped := true
 	for _, container := range taskMeta.Containers {
-		if isApplication(container) && !isStopped(container) {
+		if isApplication(container) && !container.HasStopped() {
 			allStopped = false
 		}
 	}
@@ -106,9 +105,4 @@ func allAppContainersStopped(taskMeta awsutil.ECSTaskMeta) bool {
 func isApplication(container awsutil.ECSTaskMetaContainer) bool {
 	_, ok := nonAppContainers[container.Name]
 	return !ok
-}
-
-func isStopped(container awsutil.ECSTaskMetaContainer) bool {
-	return container.DesiredStatus == ecs.DesiredStatusStopped &&
-		container.KnownStatus == ecs.DesiredStatusStopped
 }

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -259,12 +259,6 @@ func (c *Command) realRun() error {
 				}
 			}
 
-			// Cleanup bootstrap directory
-			err = os.RemoveAll(c.config.BootstrapDir)
-			if err != nil {
-				c.log.Error("error cleaning up bootstrap directory %s", err.Error())
-				result = multierror.Append(result, err)
-			}
 			return result
 		}
 	}

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -536,7 +536,7 @@ func TestRun(t *testing.T) {
 			// Verify with retries that the checks have reached the expected state
 			assertHealthChecks(t, consulClient, expectedServiceChecks, expectedProxyCheck)
 
-			stopDataplaneContainer(t, taskMetadataResponse)
+			stopDataplaneContainer(taskMetadataResponse)
 			taskMetaRespStr, err = constructTaskMetaResponseString(taskMetadataResponse)
 			require.NoError(t, err)
 			currentTaskMetaResp.Store(taskMetaRespStr)
@@ -825,7 +825,7 @@ func TestGateway(t *testing.T) {
 			expectedCheck.Status = api.HealthCritical
 			assertHealthChecks(t, consulClient, nil, expectedCheck)
 
-			stopDataplaneContainer(t, taskMetadataResponse)
+			stopDataplaneContainer(taskMetadataResponse)
 			taskMetadataRespStr, err = constructTaskMetaResponseString(taskMetadataResponse)
 			require.NoError(t, err)
 			currentTaskMetaResp.Store(taskMetadataRespStr)
@@ -1011,7 +1011,7 @@ func constructContainerResponse(name, health string) awsutil.ECSTaskMetaContaine
 
 // stopDataplaneContainer marks the dataplane container's status as STOPPED in the
 // task meta response
-func stopDataplaneContainer(t *testing.T, taskMetadataResp *awsutil.ECSTaskMeta) {
+func stopDataplaneContainer(taskMetadataResp *awsutil.ECSTaskMeta) {
 	index := -1
 	for i, c := range taskMetadataResp.Containers {
 		if isDataplaneContainer(c) {

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -536,6 +536,14 @@ func TestRun(t *testing.T) {
 			// Verify with retries that the checks have reached the expected state
 			assertHealthChecks(t, consulClient, expectedServiceChecks, expectedProxyCheck)
 
+			stopDataplaneContainer(t, taskMetadataResponse)
+			taskMetaRespStr, err = constructTaskMetaResponseString(taskMetadataResponse)
+			require.NoError(t, err)
+			currentTaskMetaResp.Store(taskMetaRespStr)
+
+			assertDeregistration(t, consulClient, expectedServiceName, expectedProxy.ServiceName)
+			assertDirectoryCleanup(t, envoyBootstrapDir)
+
 			cmd.cancel()
 		})
 	}
@@ -543,27 +551,12 @@ func TestRun(t *testing.T) {
 
 func TestGateway(t *testing.T) {
 	var (
-		family               = "family-name-mesh-gateway"
-		serviceName          = "service-name-mesh-gateway"
-		taskARN              = "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
-		taskIP               = "10.1.2.3"
-		publicIP             = "255.1.2.3"
-		taskDNSName          = "test-dns-name"
-		taskMetadataResponse = &awsutil.ECSTaskMeta{
-			Cluster: "test",
-			TaskARN: taskARN,
-			Family:  family,
-			Containers: []awsutil.ECSTaskMetaContainer{
-				{
-					Networks: []awsutil.ECSTaskMetaNetwork{
-						{
-							IPv4Addresses:  []string{taskIP},
-							PrivateDNSName: taskDNSName,
-						},
-					},
-				},
-			},
-		}
+		family           = "family-name-mesh-gateway"
+		serviceName      = "service-name-mesh-gateway"
+		taskARN          = "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+		taskIP           = "10.1.2.3"
+		publicIP         = "255.1.2.3"
+		taskDNSName      = "test-dns-name"
 		expectedTaskMeta = map[string]string{
 			"task-id":  "abcdef",
 			"task-arn": taskARN,
@@ -688,6 +681,22 @@ func TestGateway(t *testing.T) {
 			if c.config.ConsulLogin.Enabled {
 				// Enable ACLs to test with the auth method
 				srvConfig = testutil.ConsulACLConfigFn
+			}
+
+			taskMetadataResponse := &awsutil.ECSTaskMeta{
+				Cluster: "test",
+				TaskARN: taskARN,
+				Family:  family,
+				Containers: []awsutil.ECSTaskMetaContainer{
+					{
+						Networks: []awsutil.ECSTaskMetaNetwork{
+							{
+								IPv4Addresses:  []string{taskIP},
+								PrivateDNSName: taskDNSName,
+							},
+						},
+					},
+				},
 			}
 
 			server, apiCfg := testutil.ConsulServer(t, srvConfig)
@@ -815,6 +824,14 @@ func TestGateway(t *testing.T) {
 
 			expectedCheck.Status = api.HealthCritical
 			assertHealthChecks(t, consulClient, nil, expectedCheck)
+
+			stopDataplaneContainer(t, taskMetadataResponse)
+			taskMetadataRespStr, err = constructTaskMetaResponseString(taskMetadataResponse)
+			require.NoError(t, err)
+			currentTaskMetaResp.Store(taskMetadataRespStr)
+
+			assertDeregistration(t, consulClient, "", expectedService.ServiceName)
+			assertDirectoryCleanup(t, c.config.BootstrapDir)
 
 			cmd.cancel()
 		})
@@ -944,6 +961,26 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 	})
 }
 
+func assertDeregistration(t *testing.T, consulClient *api.Client, serviceName, proxyName string) {
+	timer := &retry.Timer{Timeout: 5 * time.Second, Wait: 500 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		if serviceName != "" {
+			serviceInstances, _, err := consulClient.Catalog().Service(serviceName, "", nil)
+			require.NoError(r, err)
+			require.Equal(r, 0, len(serviceInstances))
+		}
+
+		serviceInstances, _, err := consulClient.Catalog().Service(proxyName, "", nil)
+		require.NoError(r, err)
+		require.Equal(r, 0, len(serviceInstances))
+	})
+}
+
+func assertDirectoryCleanup(t *testing.T, dir string) {
+	_, err := os.ReadDir(dir)
+	require.Error(t, err)
+}
+
 func injectContainersIntoTaskMetaResponse(t *testing.T, skipDataplaneContainer, ignoreMissingContainers bool, taskMetadataResponse *awsutil.ECSTaskMeta, healthSyncContainers map[string]healthSyncContainerMetaData) string {
 	var taskMetaContainersResponse []awsutil.ECSTaskMetaContainer
 	if !ignoreMissingContainers && !skipDataplaneContainer {
@@ -970,6 +1007,24 @@ func constructContainerResponse(name, health string) awsutil.ECSTaskMetaContaine
 			Status: health,
 		},
 	}
+}
+
+// stopDataplaneContainer marks the dataplane container's status as STOPPED in the
+// task meta response
+func stopDataplaneContainer(t *testing.T, taskMetadataResp *awsutil.ECSTaskMeta) {
+	index := -1
+	for i, c := range taskMetadataResp.Containers {
+		if isDataplaneContainer(c) {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		return
+	}
+
+	taskMetadataResp.Containers[index].DesiredStatus = ecs.DesiredStatusStopped
+	taskMetadataResp.Containers[index].KnownStatus = ecs.DesiredStatusStopped
 }
 
 func constructTaskMetaResponseString(resp *awsutil.ECSTaskMeta) (string, error) {

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -1019,7 +1019,7 @@ func stopDataplaneContainer(taskMetadataResp *awsutil.ECSTaskMeta) {
 			break
 		}
 	}
-	if index == -1 {
+	if index <= -1 {
 		return
 	}
 

--- a/subcommand/mesh-init/dataplane-monitor.go
+++ b/subcommand/mesh-init/dataplane-monitor.go
@@ -1,0 +1,99 @@
+package meshinit
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
+	"github.com/hashicorp/go-hclog"
+)
+
+type dataplaneMonitor struct {
+	ctx context.Context
+	log hclog.Logger
+
+	doneCh chan struct{}
+}
+
+func newDataplaneMonitor(ctx context.Context, logger hclog.Logger) *dataplaneMonitor {
+	return &dataplaneMonitor{
+		ctx:    ctx,
+		log:    logger,
+		doneCh: make(chan struct{}, 1),
+	}
+}
+
+func (d *dataplaneMonitor) done() chan struct{} {
+	return d.doneCh
+}
+
+// Run will wake up when SIGTERM is received. Then, it polls task metadata
+// until the dataplane container stops. Use the Done() channel to wait
+// until it has finished.
+func (d *dataplaneMonitor) run() {
+	defer close(d.doneCh)
+
+	if !d.waitForSIGTERM() {
+		d.doneCh <- struct{}{}
+		return
+	}
+
+	d.log.Info("waiting for dataplane container to stop")
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-time.After(1 * time.Second):
+			taskMeta, err := awsutil.ECSTaskMetadata()
+			if err != nil {
+				d.log.Error("fetching task metadata", "err", err.Error())
+				break
+			}
+
+			if hasDataplaneContainerStopped(taskMeta) {
+				d.log.Info("dataplane container has stopped, terminating control plane")
+				d.doneCh <- struct{}{}
+				return
+			}
+		}
+	}
+}
+
+func (d *dataplaneMonitor) waitForSIGTERM() bool {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+	defer signal.Stop(sigs)
+
+	for {
+		select {
+		case <-sigs:
+			return true
+		case <-d.ctx.Done():
+			return false
+		}
+	}
+}
+
+func hasDataplaneContainerStopped(taskMeta awsutil.ECSTaskMeta) bool {
+	stopped := true
+	for _, container := range taskMeta.Containers {
+		if isDataplaneContainer(container) && !isStopped(container) {
+			stopped = false
+		}
+	}
+	return stopped
+}
+
+func isDataplaneContainer(container awsutil.ECSTaskMetaContainer) bool {
+	return container.Name == config.ConsulDataplaneContainerName
+}
+
+func isStopped(container awsutil.ECSTaskMetaContainer) bool {
+	return container.DesiredStatus == ecs.DesiredStatusStopped &&
+		container.KnownStatus == ecs.DesiredStatusStopped
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds a monitor to keep track of the dataplane container's status. This is needed to gracefully shutdown the control plane after the dataplane is shutdown. The monitor only wakes up after SIGTERM and polls ECS to get the status of the dataplane container. Once it has confirmed that the dataplane container has stopped, it signals control plane to begin it's graceful shutdown flow.
- Adds support to deregister proxies and services during shutdown
- Adds support for consul logout
- Adds support to cleanup all the config files from the `bootstrapDirectory`

## How I've tested this PR:

Unit tests

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added(Not needed)

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
