### PR TITLE
Pass DNS parameters to dataplane config JSON

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,9 @@ const (
 	// Cert used for internal RPC communication to the servers
 	ConsulGRPCCACertPemEnvVar = "CONSUL_GRPC_CACERT_PEM"
 
+	ConsulDataplaneDNSBindHost = "127.0.0.1"
+	ConsulDataplaneDNSBindPort = 8600
+
 	defaultGRPCPort    = 8503
 	defaultHTTPPort    = 8501
 	defaultIAMRolePath = "/consul-ecs/"

--- a/config/types.go
+++ b/config/types.go
@@ -610,6 +610,14 @@ func (c *TransparentProxyConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (cfg *Config) TransparentProxyEnabled() bool {
+	return cfg.TransparentProxy.Enabled && !cfg.IsGateway()
+}
+
 type ConsulDNS struct {
 	Enabled bool `json:"enabled"`
+}
+
+func (cfg *Config) ConsulDNSEnabled() bool {
+	return cfg.TransparentProxy.Enabled && cfg.TransparentProxy.ConsulDNS.Enabled && !cfg.IsGateway()
 }

--- a/internal/dataplane/dataplane_config.go
+++ b/internal/dataplane/dataplane_config.go
@@ -34,6 +34,11 @@ type GetDataplaneConfigJSONInput struct {
 
 	// The logLevel that will be used to configure dataplane's logger.
 	LogLevel string
+
+	// Whether Consul DNS is enabled in the mesh-task. If yes, dataplane
+	// starts a local DNS server and transparently proxies it to Consul
+	// server's DNS interface
+	ConsulDNSEnabled bool
 }
 
 // GetDataplaneConfigJSON returns back a configuration JSON which
@@ -86,6 +91,13 @@ func (i *GetDataplaneConfigJSONInput) GetDataplaneConfigJSON() ([]byte, error) {
 			Static: StaticCredentialConfig{
 				Token: i.ConsulToken,
 			},
+		}
+	}
+
+	if i.ConsulDNSEnabled {
+		cfg.DNSServer = &DNSServerConfig{
+			BindAddress: config.ConsulDataplaneDNSBindHost,
+			BindPort:    config.ConsulDataplaneDNSBindPort,
 		}
 	}
 

--- a/internal/dataplane/dataplane_config_test.go
+++ b/internal/dataplane/dataplane_config_test.go
@@ -233,6 +233,71 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 				}
 			}`,
 		},
+		"Test JSON generation with Consul DNS enabled": {
+			input: &GetDataplaneConfigJSONInput{
+				ProxyRegistration: &api.CatalogRegistration{
+					Node: "test-node-name",
+					Service: &api.AgentService{
+						ID:      "test-side-car-123",
+						Service: "test-side-car",
+						Port:    1234,
+					},
+				},
+				ConsulServerConfig: config.ConsulServers{
+					Hosts:           "consul.dc1",
+					SkipServerWatch: true,
+					GRPC: config.GRPCSettings{
+						Port:          8503,
+						CaCertFile:    "/consul/ca-cert.pem",
+						TLSServerName: "consul.dc1",
+						EnableTLS:     testutil.BoolPtr(true),
+					},
+				},
+				ConsulToken:          "test-token-123",
+				CACertFile:           "/consul/ca-cert.pem",
+				ProxyHealthCheckPort: 23000,
+				LogLevel:             "TRACE",
+				ConsulDNSEnabled:     true,
+			},
+			expectedJSON: `{
+				"consul": {
+				  "addresses": "consul.dc1",
+				  "grpcPort": 8503,
+				  "serverWatchDisabled": true,
+				  "tls": {
+					"disabled": false,
+					"caCertsPath": "/consul/ca-cert.pem",
+					"tlsServerName": "consul.dc1"
+				  },
+				  "credentials": {
+					"type": "static",
+					"static": {
+						"token": "test-token-123"
+					}
+				  }
+				},
+				"service": {
+				  "nodeName": "test-node-name",
+				  "serviceID": "test-side-car-123",
+				  "namespace": "%s",
+				  "partition": "%s"
+				},
+				"xdsServer": {
+				  "bindAddress": "127.0.0.1"
+				},
+				"envoy": {
+					"readyBindAddress": "127.0.0.1",
+					"readyBindPort": 23000
+				},
+				"logging": {
+					"logLevel": "TRACE"
+				},
+				"dnsServer": {
+					"bindAddress": "127.0.0.1",
+					"bindPort": 8600
+				}
+			}`,
+		},
 	}
 
 	for name, c := range testCases {

--- a/internal/dataplane/dataplane_json.go
+++ b/internal/dataplane/dataplane_json.go
@@ -8,11 +8,12 @@ import (
 )
 
 type dataplaneConfig struct {
-	Consul    ConsulConfig    `json:"consul"`
-	Service   ServiceConfig   `json:"service"`
-	XDSServer XDSServerConfig `json:"xdsServer"`
-	Envoy     EnvoyConfig     `json:"envoy"`
-	Logging   LoggingConfig   `json:"logging"`
+	Consul    ConsulConfig     `json:"consul"`
+	Service   ServiceConfig    `json:"service"`
+	XDSServer XDSServerConfig  `json:"xdsServer"`
+	Envoy     EnvoyConfig      `json:"envoy"`
+	Logging   LoggingConfig    `json:"logging"`
+	DNSServer *DNSServerConfig `json:"dnsServer,omitempty"`
 }
 
 type ConsulConfig struct {
@@ -56,6 +57,11 @@ type EnvoyConfig struct {
 
 type LoggingConfig struct {
 	LogLevel string `json:"logLevel"`
+}
+
+type DNSServerConfig struct {
+	BindAddress string `json:"bindAddress"`
+	BindPort    int    `json:"bindPort"`
 }
 
 func (d *dataplaneConfig) generateJSON() ([]byte, error) {

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/consul-ecs/config"
 	"github.com/miekg/dns"
 )
 
@@ -18,8 +19,7 @@ const (
 	defaultDNSOptionTimeout  = 5
 	defaultDNSOptionAttempts = 2
 
-	defaultEtcResolvConfFile   = "/etc/resolv.conf"
-	consulDataplaneDNSBindHost = "127.0.0.1"
+	defaultEtcResolvConfFile = "/etc/resolv.conf"
 )
 
 type ConfigureConsulDNSInput struct {
@@ -46,7 +46,7 @@ func (i *ConfigureConsulDNSInput) ConfigureConsulDNS() error {
 
 	options := constructDNSOpts(cfg)
 
-	nameservers := []string{consulDataplaneDNSBindHost}
+	nameservers := []string{config.ConsulDataplaneDNSBindHost}
 	nameservers = append(nameservers, cfg.Servers...)
 
 	return buildResolveConf(etcResolvConfFile, cfg, nameservers, options)


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds the following blob to the dataplane's configuration JSON when ConsulDNS gets enabled

```json
{
   "dnsServer": {
      "bindAddress": "127.0.0.1",
      "bindPort": 8600
    }
}
```

This instructs Consul Dataplane to start a DNS server and proxy the DNS requests to Consul.

- Add some helpers to check if TProxy and Consul DNS are enabled based on the config JSON provided.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
