### PR TITLE
Fix partition bug while deregistering services

### DIFF
--- a/controller/resource.go
+++ b/controller/resource.go
@@ -550,11 +550,11 @@ func (t *TaskState) Delete(consulClient *api.Client) error {
 func (t *TaskState) DeregisterServices(consulClient *api.Client) error {
 	var result error
 	for _, svc := range t.Services {
-		opts := &api.WriteOptions{Partition: t.Partition, Namespace: svc.Namespace}
+		opts := &api.WriteOptions{Partition: svc.Partition, Namespace: svc.Namespace}
 		deregInput := &api.CatalogDeregistration{
 			Node:      t.ClusterARN,
 			ServiceID: svc.ID,
-			Partition: t.Partition,
+			Partition: svc.Partition,
 			Namespace: svc.Namespace,
 		}
 


### PR DESCRIPTION
## Changes proposed in this PR:
- This PR fixes a bug where the controller fails to deregister a service instance based out of a non default partition whose task instance does not exist in ECS.
- The existing task state's partition (`t.Partition`) did not contain any value and hence falling back to `svc.Partition` to deregister the same.

## How I've tested this PR:

CI/Manual deployment

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added -  N/A. The partition field is setup properly for the test files and so the E2E was working fine.
- [ ] CHANGELOG entry added - N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
