### PR TITLE
Miscellaneous changes for dataplane architecture

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,6 @@ const (
 	// Cert used for securing HTTP traffic towards the server
 	consulHTTPSCertPemEnvVar = "CONSUL_HTTPS_CACERT_PEM"
 
-	// Token containing `acl:write`, `operator:write` and `node:write` privileges against the server
 	bootstrapTokenEnvVar = "CONSUL_HTTP_TOKEN"
 )
 

--- a/internal/dataplane/dataplane_config.go
+++ b/internal/dataplane/dataplane_config.go
@@ -22,6 +22,9 @@ type GetDataplaneConfigJSONInput struct {
 	// If empty, credential details are not populated in the resulting
 	// dataplane config JSON.
 	ConsulToken string
+
+	// Path of the CA cert file for Consul server's RPC interface
+	CACertFile string
 }
 
 // GetDataplaneConfigJSON returns back a configuration JSON which
@@ -41,14 +44,18 @@ func (i *GetDataplaneConfigJSONInput) GetDataplaneConfigJSON() ([]byte, error) {
 		},
 		XDSServer: XDSServerConfig{
 			Address: localhostAddr,
-			Port:    20000,
 		},
+	}
+
+	cfg.Consul.TLS = &TLSConfig{
+		Disabled: true,
 	}
 
 	grpcTLSSettings := i.ConsulServerConfig.GetGRPCTLSSettings()
 	if grpcTLSSettings.Enabled {
 		cfg.Consul.TLS = &TLSConfig{
-			GRPCCACertPath: grpcTLSSettings.CaCertFile,
+			Disabled:       false,
+			GRPCCACertPath: i.CACertFile,
 			TLSServerName:  grpcTLSSettings.TLSServerName,
 		}
 	}

--- a/internal/dataplane/dataplane_config_test.go
+++ b/internal/dataplane/dataplane_config_test.go
@@ -37,7 +37,10 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				"consul": {
 				  "addresses": "consul.dc1",
 				  "grpcPort": 8503,
-				  "serverWatchDisabled": true
+				  "serverWatchDisabled": true,
+				  "tls": {
+					"disabled": true
+				  }
 				},
 				"service": {
 				  "nodeName": "test-node-name",
@@ -46,8 +49,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				  "partition": "%s"
 				},
 				"xdsServer": {
-				  "bindAddress": "127.0.0.1",
-				  "bindPort": 20000
+				  "bindAddress": "127.0.0.1"
 				}
 			}`,
 		},
@@ -71,6 +73,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 						EnableTLS:     testutil.BoolPtr(true),
 					},
 				},
+				CACertFile: "/consul/ca-cert.pem",
 			},
 			expectedJSON: `{
 				"consul": {
@@ -90,8 +93,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				  "partition": "%s"
 				},
 				"xdsServer": {
-				  "bindAddress": "127.0.0.1",
-				  "bindPort": 20000
+				  "bindAddress": "127.0.0.1"
 				}
 			}`,
 		},
@@ -120,6 +122,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				  "addresses": "consul.dc1",
 				  "grpcPort": 8502,
 				  "serverWatchDisabled": false,
+				  "tls": {
+					"disabled": true
+				  },
 				  "credentials": {
 					"type": "static",
 					"static": {
@@ -134,8 +139,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				  "partition": "%s"
 				},
 				"xdsServer": {
-				  "bindAddress": "127.0.0.1",
-				  "bindPort": 20000
+				  "bindAddress": "127.0.0.1"
 				}
 			}`,
 		},
@@ -160,6 +164,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					},
 				},
 				ConsulToken: "test-token-123",
+				CACertFile:  "/consul/ca-cert.pem",
 			},
 			expectedJSON: `{
 				"consul": {
@@ -185,8 +190,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				  "partition": "%s"
 				},
 				"xdsServer": {
-				  "bindAddress": "127.0.0.1",
-				  "bindPort": 20000
+				  "bindAddress": "127.0.0.1"
 				}
 			}`,
 		},

--- a/internal/dataplane/dataplane_json.go
+++ b/internal/dataplane/dataplane_json.go
@@ -20,8 +20,8 @@ type ConsulConfig struct {
 
 type TLSConfig struct {
 	Disabled       bool   `json:"disabled"`
-	GRPCCACertPath string `json:"caCertsPath"`
-	TLSServerName  string `json:"tlsServerName"`
+	GRPCCACertPath string `json:"caCertsPath,omitempty"`
+	TLSServerName  string `json:"tlsServerName,omitempty"`
 }
 
 type CredentialsConfig struct {
@@ -42,7 +42,6 @@ type ServiceConfig struct {
 
 type XDSServerConfig struct {
 	Address string `json:"bindAddress"`
-	Port    int    `json:"bindPort"`
 }
 
 func (d *dataplaneConfig) generateJSON() ([]byte, error) {

--- a/subcommand/control-plane/command.go
+++ b/subcommand/control-plane/command.go
@@ -67,7 +67,7 @@ type Command struct {
 
 const (
 	dataplaneConfigFileName = "consul-dataplane.json"
-	caCertFileName          = "mesh-task-consul-ca-cert.pem"
+	caCertFileName          = "consul-grpc-ca-cert.pem"
 
 	defaultHealthCheckBindAddr = "127.0.0.1"
 	defaultHealthCheckBindPort = "10000"

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -1182,7 +1182,10 @@ func getExpectedDataplaneCfgJSON() string {
 	"consul": {
 	  "addresses": "127.0.0.1",
 	  "grpcPort": %d,
-	  "serverWatchDisabled": %t%s
+	  "serverWatchDisabled": %t,
+	  "tls": {
+		"disabled": true
+	   }%s
 	},
 	"service": {
 	  "nodeName": "arn:aws:ecs:us-east-1:123456789:cluster/test",
@@ -1191,8 +1194,7 @@ func getExpectedDataplaneCfgJSON() string {
 	  "partition": "%s"
 	},
 	"xdsServer": {
-	  "bindAddress": "127.0.0.1",
-	  "bindPort": 20000
+	  "bindAddress": "127.0.0.1"
 	}
   }`
 }

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -926,6 +926,68 @@ func TestMakeProxyServiceIDAndName(t *testing.T) {
 	require.Equal(t, expectedName, actualName)
 }
 
+func TestWriteCACertToVolume(t *testing.T) {
+	cases := map[string]struct {
+		serverConfig               config.ConsulServers
+		expectedFileName           string
+		caCertPemProvidedViaEnvVar bool
+	}{
+		"TLS disabled": {
+			serverConfig: config.ConsulServers{
+				Defaults: config.DefaultSettings{
+					EnableTLS: false,
+				},
+			},
+		},
+		"TLS enabled and CA cert not provided via env variable": {
+			serverConfig: config.ConsulServers{
+				Defaults: config.DefaultSettings{
+					EnableTLS:  true,
+					CaCertFile: "consul-ca-cert.pem",
+				},
+			},
+			expectedFileName: "consul-ca-cert.pem",
+		},
+		"TLS enabled and CA cert provided via env variable": {
+			serverConfig: config.ConsulServers{
+				Defaults: config.DefaultSettings{
+					EnableTLS:  true,
+					CaCertFile: "consul-ca-cert.pem",
+				},
+			},
+			caCertPemProvidedViaEnvVar: true,
+			expectedFileName:           caCertFileName,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			ui := cli.NewMockUi()
+			cmd := Command{UI: ui, isTestEnv: true}
+
+			cmd.config = &config.Config{
+				BootstrapDir:  testutil.TempDir(t),
+				ConsulServers: c.serverConfig,
+			}
+
+			if c.caCertPemProvidedViaEnvVar {
+				t.Setenv(config.ConsulGRPCCACertPemEnvVar, "SAMPLE_CA_CERT_PEM")
+			}
+
+			caCertFilePath, err := cmd.writeRPCCACertToSharedVolume()
+			require.NoError(t, err)
+			require.Contains(t, caCertFilePath, c.expectedFileName)
+
+			if c.caCertPemProvidedViaEnvVar {
+				contents, err := os.ReadFile(caCertFilePath)
+				require.NoError(t, err)
+				require.Equal(t, string(contents), "SAMPLE_CA_CERT_PEM")
+			}
+		})
+	}
+}
+
 func assertServiceAndProxyRegistrations(t *testing.T, consulClient *api.Client, expectedService, expectedProxy *api.CatalogService, serviceName, proxyName string) {
 	// Note: TaggedAddressees may be set, but it seems like a race.
 	// We don't support tproxy in ECS, so I don't think we care about this?

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -99,12 +99,6 @@ func (c *Command) run() error {
 	// Set up ECS client.
 	ecsClient := ecs.New(clientSession)
 
-	// Token containing `acl:write`, `operator:write` and `node:write` privileges against the server
-	token := config.GetConsulToken()
-	if token != "" {
-		return fmt.Errorf("CONSUL_HTTP_TOKEN should be non empty")
-	}
-
 	serverConnMgrCfg, err := c.config.ConsulServerConnMgrConfig(ecsMeta)
 	if err != nil {
 		return fmt.Errorf("constructing server connection manager config: %w", err)

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -99,6 +99,7 @@ func (c *Command) run() error {
 	// Set up ECS client.
 	ecsClient := ecs.New(clientSession)
 
+	// Token containing `acl:write`, `operator:write` and `node:write` privileges against the server
 	token := config.GetConsulToken()
 	if token != "" {
 		return fmt.Errorf("CONSUL_HTTP_TOKEN should be non empty")


### PR DESCRIPTION
## Changes proposed in this PR:
- Added ability to write the CA cert PEM to the shared volume because dataplane only accepts a file path for the same.
- Removed XDS Bind Port so that the dataplane can decided what port to pick.
- Users would pass a bootstrap token to the controller. In such cases, asking logging in to consul via the IAM auth method might not be needed. Added ability to pass the bootstrap token as a static credential to the server connection manager's discovery credentials.

## How I've tested this PR:

Unit tests

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
