### PR TITLE
Deprecate mesh-init in favour of control-plane

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ LABEL description="consul-ecs provides first-class integration between Consul an
 # Create a non-root user to run the software.
 RUN addgroup $BIN_NAME && \
     adduser -S -G $BIN_NAME $BIN_NAME && \
-    # Changing the owner of /consul to NAME allows mesh-init to run as NAME rather
+    # Changing the owner of /consul to NAME allows control-plane to run as NAME rather
     # than root. See
     # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html
     # for more information

--- a/commands.go
+++ b/commands.go
@@ -8,9 +8,9 @@ import (
 
 	cmdController "github.com/hashicorp/consul-ecs/subcommand/acl-controller"
 	cmdAppEntrypoint "github.com/hashicorp/consul-ecs/subcommand/app-entrypoint"
+	cmdControlPlane "github.com/hashicorp/consul-ecs/subcommand/control-plane"
 	cmdEnvoyEntrypoint "github.com/hashicorp/consul-ecs/subcommand/envoy-entrypoint"
 	cmdHealthSync "github.com/hashicorp/consul-ecs/subcommand/health-sync"
-	cmdMeshInit "github.com/hashicorp/consul-ecs/subcommand/mesh-init"
 	cmdNetDial "github.com/hashicorp/consul-ecs/subcommand/net-dial"
 	cmdVersion "github.com/hashicorp/consul-ecs/subcommand/version"
 	"github.com/hashicorp/consul-ecs/version"
@@ -27,8 +27,8 @@ func init() {
 		"version": func() (cli.Command, error) {
 			return &cmdVersion.Command{UI: ui, Version: version.GetHumanVersion()}, nil
 		},
-		"mesh-init": func() (cli.Command, error) {
-			return &cmdMeshInit.Command{UI: ui}, nil
+		"control-plane": func() (cli.Command, error) {
+			return &cmdControlPlane.Command{UI: ui}, nil
 		},
 		"acl-controller": func() (cli.Command, error) {
 			return &cmdController.Command{UI: ui}, nil

--- a/config/schema.json
+++ b/config/schema.json
@@ -11,7 +11,7 @@
       "enum": ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", null]
     },
     "bootstrapDir": {
-      "description": "The directory at which to mount the shared volume where dataplane configuration is written by `consul-ecs control-plane`.",
+      "description": "The directory at which to mount the shared volume where Consul dataplane configuration is written by `consul-ecs control-plane`.",
       "type": "string",
       "minLength": 1
     },

--- a/config/schema.json
+++ b/config/schema.json
@@ -6,12 +6,12 @@
   "type": "object",
   "properties": {
     "logLevel": {
-      "description": "Sets the log level for the `consul-ecs mesh-init` and `consul-ecs health-sync` commands. Defaults to `INFO`.",
+      "description": "Sets the log level for the `consul-ecs control-plane` and `consul-ecs health-sync` commands. Defaults to `INFO`.",
       "type": ["string", "null"],
       "enum": ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", null]
     },
     "bootstrapDir": {
-      "description": "The directory at which to mount the shared volume where Envoy bootstrap configuration is written by `consul-ecs mesh-init`.",
+      "description": "The directory at which to mount the shared volume where dataplane configuration is written by `consul-ecs control-plane`.",
       "type": "string",
       "minLength": 1
     },

--- a/config/types.go
+++ b/config/types.go
@@ -168,7 +168,7 @@ func (c *ConsulServers) UnmarshalJSON(data []byte) error {
 // ServiceRegistration configures the Consul service registration.
 //
 // NOTE:
-// - The Kind and Id fields are set by mesh-init during service/proxy registration.
+// - The Kind and Id fields are set by control-plane during service/proxy registration.
 // - The Address field excluded. The agent's address (task ip) should always be used in ECS.
 // - The Connect field is not supported:
 //   - No Connect-native support for now. We assume Envoy is used.
@@ -219,21 +219,21 @@ func (w *AgentWeights) ToConsulType() api.AgentWeights {
 // AgentServiceConnectProxyConfig defines the sidecar proxy configuration.
 //
 // NOTE: For the proxy registration request (api.AgentServiceRegistration in Consul),
-//   - The Kind and Port are set by mesh-init, so these fields are not configurable.
+//   - The Kind and Port are set by control-plane, so these fields are not configurable.
 //   - The ID, Name, Tags, Meta, EnableTagOverride, and Weights fields are inferred or copied
-//     from the service registration by mesh-init.
+//     from the service registration by control-plane.
 //   - The bind address is always localhost in ECS, so the Address and SocketPath are excluded.
 //   - The Connect field is excluded. Since the sidecar proxy is being used, it's not a Connect-native
 //     service, and we don't need the nested proxy config included in the Connect field.
-//   - The Partition field is excluded. mesh-init will use the partition from the service registration.
-//   - The Namespace field is excluded. mesh-init will use the namespace from the service registration.
+//   - The Partition field is excluded. control-plane will use the partition from the service registration.
+//   - The Namespace field is excluded. control-plane will use the namespace from the service registration.
 //   - There's not a use-case for specifying TaggedAddresses with Consul ECS, and Enable
 //
 // For the proxy configuration (api.AgentServiceConnectProxyConfig in Consul),
 //   - The DestinationServiceName, DestinationServiceId, LocalServiceAddress, and LocalServicePort
-//     are all set by mesh-init, based on the service configuration.
-//   - The LocalServiceSocketPath is excluded, since it would conflict with the address/port set by mesh-init.
-//   - Checks are excluded. mesh-init automatically configures useful checks for the proxy.
+//     are all set by control-plane, based on the service configuration.
+//   - The LocalServiceSocketPath is excluded, since it would conflict with the address/port set by control-plane.
+//   - Checks are excluded. control-plane automatically configures useful checks for the proxy.
 //   - TProxy is not supported on ECS, so the Mode and TransparentProxy fields are excluded.
 type AgentServiceConnectProxyConfig struct {
 	Config             map[string]interface{} `json:"config,omitempty"`

--- a/subcommand/control-plane/checks.go
+++ b/subcommand/control-plane/checks.go
@@ -1,4 +1,4 @@
-package meshinit
+package controlplane
 
 import (
 	"fmt"

--- a/subcommand/control-plane/checks_test.go
+++ b/subcommand/control-plane/checks_test.go
@@ -1,4 +1,4 @@
-package meshinit
+package controlplane
 
 import (
 	"testing"

--- a/subcommand/control-plane/command.go
+++ b/subcommand/control-plane/command.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package meshinit
+package controlplane
 
 import (
 	"context"

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package meshinit
+package controlplane
 
 import (
 	"context"

--- a/subcommand/control-plane/dataplane-monitor.go
+++ b/subcommand/control-plane/dataplane-monitor.go
@@ -1,4 +1,4 @@
-package meshinit
+package controlplane
 
 import (
 	"context"

--- a/subcommand/envoy-entrypoint/command_unix_test.go
+++ b/subcommand/envoy-entrypoint/command_unix_test.go
@@ -117,7 +117,7 @@ func TestRun(t *testing.T) {
 						"some-app-container",
 						"consul-client",
 						"consul-ecs-health-sync",
-						"consul-ecs-mesh-init",
+						"consul-ecs-control-plane",
 						"sidecar-proxy",
 					)
 

--- a/subcommand/envoy-entrypoint/task-monitor.go
+++ b/subcommand/envoy-entrypoint/task-monitor.go
@@ -19,10 +19,10 @@ import (
 
 var (
 	nonAppContainers = map[string]struct{}{
-		"consul-client":          {},
-		"sidecar-proxy":          {},
-		"consul-ecs-health-sync": {},
-		"consul-ecs-mesh-init":   {},
+		"consul-client":            {},
+		"sidecar-proxy":            {},
+		"consul-ecs-health-sync":   {},
+		"consul-ecs-control-plane": {},
 	}
 )
 

--- a/testutil/consul.go
+++ b/testutil/consul.go
@@ -44,7 +44,7 @@ func ConsulServer(t *testing.T, cb ServerConfigCallback) (*testutil.TestServer, 
 		cfg.Token = server.Config.ACL.Tokens.InitialManagement
 	}
 
-	// Set CONSUL_HTTP_ADDR for mesh-init. Required to invoke the consul binary (i.e. in mesh-init).
+	// Set CONSUL_HTTP_ADDR for control-plane. Required to invoke the consul binary (i.e. in control-plane).
 	require.NoError(t, os.Setenv("CONSUL_HTTP_ADDR", server.HTTPAddr))
 	t.Cleanup(func() {
 		_ = os.Unsetenv("CONSUL_HTTP_ADDR")


### PR DESCRIPTION
## Changes proposed in this PR:
- Just renames the `mesh-init` package names to `control-plane`
- The mesh-init command is also replaced by the `control-plane` command

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added - Not needed since this is just a rename
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
