### PR TITLE
Fix clusterARN login meta for EC2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -169,10 +169,15 @@ func (c *Config) getLoginDiscoveryCredentials(taskMeta awsutil.ECSTaskMeta) (dis
 	}
 	cfg.Login.AuthMethod = authMethod
 
+	clusterARN, err := taskMeta.ClusterARN()
+	if err != nil {
+		return discovery.Credentials{}, err
+	}
+
 	cfg.Login.Meta = mergeMeta(
 		map[string]string{
 			"consul.hashicorp.com/task-id": taskMeta.TaskID(),
-			"consul.hashicorp.com/cluster": taskMeta.Cluster,
+			"consul.hashicorp.com/cluster": clusterARN,
 		},
 		c.ConsulLogin.Meta,
 	)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,7 +37,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 		cfg                    *Config
 		taskMeta               awsutil.ECSTaskMeta
 		consulHTTPTokenPresent bool
-		expConfig              func(awsutil.ECSTaskMeta) discovery.Config
+		expConfig              func(t *testing.T, e awsutil.ECSTaskMeta) discovery.Config
 	}{
 		"basic flags without TLS or ACLs": {
 			cfg: &Config{
@@ -48,7 +48,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 					},
 				},
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+			expConfig: func(_ *testing.T, _ awsutil.ECSTaskMeta) discovery.Config {
 				return discovery.Config{
 					Addresses: "consul.dc1.address",
 					GRPCPort:  8502,
@@ -67,7 +67,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 					},
 				},
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+			expConfig: func(_ *testing.T, _ awsutil.ECSTaskMeta) discovery.Config {
 				return discovery.Config{
 					Addresses: "consul.dc1.address",
 					GRPCPort:  8503,
@@ -88,7 +88,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 					},
 				},
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+			expConfig: func(_ *testing.T, _ awsutil.ECSTaskMeta) discovery.Config {
 				return discovery.Config{
 					Addresses: "consul.dc1.address",
 					GRPCPort:  8503,
@@ -109,7 +109,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 					},
 				},
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+			expConfig: func(_ *testing.T, _ awsutil.ECSTaskMeta) discovery.Config {
 				return discovery.Config{
 					Addresses: "consul.dc1.address",
 					GRPCPort:  8503,
@@ -133,7 +133,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 					},
 				},
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+			expConfig: func(_ *testing.T, _ awsutil.ECSTaskMeta) discovery.Config {
 				return discovery.Config{
 					Addresses: "exec=/usr/local/bin/discover-servers",
 					GRPCPort:  8503,
@@ -159,7 +159,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 					},
 				},
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+			expConfig: func(_ *testing.T, _ awsutil.ECSTaskMeta) discovery.Config {
 				return discovery.Config{
 					Addresses:           "exec=/usr/local/bin/discover-servers",
 					GRPCPort:            8502,
@@ -189,11 +189,9 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 				TaskARN: "arn:aws:ecs:us-east-1:123456789:task/test/abcdef",
 				Family:  "family-service",
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
-				clusterARN, err := t.ClusterARN()
-				if err != nil {
-					return discovery.Config{}
-				}
+			expConfig: func(t *testing.T, e awsutil.ECSTaskMeta) discovery.Config {
+				clusterARN, err := e.ClusterARN()
+				require.NoError(t, err)
 				return discovery.Config{
 					Addresses: "consul.dc1.address",
 					Credentials: discovery.Credentials{
@@ -205,7 +203,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 							Meta: map[string]string{
 								"key1":                         "value1",
 								"key2":                         "value2",
-								"consul.hashicorp.com/task-id": t.TaskID(),
+								"consul.hashicorp.com/task-id": e.TaskID(),
 								"consul.hashicorp.com/cluster": clusterARN,
 							},
 						},
@@ -222,7 +220,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 					Enabled: true,
 				},
 			},
-			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+			expConfig: func(_ *testing.T, _ awsutil.ECSTaskMeta) discovery.Config {
 				return discovery.Config{
 					Addresses: "consul.dc1.address",
 					Credentials: discovery.Credentials{
@@ -257,7 +255,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 			cfg, err := c.cfg.ConsulServerConnMgrConfig(c.taskMeta)
 			require.NoError(t, err)
 
-			expectedCfg := c.expConfig(c.taskMeta)
+			expectedCfg := c.expConfig(t, c.taskMeta)
 			require.Equal(t, expectedCfg.Addresses, cfg.Addresses)
 
 			if testutil.EnterpriseFlag() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -190,6 +190,10 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 				Family:  "family-service",
 			},
 			expConfig: func(t awsutil.ECSTaskMeta) discovery.Config {
+				clusterARN, err := t.ClusterARN()
+				if err != nil {
+					return discovery.Config{}
+				}
 				return discovery.Config{
 					Addresses: "consul.dc1.address",
 					Credentials: discovery.Credentials{
@@ -202,7 +206,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 								"key1":                         "value1",
 								"key2":                         "value2",
 								"consul.hashicorp.com/task-id": t.TaskID(),
-								"consul.hashicorp.com/cluster": t.Cluster,
+								"consul.hashicorp.com/cluster": clusterARN,
 							},
 						},
 					},


### PR DESCRIPTION
## Changes proposed in this PR:
- When ECS containers run on user managed EC2 instances, the `taskMeta.Cluster` field contains just the name unlike FARGATE where `taskMeta.Cluster` points to the entire ARN. This is already handled while calculating the ARN for a cluster [here](https://github.com/hashicorp/consul-ecs/blob/dbef0a2ca2fad2891230c2841b0443258f35b75c/awsutil/awsutil.go#L54).
- In the ECS controller, when syncing the state of ACL tokens with tasks we skip those tokens whose taskState's clusterARN doesn't match with the actual cluster ARN where the controller runs. ([here](https://github.com/hashicorp/consul-ecs/blob/405f8d48f5a8355e2d56761bf12dd15bbc0a8aef/controller/resource.go#L232)). 
- We are assigning `taskMeta.Cluster` to the `consul.hashicorp.com/cluster` login meta field. This works fine for FARGATE setups, but the token sync/deletion is skipped in EC2 because `taskMeta.Cluster` returns the name of the cluster in EC2 and not the ARN. This PR fixes this issue by making sure we always assign `taskMeta.ClusterARN` to the login meta field.

## How I've tested this PR:

Unit tests. Acceptance tests in the dev branch of terraform-aws-consul-ecs repo

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
