### PR TITLE
Propagate ECS Log level to dataplane

### DIFF
--- a/internal/dataplane/dataplane_config.go
+++ b/internal/dataplane/dataplane_config.go
@@ -31,6 +31,9 @@ type GetDataplaneConfigJSONInput struct {
 
 	// The HTTP health check port that indicates envoy's readiness
 	ProxyHealthCheckPort int
+
+	// The logLevel that will be used to configure dataplane's logger.
+	LogLevel string
 }
 
 // GetDataplaneConfigJSON returns back a configuration JSON which
@@ -54,6 +57,9 @@ func (i *GetDataplaneConfigJSONInput) GetDataplaneConfigJSON() ([]byte, error) {
 		Envoy: EnvoyConfig{
 			ReadyBindAddr: localhostAddr,
 			ReadyBindPort: i.ProxyHealthCheckPort,
+		},
+		Logging: LoggingConfig{
+			LogLevel: i.LogLevel,
 		},
 	}
 

--- a/internal/dataplane/dataplane_config_test.go
+++ b/internal/dataplane/dataplane_config_test.go
@@ -36,6 +36,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					SkipServerWatch: true,
 				},
 				ProxyHealthCheckPort: 22000,
+				LogLevel:             "INFO",
 			},
 			expectedJSON: `{
 				"consul": {
@@ -58,6 +59,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				"envoy": {
 					"readyBindAddress": "127.0.0.1",
 					"readyBindPort": 22000
+				},
+				"logging": {
+					"logLevel": "INFO"
 				}
 			}`,
 		},
@@ -83,6 +87,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				},
 				CACertFile:           "/consul/ca-cert.pem",
 				ProxyHealthCheckPort: 22000,
+				LogLevel:             "DEBUG",
 			},
 			expectedJSON: `{
 				"consul": {
@@ -107,6 +112,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				"envoy": {
 					"readyBindAddress": "127.0.0.1",
 					"readyBindPort": 22000
+				},
+				"logging": {
+					"logLevel": "DEBUG"
 				}
 			}`,
 		},
@@ -130,6 +138,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				},
 				ConsulToken:          "test-token-123",
 				ProxyHealthCheckPort: 22000,
+				LogLevel:             "WARN",
 			},
 			expectedJSON: `{
 				"consul": {
@@ -158,6 +167,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				"envoy": {
 					"readyBindAddress": "127.0.0.1",
 					"readyBindPort": 22000
+				},
+				"logging": {
+					"logLevel": "WARN"
 				}
 			}`,
 		},
@@ -184,6 +196,7 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				ConsulToken:          "test-token-123",
 				CACertFile:           "/consul/ca-cert.pem",
 				ProxyHealthCheckPort: 23000,
+				LogLevel:             "TRACE",
 			},
 			expectedJSON: `{
 				"consul": {
@@ -214,6 +227,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				"envoy": {
 					"readyBindAddress": "127.0.0.1",
 					"readyBindPort": 23000
+				},
+				"logging": {
+					"logLevel": "TRACE"
 				}
 			}`,
 		},

--- a/internal/dataplane/dataplane_json.go
+++ b/internal/dataplane/dataplane_json.go
@@ -12,6 +12,7 @@ type dataplaneConfig struct {
 	Service   ServiceConfig   `json:"service"`
 	XDSServer XDSServerConfig `json:"xdsServer"`
 	Envoy     EnvoyConfig     `json:"envoy"`
+	Logging   LoggingConfig   `json:"logging"`
 }
 
 type ConsulConfig struct {
@@ -51,6 +52,10 @@ type XDSServerConfig struct {
 type EnvoyConfig struct {
 	ReadyBindAddr string `json:"readyBindAddress"`
 	ReadyBindPort int    `json:"readyBindPort"`
+}
+
+type LoggingConfig struct {
+	LogLevel string `json:"logLevel"`
 }
 
 func (d *dataplaneConfig) generateJSON() ([]byte, error) {

--- a/subcommand/control-plane/command.go
+++ b/subcommand/control-plane/command.go
@@ -500,6 +500,7 @@ func (c *Command) generateAndWriteDataplaneConfig(proxyRegistration *api.Catalog
 		ConsulServerConfig: c.config.ConsulServers,
 		ConsulToken:        consulToken,
 		CACertFile:         caCertFilePath,
+		LogLevel:           logging.FromConfig(c.config).LogLevel,
 	}
 
 	if c.config.IsGateway() {

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -1205,6 +1205,9 @@ func getExpectedDataplaneCfgJSON() string {
 	"envoy": {
 		"readyBindAddress": "127.0.0.1",
 		"readyBindPort": 22000
+	},
+	"logging": {
+		"logLevel": "DEBUG"
 	}
   }`
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds changes to pass the ECS log level attribute to the dataplane config JSON.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
