### PR TITLE
Schema to support transparent proxy

### DIFF
--- a/config/resources/test_config_additional_properties_service.json
+++ b/config/resources/test_config_additional_properties_service.json
@@ -124,6 +124,16 @@
           }
         ]
       }
+    },
+    "transparentProxy": {
+      "enabled": true,
+      "excludeInboundPorts": [1234, 5678],
+      "excludeOutboundPorts": [3456,8080],
+      "excludeOutboundCIDRs": ["1.1.1.1/32"],
+      "excludeUIDs": ["6678"],
+      "consulDNS": {
+        "enabled": false
+      }
     }
   }
   

--- a/config/resources/test_config_empty_fields.json
+++ b/config/resources/test_config_empty_fields.json
@@ -28,5 +28,6 @@
     "healthCheckPort": 0,
     "proxy": {}
   },
-  "proxy": {}
+  "proxy": {},
+  "transparentProxy": {}
 }

--- a/config/resources/test_config_null_nested_fields.json
+++ b/config/resources/test_config_null_nested_fields.json
@@ -87,5 +87,15 @@
     ],
     "meshGateway": null,
     "expose": null
+  },
+  "transparentProxy": {
+    "enabled": null,
+    "excludeInboundPorts": null,
+    "excludeOutboundPorts": null,
+    "excludeOutboundCIDRs": null,
+    "excludeUIDs": null,
+    "consulDNS": {
+      "enabled": null
+    }
   }
 }

--- a/config/resources/test_config_null_top_level_fields.json
+++ b/config/resources/test_config_null_top_level_fields.json
@@ -33,5 +33,6 @@
     "proxy": null,
     "healthCheckPort": null
   },
-  "proxy": null
+  "proxy": null,
+  "transparentProxy": null
 }

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -125,5 +125,15 @@
         }
       ]
     }
+  },
+  "transparentProxy": {
+    "enabled": true,
+    "excludeInboundPorts": [1234, 5678],
+    "excludeOutboundPorts": [3456,8080],
+    "excludeOutboundCIDRs": ["1.1.1.1/32"],
+    "excludeUIDs": ["6678"],
+    "consulDNS": {
+      "enabled": true
+    }
   }
 }

--- a/config/schema.json
+++ b/config/schema.json
@@ -435,6 +435,60 @@
       },
       "required": ["kind"],
       "additionalProperties": false
+    },
+    "transparentProxy": {
+      "description": "Transparent proxy configuration for the Consul service",
+      "type": ["object", "null"],
+      "properties": {
+        "enabled": {
+          "description": "Whether transparent proxy is enabled or disabled for this task. Defaults to true",
+          "type": ["boolean", "null"]
+        },
+        "excludeInboundPorts": {
+          "description": "List of inbound ports to exclude from traffic redirection",
+          "type": ["array", "null"],
+          "items": {
+            "type": "integer"
+          },
+          "uniqueItems": true
+        },
+        "excludeOutboundPorts": {
+          "description": "List of outbound ports to exclude from traffic redirection",
+          "type": ["array", "null"],
+          "items": {
+            "type": "integer"
+          },
+          "uniqueItems": true
+        },
+        "excludeOutboundCIDRs": {
+          "description": "List of outbound IP CIDRs to exclude from traffic redirection",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "excludeUIDs": {
+          "description": "List of additional UserIDs to exclude from traffic redirection",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "consulDNS": {
+          "description": "Configuration for DNS inside the ECS task",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether Consul DNS should be enabled for this task. Requires transparent proxy to be enabled. Defaults to false. If enabled, services in the mesh will use Consul DNS for default DNS resolution.",
+              "type": ["boolean", "null"]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": ["bootstrapDir", "consulServers"],

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -185,6 +185,12 @@ var (
 		},
 		HealthSyncContainers: []string{"container1"},
 		BootstrapDir:         "/consul/",
+		TransparentProxy: TransparentProxyConfig{
+			Enabled: true,
+			ConsulDNS: ConsulDNS{
+				Enabled: false,
+			},
+		},
 	}
 
 	expectedExtensiveConfig = &Config{
@@ -311,6 +317,16 @@ var (
 				},
 			},
 		},
+		TransparentProxy: TransparentProxyConfig{
+			Enabled:              true,
+			ExcludeInboundPorts:  []int{1234, 5678},
+			ExcludeOutboundPorts: []int{3456, 8080},
+			ExcludeOutboundCIDRs: []string{"1.1.1.1/32"},
+			ExcludeUIDs:          []string{"6678"},
+			ConsulDNS: ConsulDNS{
+				Enabled: true,
+			},
+		},
 	}
 
 	expectedConfigNullTopLevelFields = &Config{
@@ -376,6 +392,16 @@ var (
 			Partition:         "",
 		},
 		Proxy: nil,
+		TransparentProxy: TransparentProxyConfig{
+			Enabled:              true,
+			ExcludeInboundPorts:  nil,
+			ExcludeOutboundPorts: nil,
+			ExcludeUIDs:          nil,
+			ExcludeOutboundCIDRs: nil,
+			ConsulDNS: ConsulDNS{
+				Enabled: false,
+			},
+		},
 	}
 
 	expectedConfigNullNestedFields = &Config{
@@ -469,6 +495,16 @@ var (
 			MeshGateway: nil,
 			Expose:      nil,
 		},
+		TransparentProxy: TransparentProxyConfig{
+			Enabled:              true,
+			ExcludeInboundPorts:  nil,
+			ExcludeOutboundPorts: nil,
+			ExcludeUIDs:          nil,
+			ExcludeOutboundCIDRs: nil,
+			ConsulDNS: ConsulDNS{
+				Enabled: false,
+			},
+		},
 	}
 
 	expectedConfigEmptyFields = &Config{
@@ -539,6 +575,16 @@ var (
 			MeshGateway:        nil,
 			Expose:             nil,
 			HealthCheckPort:    0,
+		},
+		TransparentProxy: TransparentProxyConfig{
+			Enabled:              true,
+			ExcludeInboundPorts:  nil,
+			ExcludeOutboundPorts: nil,
+			ExcludeOutboundCIDRs: nil,
+			ExcludeUIDs:          nil,
+			ConsulDNS: ConsulDNS{
+				Enabled: false,
+			},
 		},
 	}
 )


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds required fields to schema.json to support tproxy on ECS. The schema looks something like

```json
{
   "transparentProxy": {
      "enabled": true, // Defaults to true
      "excludeInboundPorts": [1234, 5678],
      "excludeOutboundPorts": [3456,8080],
      "excludeOutboundCIDRs": ["1.1.1.1/32"],
      "excludeUIDs": ["6678"],
      "consulDNS": {
        "enabled": true
      }
  }
}
```

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

👀 

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
