### PR TITLE
Add support to add Consul dataplane as a nameserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-uuid v1.0.2
+	github.com/miekg/dns v1.1.41
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/stretchr/testify v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -1,0 +1,97 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dns
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+const (
+	// Defaults taken from /etc/resolv.conf man page
+	defaultDNSOptionNdots    = 1
+	defaultDNSOptionTimeout  = 5
+	defaultDNSOptionAttempts = 2
+
+	defaultEtcResolvConfFile   = "/etc/resolv.conf"
+	consulDataplaneDNSBindHost = "127.0.0.1"
+)
+
+type ConfigureConsulDNSInput struct {
+	// Used only for unit tests
+	etcResolvConfFile string
+}
+
+// ConfigureConsulDNS reconstructs the /etc/resolv.conf file by setting the
+// consul-dataplane's DNS server (i.e. localhost) as the first nameserver in the list.
+func (i *ConfigureConsulDNSInput) ConfigureConsulDNS() error {
+	etcResolvConfFile := defaultEtcResolvConfFile
+	if i.etcResolvConfFile != "" {
+		etcResolvConfFile = i.etcResolvConfFile
+	}
+
+	cfg, err := dns.ClientConfigFromFile(etcResolvConfFile)
+	if err != nil {
+		return err
+	}
+
+	if cfg == nil {
+		return fmt.Errorf("failed to fetch DNS config")
+	}
+
+	options := constructDNSOpts(cfg)
+
+	nameservers := []string{consulDataplaneDNSBindHost}
+	nameservers = append(nameservers, cfg.Servers...)
+
+	return buildResolveConf(etcResolvConfFile, cfg, nameservers, options)
+}
+
+func constructDNSOpts(cfg *dns.ClientConfig) []string {
+	var opts []string
+	if cfg.Ndots != defaultDNSOptionNdots {
+		opts = append(opts, fmt.Sprintf("ndots:%d", cfg.Ndots))
+	}
+
+	if cfg.Timeout != defaultDNSOptionTimeout {
+		opts = append(opts, fmt.Sprintf("timeout:%d", cfg.Timeout))
+	}
+
+	if cfg.Attempts != defaultDNSOptionAttempts {
+		opts = append(opts, fmt.Sprintf("attempts:%d", cfg.Attempts))
+	}
+
+	return opts
+}
+
+func buildResolveConf(etcResolvConfFile string, cfg *dns.ClientConfig, nameservers, options []string) error {
+	content := bytes.NewBuffer(nil)
+	if len(cfg.Search) > 0 {
+		if searchString := strings.Join(cfg.Search, " "); strings.Trim(searchString, " ") != "." {
+			if _, err := content.WriteString("search " + searchString + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, ns := range nameservers {
+		if _, err := content.WriteString("nameserver " + ns + "\n"); err != nil {
+			return err
+		}
+	}
+
+	if len(options) > 0 {
+		if optsString := strings.Join(options, " "); strings.Trim(optsString, " ") != "" {
+			if _, err := content.WriteString("options " + optsString + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+
+	return os.WriteFile(etcResolvConfFile, content.Bytes(), 0644)
+}

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dns
+
+import (
+	"os"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureConsulDNS(t *testing.T) {
+	cases := map[string]struct {
+		etcResolvConf   string
+		assertDNSConfig func(*testing.T, *dns.ClientConfig)
+	}{
+		"empty /etc/resolv.conf file": {
+			assertDNSConfig: func(t *testing.T, cfg *dns.ClientConfig) {
+				require.Equal(t, 1, len(cfg.Servers))
+				require.Contains(t, cfg.Servers, "127.0.0.1")
+			},
+		},
+		"single nameserver": {
+			etcResolvConf: `nameserver 1.1.1.1`,
+			assertDNSConfig: func(t *testing.T, cfg *dns.ClientConfig) {
+				require.Equal(t, 2, len(cfg.Servers))
+				require.Contains(t, cfg.Servers, "127.0.0.1")
+			},
+		},
+		"several nameservers, searches and options": {
+			etcResolvConf: `
+nameserver 1.1.1.1
+nameserver 2.2.2.2
+nameserver 3.3.3.3
+nameserver 4.4.4.4
+search foo.bar bar.baz bar.foo
+options ndots:5 timeout:6 attempts:3`,
+			assertDNSConfig: func(t *testing.T, cfg *dns.ClientConfig) {
+				require.Equal(t, 5, len(cfg.Servers))
+				require.Contains(t, cfg.Servers, "127.0.0.1")
+				require.Equal(t, 5, cfg.Ndots)
+				require.Equal(t, 6, cfg.Timeout)
+				require.Equal(t, 5, cfg.Ndots)
+				require.Equal(t, 3, cfg.Attempts)
+				require.Equal(t, 3, len(cfg.Search))
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			etcResolvFile, err := os.CreateTemp("", "")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = os.Remove(etcResolvFile.Name())
+			})
+			_, err = etcResolvFile.WriteString(c.etcResolvConf)
+			require.NoError(t, err)
+
+			inp := &ConfigureConsulDNSInput{
+				etcResolvConfFile: etcResolvFile.Name(),
+			}
+
+			require.NoError(t, inp.ConfigureConsulDNS())
+
+			// Assert the DNS config
+			cfg, err := dns.ClientConfigFromFile(inp.etcResolvConfFile)
+			require.NoError(t, err)
+			c.assertDNSConfig(t, cfg)
+		})
+	}
+}

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -42,7 +42,6 @@ options ndots:5 timeout:6 attempts:3`,
 				require.Contains(t, cfg.Servers, "127.0.0.1")
 				require.Equal(t, 5, cfg.Ndots)
 				require.Equal(t, 6, cfg.Timeout)
-				require.Equal(t, 5, cfg.Ndots)
 				require.Equal(t, 3, cfg.Attempts)
 				require.Equal(t, 3, len(cfg.Search))
 			},


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds a package that reconfigures the `/etc/resolv.conf` file to add localhost as a nameserver. This enables us to define upstreams as Consul DNS names in the ECS task definition. With Tproxy, the request gets transparently routed to Consul dataplane's DNS interface which then proxies the request to Consul DNS server.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

👀 

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added (This PR is raised against a feature branch)

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
