### PR TITLE
Controller changes  to support new ECS architecture - Part 1

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	defaultGRPCPort = 8503
-	defaultHTTPPort = 8501
+	defaultGRPCPort    = 8503
+	defaultHTTPPort    = 8501
+	defaultIAMRolePath = "/consul-ecs/"
 
 	// Cert used for internal RPC communication to the servers
 	consulGRPCCACertPemEnvVar = "CONSUL_GRPC_CACERT_PEM"

--- a/config/resources/test_config_additional_properties_service.json
+++ b/config/resources/test_config_additional_properties_service.json
@@ -19,6 +19,11 @@
       "stsEndpoint": "https://sts.bogus-east-2.example.com",
       "serverIdHeaderValue": "my.consul.example.com"
     },
+    "controller": {
+      "iamRolePath": "/consul-iam/",
+      "partition": "default",
+      "partitionsEnabled": true
+    },
     "consulServers": {
       "hosts": "consul.dc1",
       "https": true,

--- a/config/resources/test_config_empty_fields.json
+++ b/config/resources/test_config_empty_fields.json
@@ -7,6 +7,7 @@
   "consulServers": {
     "hosts": ""
   },
+  "controller": {},
   "service": {
     "name": "",
     "tags": [],

--- a/config/resources/test_config_null_nested_fields.json
+++ b/config/resources/test_config_null_nested_fields.json
@@ -22,6 +22,11 @@
     "tlsServerName": null,
     "skipServerWatch": null
   },
+  "controller": {
+    "iamRolePath": null,
+    "partition": null,
+    "partitionsEnabled": null
+  },
   "service": {
     "name": null,
     "tags": null,

--- a/config/resources/test_config_null_top_level_fields.json
+++ b/config/resources/test_config_null_top_level_fields.json
@@ -5,6 +5,7 @@
   "consulHTTPAddr": null,
   "consulCACertFile": null,
   "consulLogin": null,
+  "controller": null,
   "consulServers": {
     "hosts": "",
     "https": null,

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -6,6 +6,11 @@
   "logLevel": "DEBUG",
   "consulHTTPAddr": "consul.example.com",
   "consulCACertFile": "/consul/consul-ca-cert.pem",
+  "controller": {
+    "iamRolePath": "/consul-iam/",
+    "partition": "default",
+    "partitionsEnabled": true
+  },
   "consulLogin": {
     "enabled": true,
     "method": "my-auth-method",

--- a/config/schema.json
+++ b/config/schema.json
@@ -67,6 +67,25 @@
       },
       "additionalProperties": false
     },
+    "controller": {
+      "description": "Configuration for the `consul-ecs controller` command.",
+      "type": ["object", "null"],
+      "properties": {
+        "iamRolePath": {
+          "description": "IAM roles at this path will be trusted by the Consul IAM auth method configured by the controller. Defaults to `/consul-ecs/`.",
+          "type": ["string", "null"]
+        },
+        "partitionsEnabled": {
+          "description": "Enables support for Consul partitions and namespaces [Consul Enterprise].",
+          "type": ["boolean", "null"]
+        },
+        "partition": {
+          "description": "The Consul partition name that the controller will use. Defaults to the `default` partition [Consul Enterprise].",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
     "consulServers": {
       "description": "Configuration for the Consul servers.",
       "type": "object",

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -128,6 +128,11 @@ func OpenFile(t *testing.T, path string) string {
 var (
 	expectedConfig = &Config{
 		LogLevel: "",
+		Controller: Controller{
+			IAMRolePath:       "",
+			PartitionsEnabled: false,
+			Partition:         "",
+		},
 		ConsulLogin: ConsulLogin{
 			Enabled:    false,
 			Method:     "",
@@ -174,6 +179,11 @@ var (
 		LogLevel:             "DEBUG",
 		ConsulHTTPAddr:       "consul.example.com",
 		ConsulCACertFile:     "/consul/consul-ca-cert.pem",
+		Controller: Controller{
+			PartitionsEnabled: true,
+			Partition:         "default",
+			IAMRolePath:       "/consul-iam/",
+		},
 		ConsulServers: ConsulServers{
 			GRPCPort:        8503,
 			Hosts:           "consul.dc1",
@@ -283,6 +293,11 @@ var (
 		LogLevel:             "",
 		ConsulHTTPAddr:       "",
 		ConsulCACertFile:     "",
+		Controller: Controller{
+			IAMRolePath:       defaultIAMRolePath,
+			PartitionsEnabled: false,
+			Partition:         "",
+		},
 		ConsulServers: ConsulServers{
 			GRPCPort:        8503,
 			Hosts:           "",
@@ -332,6 +347,11 @@ var (
 		HealthSyncContainers: nil,
 		ConsulHTTPAddr:       "",
 		ConsulCACertFile:     "",
+		Controller: Controller{
+			IAMRolePath:       defaultIAMRolePath,
+			PartitionsEnabled: false,
+			Partition:         "",
+		},
 		ConsulLogin: ConsulLogin{
 			Enabled:             false,
 			Datacenter:          "",
@@ -414,6 +434,11 @@ var (
 			Region:              "",
 			STSEndpoint:         "",
 			ServerIDHeaderValue: "",
+		},
+		Controller: Controller{
+			IAMRolePath:       defaultIAMRolePath,
+			PartitionsEnabled: false,
+			Partition:         "",
 		},
 		ConsulServers: ConsulServers{
 			GRPCPort:        8503,

--- a/subcommand/acl-controller/command.go
+++ b/subcommand/acl-controller/command.go
@@ -6,19 +6,22 @@ package aclcontroller
 import (
 	"bytes"
 	"context"
-	"flag"
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul-ecs/controller"
 	"github.com/hashicorp/consul-ecs/logging"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
@@ -26,12 +29,6 @@ import (
 )
 
 const (
-	flagIAMRolePath       = "iam-role-path"
-	flagPartition         = "partition"
-	flagPartitionsEnabled = "partitions-enabled"
-
-	consulCACertEnvVar = "CONSUL_CACERT_PEM"
-
 	// Binding rules don't support a '/' character, so we need compatible IAM role tag names.
 	authMethodServiceNameTag = "consul.hashicorp.com.service-name"
 	authMethodNamespaceTag   = "consul.hashicorp.com.namespace"
@@ -40,42 +37,44 @@ const (
 	anonTokenID    = "00000000-0000-0000-0000-000000000002"
 	anonPolicyName = "anonymous-token-policy"
 	anonPolicyDesc = "Anonymous token Policy"
+
+	// Token containing `acl:write`, `operator:write` and `node:write` privileges against the server
+	bootstrapTokenEnvVar = "CONSUL_HTTP_TOKEN"
 )
 
 type Command struct {
-	UI                    cli.Ui
-	flagIAMRolePath       string
-	flagPartition         string
-	flagPartitionsEnabled bool
+	UI cli.Ui
 
-	log     hclog.Logger
-	flagSet *flag.FlagSet
-	once    sync.Once
-	ctx     context.Context
+	config *config.Config
+	log    hclog.Logger
+	once   sync.Once
+	ctx    context.Context
 
 	logging.LogOpts
 }
 
 func (c *Command) init() {
-	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
-	c.flagSet.StringVar(&c.flagIAMRolePath, flagIAMRolePath, "", "IAM roles at this path will be trusted by the IAM Auth method created by the controller")
-	c.flagSet.StringVar(&c.flagPartition, flagPartition, "", "The Consul partition name that the ACL controller will use for ACL resources. If not provided will default to the `default` partition [Consul Enterprise]")
-	c.flagSet.BoolVar(&c.flagPartitionsEnabled, flagPartitionsEnabled, false, "Enables support for Consul partitions and namespaces [Consul Enterprise]")
-
-	logging.Merge(c.flagSet, c.LogOpts.Flags())
 	c.ctx = context.Background()
 }
 
 func (c *Command) Run(args []string) int {
 	c.once.Do(c.init)
 
-	if err := c.flagSet.Parse(args); err != nil {
+	if len(args) > 0 {
+		c.UI.Error(fmt.Sprintf("unexpected argument: %v", args[0]))
 		return 1
 	}
 
-	c.log = c.LogOpts.Logger()
+	config, err := config.FromEnv()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("invalid config: %s", err))
+		return 1
+	}
+	c.config = config
 
-	err := c.run()
+	c.log = logging.FromConfig(c.config).Logger()
+
+	err = c.run()
 	if err != nil {
 		c.log.Error(err.Error())
 		return 1
@@ -102,19 +101,39 @@ func (c *Command) run() error {
 	// Set up ECS client.
 	ecsClient := ecs.New(clientSession)
 
-	cfg := api.DefaultConfig()
-	if caCert := os.Getenv(consulCACertEnvVar); caCert != "" {
-		cfg.TLSConfig = api.TLSConfig{
-			CAPem: []byte(caCert),
-		}
+	serverConnMgrCfg, err := c.config.ConsulServerConnMgrConfig(ecsMeta)
+	if err != nil {
+		return fmt.Errorf("constructing server connection manager config: %s", err)
+	}
+
+	watcher, err := discovery.NewWatcher(c.ctx, serverConnMgrCfg, c.log)
+	if err != nil {
+		return fmt.Errorf("unable to create consul server watcher: %s", err)
+	}
+
+	go watcher.Run()
+	defer watcher.Stop()
+
+	state, err := watcher.State()
+	if err != nil {
+		return fmt.Errorf("unable to fetch consul server watcher state: %s", err)
+	}
+
+	// Client config for the client that talks directly to the server agent
+	cfg := c.config.ClientConfig()
+	cfg.Address = net.JoinHostPort(state.Address.IP.String(), strconv.FormatInt(int64(c.config.ConsulServers.HTTPPort), 10))
+
+	token := os.Getenv(bootstrapTokenEnvVar)
+	if token != "" {
+		cfg.Token = token
 	}
 
 	consulClient, err := api.NewClient(cfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("constructing consul client from config: %s", err)
 	}
 
-	if err := c.upsertConsulResources(consulClient, ecsMeta); err != nil {
+	if err := c.upsertConsulResources(consulClient, ecsMeta, clusterArn); err != nil {
 		return err
 	}
 
@@ -122,7 +141,7 @@ func (c *Command) run() error {
 		ECSClient:    ecsClient,
 		ConsulClient: consulClient,
 		ClusterARN:   clusterArn,
-		Partition:    c.flagPartition,
+		Partition:    c.config.Controller.Partition,
 		Log:          c.log,
 	}
 	ctrl := controller.Controller{
@@ -149,28 +168,17 @@ func (c *Command) Help() string {
 // and the necessary binding rules.
 // If mesh federation via mesh gateways is enabled the anonymous token will be updated with the
 // necessary read permissions.
-func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsutil.ECSTaskMeta) error {
+func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsutil.ECSTaskMeta, clusterARN string) error {
 	account, err := ecsMeta.AccountID()
 	if err != nil {
 		return err
 	}
-	path := strings.Trim(c.flagIAMRolePath, "/")
+	path := strings.Trim(c.config.Controller.IAMRolePath, "/")
 	if path != "" {
 		path += "/"
 	}
 	boundArnPattern := fmt.Sprintf("arn:aws:iam::%s:role/%s*", account, path)
 
-	clientAuthMethod := &api.ACLAuthMethod{
-		Name:        "iam-ecs-client-token",
-		Type:        "aws-iam",
-		Description: "AWS IAM auth method for ECS client tokens",
-		Config: map[string]interface{}{
-			// Trust a wildcard - any roles at a path.
-			"BoundIAMPrincipalARNs": []string{boundArnPattern},
-			// Must be true to use a wildcard
-			"EnableIAMEntityDetails": true,
-		},
-	}
 	serviceAuthMethod := &api.ACLAuthMethod{
 		Name:        "iam-ecs-service-token",
 		Type:        "aws-iam",
@@ -186,22 +194,13 @@ func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsuti
 			},
 		},
 	}
-	if c.flagPartitionsEnabled {
+	if c.config.Controller.PartitionsEnabled {
 		serviceAuthMethod.NamespaceRules = append(serviceAuthMethod.NamespaceRules,
 			&api.ACLAuthMethodNamespaceRule{
 				Selector:      fmt.Sprintf(`entity_tags["%s"] != ""`, authMethodNamespaceTag),
 				BindNamespace: fmt.Sprintf(`${entity_tags.%s}`, authMethodNamespaceTag),
 			},
 		)
-	}
-
-	roleName := "consul-ecs-client-role"
-	policyName := "consul-ecs-client-policy"
-	clientBindingRule := &api.ACLBindingRule{
-		Description: "Bind a policy for Consul clients on ECS",
-		AuthMethod:  clientAuthMethod.Name,
-		BindType:    api.BindingRuleBindTypeRole,
-		BindName:    roleName,
 	}
 
 	serviceBindingRule := &api.ACLBindingRule{
@@ -213,36 +212,27 @@ func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsuti
 
 	agentSelf, err := consulClient.Agent().Self()
 	if err != nil {
-		return fmt.Errorf("failed to get Consul agent self config: %w", err)
+		return fmt.Errorf("failed to get Consul server agent's self config: %w", err)
 	}
 	var agentConfig AgentConfig
 	err = mapstructure.Decode(agentSelf, &agentConfig)
 	if err != nil {
-		return fmt.Errorf("failed to decode Consul agent self config: %w", err)
+		return fmt.Errorf("failed to decode Consul server agent's self config: %w", err)
 	}
 
-	if c.flagPartitionsEnabled {
-		if c.flagPartition == "" {
+	if c.config.Controller.PartitionsEnabled {
+		if c.config.Controller.Partition == "" {
 			// if an explicit partition was not provided use the default partition.
-			c.flagPartition = controller.DefaultPartition
+			c.config.Controller.Partition = controller.DefaultPartition
 		}
 		if err := c.upsertPartition(consulClient); err != nil {
 			return err
 		}
-	} else if c.flagPartition != "" {
-		return fmt.Errorf("partition flag provided without partitions-enabled flag")
+	} else if c.config.Controller.Partition != "" {
+		return fmt.Errorf("`config.controller.partition` provided without setting `config.controller.partitionEnabled` as true")
 	}
 
-	if err := c.upsertConsulClientRole(consulClient, roleName, policyName); err != nil {
-		return err
-	}
-	if err := c.upsertAuthMethod(consulClient, clientAuthMethod); err != nil {
-		return err
-	}
 	if err := c.upsertAuthMethod(consulClient, serviceAuthMethod); err != nil {
-		return err
-	}
-	if err := c.upsertBindingRule(consulClient, clientBindingRule); err != nil {
 		return err
 	}
 	if err := c.upsertBindingRule(consulClient, serviceBindingRule); err != nil {
@@ -251,6 +241,11 @@ func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsuti
 	if err := c.upsertAnonymousTokenPolicy(consulClient, agentConfig); err != nil {
 		return err
 	}
+
+	if err := c.registerNode(consulClient, ecsMeta, clusterARN); err != nil {
+		return fmt.Errorf("registering ecs cluster as a node in Consul: %s", err)
+	}
+
 	return nil
 }
 
@@ -266,109 +261,17 @@ func (c *Command) upsertPartition(consulClient *api.Client) error {
 		return fmt.Errorf("failed to list partitions: %s", err)
 	}
 	for _, p := range partitions {
-		if p.Name == c.flagPartition {
+		if p.Name == c.config.Controller.Partition {
 			c.log.Info("found existing partition", "partition", p.Name)
 			return nil
 		}
 	}
 	// the partition doesn't exist, so create it.
-	_, _, err = consulClient.Partitions().Create(c.ctx, &api.Partition{Name: c.flagPartition}, nil)
+	_, _, err = consulClient.Partitions().Create(c.ctx, &api.Partition{Name: c.config.Controller.Partition}, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create partition %s: %s", c.flagPartition, err)
+		return fmt.Errorf("failed to create partition %s: %s", c.config.Controller.Partition, err)
 	}
-	c.log.Info("created partition", "partition", c.flagPartition)
-	return nil
-}
-
-var ossClientPolicy = `node_prefix "" { policy = "write" } service_prefix "" { policy = "read" }`
-var partitionedClientPolicyTpl = `partition "%s" {
-  node_prefix "" {
-    policy = "write"
-  }
-  namespace_prefix "" {
-    service_prefix "" {
-      policy = "read"
-    }
-  }
-}`
-
-// upsertConsulClientRole creates or updates the Consul ACL role for the client token.
-func (c *Command) upsertConsulClientRole(consulClient *api.Client, roleName, policyName string) error {
-	if err := c.upsertClientPolicy(consulClient, policyName); err != nil {
-		return err
-	}
-	if err := c.upsertClientRole(consulClient, roleName, policyName); err != nil {
-		return err
-	}
-	return nil
-}
-
-// upsertClientPolicy creates the ACL policy for the Consul client, if the policy does not exist.
-func (c *Command) upsertClientPolicy(consulClient *api.Client, policyName string) error {
-	// If the policy already exists, we're done.
-	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
-	if err != nil && !controller.IsACLNotFoundError(err) {
-		return fmt.Errorf("reading Consul client ACL policy: %w", err)
-	} else if err == nil && policy != nil { // returns policy=nil and err=nil if not found
-		c.log.Info("ACL policy already exists; skipping policy creation", "name", policyName)
-		return nil
-	}
-
-	// Otherwise, the policy is not found, so create it.
-	c.log.Info("creating ACL policy", "name", policyName)
-	rules := ossClientPolicy
-	if c.flagPartitionsEnabled {
-		// If partitions are enabled then create a policy that supports partitions
-		rules = fmt.Sprintf(partitionedClientPolicyTpl, c.flagPartition)
-	}
-	_, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{
-		Name:        policyName,
-		Description: "Consul Client Token Policy for ECS",
-		Rules:       rules,
-	}, c.writeOptions())
-	if err != nil {
-		return fmt.Errorf("creating Consul client ACL policy: %w", err)
-	}
-	c.log.Info("ACL policy created successfully", "name", policyName)
-	return nil
-}
-
-// upsertClientRole creates the ACL role for the Consul client, if the role does not exist.
-func (c *Command) upsertClientRole(consulClient *api.Client, roleName, policyName string) error {
-	// If the role already exists, we're done.
-	role, _, err := consulClient.ACL().RoleReadByName(roleName, c.queryOptions())
-	if err != nil && !controller.IsACLNotFoundError(err) {
-		return fmt.Errorf("reading Consul client ACL role: %w", err)
-	} else if err == nil && role != nil { // returns role=nil and err=nil if not found
-		c.log.Info("ACL role already exists; skipping role creation", "name", roleName)
-
-		if len(role.Policies) == 0 {
-			c.log.Info("updating ACL role with policy", "role", roleName, "policy", policyName)
-			role.Policies = []*api.ACLLink{{Name: policyName}}
-			_, _, err := consulClient.ACL().RoleUpdate(role, c.writeOptions())
-			if err != nil {
-				return fmt.Errorf("updating Consul client ACL role: %s", err)
-			}
-			c.log.Info("update ACL role successfully", "name", roleName)
-		}
-		return nil
-	}
-
-	c.log.Info("creating ACL role", "name", roleName)
-	_, _, err = consulClient.ACL().RoleCreate(&api.ACLRole{
-		Name:        roleName,
-		Description: "Consul Client Token Role for ECS",
-		Policies: []*api.ACLLink{
-			{
-				Name: policyName,
-			},
-		},
-	}, c.writeOptions())
-	if err != nil {
-		return fmt.Errorf("creating Consul client ACL role: %w", err)
-	}
-	c.log.Info("ACL role created successfully", "name", roleName)
-
+	c.log.Info("created partition", "partition", c.config.Controller.Partition)
 	return nil
 }
 
@@ -522,7 +425,7 @@ func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client, agentConf
 	// mesh gateways actually work across partitions.
 	var qopts *api.QueryOptions
 	var wopts *api.WriteOptions
-	if c.flagPartitionsEnabled {
+	if c.config.Controller.PartitionsEnabled {
 		qopts = &api.QueryOptions{
 			Namespace: controller.DefaultPartition,
 			Partition: controller.DefaultNamespace,
@@ -585,15 +488,15 @@ func (c *Command) upsertAnonymousTokenPolicy(consulClient *api.Client, agentConf
 }
 
 func (c *Command) queryOptions() *api.QueryOptions {
-	if c.flagPartitionsEnabled {
-		return &api.QueryOptions{Partition: c.flagPartition}
+	if c.config.Controller.PartitionsEnabled {
+		return &api.QueryOptions{Partition: c.config.Controller.Partition}
 	}
 	return nil
 }
 
 func (c *Command) writeOptions() *api.WriteOptions {
-	if c.flagPartitionsEnabled {
-		return &api.WriteOptions{Partition: c.flagPartition}
+	if c.config.Controller.PartitionsEnabled {
+		return &api.WriteOptions{Partition: c.config.Controller.Partition}
 	}
 	return nil
 }
@@ -629,7 +532,7 @@ type templateData struct {
 }
 
 func (c *Command) templateData() templateData {
-	return templateData{Enterprise: c.flagPartitionsEnabled}
+	return templateData{Enterprise: c.config.Controller.PartitionsEnabled}
 }
 
 func (c *Command) anonymousPolicyRules() (string, error) {
@@ -652,6 +555,20 @@ partition_prefix "" {
 	return RenderTemplate(rules, c.templateData())
 }
 
+// registerNode registers the clusterARN as a node in Consul. All tasks in ECS
+// will be registered as consul services against this node.
+func (c *Command) registerNode(consulClient *api.Client, taskMeta awsutil.ECSTaskMeta, clusterARN string) error {
+	payload := &api.CatalogRegistration{
+		Node:      clusterARN,
+		NodeMeta:  getNodeMeta(),
+		Address:   taskMeta.NodeIP(),
+		Partition: c.config.Controller.Partition,
+	}
+
+	_, err := consulClient.Catalog().Register(payload, c.writeOptions())
+	return err
+}
+
 // RenderTemplate parses and executes the template t against the given data source.
 func RenderTemplate(t string, data interface{}) (string, error) {
 	parsed, err := template.New("root").Parse(strings.TrimSpace(t))
@@ -665,4 +582,10 @@ func RenderTemplate(t string, data interface{}) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func getNodeMeta() map[string]string {
+	return map[string]string{
+		config.SyntheticNode: "true",
+	}
 }

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -6,7 +6,6 @@
 package aclcontroller
 
 import (
-	"fmt"
 	"testing"
 )
 

--- a/subcommand/acl-controller/command_ent_test.go
+++ b/subcommand/acl-controller/command_ent_test.go
@@ -10,23 +10,11 @@ import (
 	"testing"
 )
 
-var expPartitionedClientPolicy = fmt.Sprintf(`partition "%s" {
-  node_prefix "" {
-    policy = "write"
-  }
-  namespace_prefix "" {
-    service_prefix "" {
-      policy = "read"
-    }
-  }
-}`, testPartitionName)
-
 func TestUpsertConsulResourcesEnt(t *testing.T) {
 	testUpsertConsulResources(t, map[string]iamAuthTestCase{
 		"recreate the partition": {
 			partitionsEnabled: true,
 			deletePartition:   true,
-			expPolicyRules:    expPartitionedClientPolicy,
 		},
 		"recreate all resources ent": {
 			deletePolicy:       true,
@@ -35,7 +23,6 @@ func TestUpsertConsulResourcesEnt(t *testing.T) {
 			deleteBindingRules: true,
 			deletePartition:    true,
 			partitionsEnabled:  true,
-			expPolicyRules:     expPartitionedClientPolicy,
 		},
 	})
 }

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -162,7 +162,7 @@ func testUpsertConsulResources(t *testing.T, cases map[string]iamAuthTestCase) {
 				for _, policy := range policies {
 					policyNames = append(policyNames, policy.Name)
 				}
-				if !c.partitionsEnabled {
+				if c.partitionsEnabled {
 					require.NotContains(t, policyNames, "global-management")
 				} else {
 					// The default partition has a global-management policy

--- a/subcommand/acl-controller/command_test.go
+++ b/subcommand/acl-controller/command_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -51,7 +52,6 @@ var (
 		TaskARN: "arn:aws:ecs:us-east-1:123456789:task/test/abcdef",
 		Family:  "controller",
 	}
-	expOssClientPolicy = `node_prefix "" { policy = "write" } service_prefix "" { policy = "read" }`
 )
 
 type iamAuthTestCase struct {
@@ -61,36 +61,28 @@ type iamAuthTestCase struct {
 	deleteBindingRules bool
 	deletePartition    bool
 	partitionsEnabled  bool
-	expPolicyRules     string
 }
 
 func TestUpsertConsulResources(t *testing.T) {
 	testUpsertConsulResources(t, map[string]iamAuthTestCase{
-		"recreate no ACL resources": {
-			expPolicyRules: expOssClientPolicy,
-		},
+		"recreate no ACL resources": {},
 		"recreate the ACL auth method": {
 			deleteAuthMethods: true,
-			expPolicyRules:    expOssClientPolicy,
 		},
 		"recreate the ACL policy": {
-			deletePolicy:   true,
-			expPolicyRules: expOssClientPolicy,
+			deletePolicy: true,
 		},
 		"recreate the ACL role": {
-			deleteRole:     true,
-			expPolicyRules: expOssClientPolicy,
+			deleteRole: true,
 		},
 		"recreate the ACL binding rule": {
 			deleteBindingRules: true,
-			expPolicyRules:     expOssClientPolicy,
 		},
 		"recreate all resources": {
 			deletePolicy:       true,
 			deleteRole:         true,
 			deleteAuthMethods:  true,
 			deleteBindingRules: true,
-			expPolicyRules:     expOssClientPolicy,
 		},
 	})
 }
@@ -100,29 +92,46 @@ func testUpsertConsulResources(t *testing.T, cases map[string]iamAuthTestCase) {
 		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			_, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
+			server, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
 			if c.partitionsEnabled {
 				cfg.Partition = testPartitionName
 			}
+			serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
+			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
+
 			consulClient, err := api.NewClient(cfg)
 			require.NoError(t, err)
 
 			ui := cli.NewMockUi()
 			cmd := Command{
-				UI:              ui,
-				flagIAMRolePath: "/path/to/roles",
-				log:             hclog.Default().Named("acl-controller"),
+				UI: ui,
+				config: &config.Config{
+					Controller: config.Controller{
+						IAMRolePath: "/path/to/roles",
+					},
+					ConsulServers: config.ConsulServers{
+						Hosts:           serverHost,
+						GRPCPort:        serverGRPCPort,
+						HTTPPort:        serverHTTPPort,
+						EnableTLS:       false,
+						SkipServerWatch: true,
+					},
+				},
+				log: hclog.Default().Named("acl-controller"),
 			}
 			if c.partitionsEnabled {
-				cmd.flagPartitionsEnabled = true
-				cmd.flagPartition = testPartitionName
+				cmd.config.Controller.Partition = testPartitionName
+				cmd.config.Controller.PartitionsEnabled = true
 			}
 
-			// Upsert once to create the resources
-			err = cmd.upsertConsulResources(consulClient, testTaskMetadataResponse)
+			clusterARN, err := testTaskMetadataResponse.ClusterARN()
 			require.NoError(t, err)
 
-			checkConsulResources(t, consulClient, c.expPolicyRules, c.partitionsEnabled)
+			// Upsert once to create the resources
+			err = cmd.upsertConsulResources(consulClient, testTaskMetadataResponse, clusterARN)
+			require.NoError(t, err)
+
+			checkConsulResources(t, consulClient, c.partitionsEnabled)
 
 			// Optionally, delete some of the resources
 			if c.deleteAuthMethods {
@@ -201,14 +210,14 @@ func testUpsertConsulResources(t *testing.T, cases map[string]iamAuthTestCase) {
 			}
 
 			// Upsert again to recreate the deleted resources
-			err = cmd.upsertConsulResources(consulClient, testTaskMetadataResponse)
+			err = cmd.upsertConsulResources(consulClient, testTaskMetadataResponse, clusterARN)
 			require.NoError(t, err)
-			checkConsulResources(t, consulClient, c.expPolicyRules, c.partitionsEnabled)
+			checkConsulResources(t, consulClient, c.partitionsEnabled)
 		})
 	}
 }
 
-func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules string, partitionsEnabled bool) {
+func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnabled bool) {
 	t.Helper()
 
 	// Check the partition is created.
@@ -223,7 +232,7 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules
 		require.Equal(t, partitions[1].Name, testPartitionName)
 	}
 
-	// Check the client policy is created.
+	// Check if policies are created as expected
 	policies, _, err := consulClient.ACL().PolicyList(nil)
 	require.NoError(t, err)
 
@@ -232,69 +241,25 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules
 		policyNames = append(policyNames, policy.Name)
 	}
 
-	require.Contains(t, policyNames, "consul-ecs-client-policy")
 	if partitionsEnabled {
 		// We test with a non-default partition which lacks the global-management policy.
 		// The anonymous token policy is only created in the default partition, since that
-		// is where the anonymous token lives, so we expect only the client policy.
-		require.Len(t, policies, 1)
+		// is where the anonymous token lives, so we expect no policies to be present
+		require.Len(t, policies, 0)
 	} else {
 		// Otherwise, we expect the global-management policy and anonymous-token-policy to be found
 		// if we're running Consul Enterprise and in the default partition, or if we're running
 		// Consul OSS.
-		require.Len(t, policies, 3)
+		require.Len(t, policies, 2)
 		require.Contains(t, policyNames, "anonymous-token-policy")
 		require.Contains(t, policyNames, "global-management")
 	}
 
-	policy, _, err := consulClient.ACL().PolicyReadByName("consul-ecs-client-policy", nil)
-	require.NoError(t, err)
-	require.Equal(t, expPolicyRules, policy.Rules)
-
-	// Check the client role is created with policy attached
-	// Note: When the policy is deleted, it is detached from the role
-	roles, _, err := consulClient.ACL().RoleList(nil)
-	require.NoError(t, err)
-	require.Len(t, roles, 1)
-
-	role, _, err := consulClient.ACL().RoleReadByName("consul-ecs-client-role", nil)
-	require.NoError(t, err)
-	require.Len(t, role.Policies, 1)
-	require.Equal(t, role.Policies[0].Name, "consul-ecs-client-policy")
-
 	// Check the auth methods are created
 	methods, _, err := consulClient.ACL().AuthMethodList(nil)
 	require.NoError(t, err)
-	require.Len(t, methods, 2)
-	sort.Slice(methods, func(i, j int) bool {
-		return methods[i].Name < methods[j].Name
-	})
-	require.Equal(t, methods[0].Name, "iam-ecs-client-token")
-	require.Equal(t, methods[1].Name, "iam-ecs-service-token")
-
-	{
-		method, _, err := consulClient.ACL().AuthMethodRead("iam-ecs-client-token", nil)
-		require.NoError(t, err)
-		require.Equal(t, method.Type, "aws-iam")
-		require.Equal(t, method.Name, "iam-ecs-client-token")
-		require.Len(t, method.NamespaceRules, 0)
-		require.Equal(t, method.Config, map[string]interface{}{
-			"BoundIAMPrincipalARNs": []interface{}{
-				"arn:aws:iam::123456789:role/path/to/roles/*",
-			},
-			"EnableIAMEntityDetails": true,
-		})
-
-		// Check the binding rule is created.
-		rules, _, err := consulClient.ACL().BindingRuleList(method.Name, nil)
-		require.NoError(t, err)
-		require.Len(t, rules, 1)
-
-		rule, _, err := consulClient.ACL().BindingRuleRead(rules[0].ID, nil)
-		require.NoError(t, err)
-		require.Equal(t, rule.BindType, api.BindingRuleBindTypeRole)
-		require.Equal(t, rule.BindName, "consul-ecs-client-role")
-	}
+	require.Len(t, methods, 1)
+	require.Equal(t, methods[0].Name, "iam-ecs-service-token")
 
 	{
 		method, _, err := consulClient.ACL().AuthMethodRead("iam-ecs-service-token", nil)
@@ -336,12 +301,24 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, expPolicyRules
 
 func TestUpsertAuthMethod(t *testing.T) {
 	t.Parallel()
-	_, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
+	server, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
 	consulClient, err := api.NewClient(cfg)
 	require.NoError(t, err)
 
+	serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
+	_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
+
 	cmd := Command{
 		log: hclog.Default().Named("acl-controller"),
+		config: &config.Config{
+			ConsulServers: config.ConsulServers{
+				Hosts:           serverHost,
+				GRPCPort:        serverGRPCPort,
+				HTTPPort:        serverHTTPPort,
+				EnableTLS:       false,
+				SkipServerWatch: true,
+			},
+		},
 	}
 
 	// Simulate two ACL controllers adding auth method config.
@@ -514,13 +491,27 @@ func testUpsertAnonymousTokenPolicy(t *testing.T, cases map[string]anonTokenTest
 	for name, c := range cases {
 		c := c
 		t.Run(name, func(t *testing.T) {
-			_, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
+			server, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
 			consulClient, err := api.NewClient(cfg)
 			require.NoError(t, err)
 
+			serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
+			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
+
 			cmd := Command{
-				log:                   hclog.Default().Named("acl-controller"),
-				flagPartitionsEnabled: c.partitionsEnabled,
+				log: hclog.Default().Named("acl-controller"),
+				config: &config.Config{
+					Controller: config.Controller{
+						PartitionsEnabled: c.partitionsEnabled,
+					},
+					ConsulServers: config.ConsulServers{
+						Hosts:           serverHost,
+						GRPCPort:        serverGRPCPort,
+						HTTPPort:        serverHTTPPort,
+						EnableTLS:       false,
+						SkipServerWatch: true,
+					},
+				},
 			}
 
 			// if we're simulating that the policy already exists, then create it.


### PR DESCRIPTION
## Changes proposed in this PR:
- Exposes the `controller` field in the config JSON. With agentless, the `ecs-controller` will receive the entire config JSON instead of individual flags to facilitate server discovery and other stuff. The json looks like
```json
"controller": {
    "iamRolePath": "", // Defaults to `/consul-ecs/`
    "partitionsEnabled": false,
    "partition": ""
}
```
- Removed `client` specific policy creation, role creation, auth method creation from the existing ACL controller.
- Added ability to register clusterARN as the synthetic node for ECS in the catalog
- Added ability to discover servers in the controller. Server watch will be added in the upcoming PRs.
- Configured the client with the `CONSUL_HTTP_TOKEN` which is the bootstrap token we expect to have `acl:write`, `operator:write` and `node:write` permissions.
- Removed flags from the controller command

## How I've tested this PR:

Unit tests

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
