### PR TITLE
Added go-discover binary to the ECS image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # when building.
 
 # go-discover builds the discover binary
-FROM golang:1.20.4-alpine as go-discover
+FROM golang:1.20.7-alpine as go-discover
 RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 FROM docker.mirror.hashicorp.services/alpine:latest AS release-default

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@
 # Every target has a BIN_NAME argument that must be provided via --build-arg=BIN_NAME=<name>
 # when building.
 
+# go-discover builds the discover binary
+FROM golang:1.20.4-alpine as go-discover
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
+
 FROM docker.mirror.hashicorp.services/alpine:latest AS release-default
 
 ARG BIN_NAME=consul-ecs
@@ -59,6 +63,7 @@ RUN ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
 USER $BIN_NAME
 ENTRYPOINT ["/bin/consul-ecs"]
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+COPY --from=go-discover /go/bin/discover /bin/
 
 # Separate FIPS target to accomodate CRT label assumptions
 FROM release-default AS release-fips-default


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds the `go-discover` CLI binary to the `consul-ecs` image. This will be used by the new control plane to discover servers when `consulServers.hosts` is of the form

```
exec /bin/discover addrs provider="aws" region="us-east-1" ...
```

## How I've tested this PR:

Rely on CI

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added N/A
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
