### PR TITLE
Enable running CI unit tests against `consul-1.16`

### DIFF
--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -53,10 +53,10 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.14.5
-        - 1.14.5+ent
-        - 1.15.1
-        - 1.15.1+ent
+        - 1.14.8
+        - 1.14.8+ent
+        - 1.15.4
+        - 1.15.4+ent
         - 1.16.0
         - 1.16.0+ent
     env:

--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -53,12 +53,12 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.13.7
-        - 1.13.7+ent
         - 1.14.5
         - 1.14.5+ent
         - 1.15.1
         - 1.15.1+ent
+        - 1.16.0
+        - 1.16.0+ent
     env:
       TEST_RESULTS_DIR: /tmp/test-results
       GOTESTSUM_VERSION: 1.8.2


### PR DESCRIPTION
## Changes proposed in this PR:
- Since consul 1.16 has already been GA'ed and we only maintain and test with `n-2` versions of Consul, I have added `1.16.0` and `1.16.0+ent` versions and removed `1.13.7` and `1.13.7+ent` versions from the workflow file.
- Upgraded the consul 1.14 and 1.15 to their latest patch releases

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added - Not needed
- [ ] CHANGELOG entry added - Not needed (I guess?)

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
