### PR TITLE
Added package for supporting traffic redirection

### DIFF
--- a/internal/redirecttraffic/redirect_traffic.go
+++ b/internal/redirecttraffic/redirect_traffic.go
@@ -66,7 +66,7 @@ func WithIPTablesProvider(provider iptables.Provider) TrafficRedirectionOpts {
 }
 
 func New(cfg *config.Config, proxySvc *api.AgentService, consulServerAddress, clusterARN string, proxyHealthCheckPort int, opts ...TrafficRedirectionOpts) TrafficRedirectionProvider {
-	input := &TrafficRedirectionCfg{
+	trafficRedirectionCfg := &TrafficRedirectionCfg{
 		ProxySvc:             proxySvc,
 		ConsulServerAddress:  consulServerAddress,
 		ClusterARN:           clusterARN,
@@ -79,10 +79,10 @@ func New(cfg *config.Config, proxySvc *api.AgentService, consulServerAddress, cl
 	}
 
 	for _, opt := range opts {
-		opt(input)
+		opt(trafficRedirectionCfg)
 	}
 
-	return input
+	return trafficRedirectionCfg
 }
 
 // applyTrafficRedirectionRules creates and applies traffic redirection rules with
@@ -176,8 +176,7 @@ func (c *TrafficRedirectionCfg) Apply() error {
 	if err != nil {
 		return err
 	}
-	c.iptablesCfg.ExcludeOutboundCIDRs = append(c.iptablesCfg.ExcludeOutboundCIDRs, fmt.Sprintf("%s/32", parsedURL.Host))
-	c.iptablesCfg.ExcludeOutboundCIDRs = append(c.iptablesCfg.ExcludeOutboundCIDRs, fmt.Sprintf("%s/32", c.ConsulServerAddress))
+	c.iptablesCfg.ExcludeOutboundCIDRs = append(c.iptablesCfg.ExcludeOutboundCIDRs, fmt.Sprintf("%s/32", parsedURL.Host), fmt.Sprintf("%s/32", c.ConsulServerAddress))
 
 	// UIDs
 	c.iptablesCfg.ExcludeUIDs = append(c.iptablesCfg.ExcludeUIDs, c.ExcludeUIDs...)

--- a/internal/redirecttraffic/redirect_traffic.go
+++ b/internal/redirecttraffic/redirect_traffic.go
@@ -1,0 +1,205 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redirecttraffic
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/iptables"
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	defaultProxyUserID      = 5995
+	defaultProxyInboundPort = 20000
+
+	consulDataplaneDNSBindHost = "127.0.0.1"
+	consulDataplaneDNSBindPort = 8600
+)
+
+type trafficRedirectProxyConfig struct {
+	BindPort           int    `mapstructure:"bind_port"`
+	PrometheusBindAddr string `mapstructure:"envoy_prometheus_bind_addr"`
+	StatsBindAddr      string `mapstructure:"envoy_stats_bind_addr"`
+}
+
+type TrafficRedirectionCfg struct {
+	ProxySvc *api.AgentService
+
+	ConsulServerAddress  string
+	ClusterARN           string
+	ProxyHealthCheckPort int
+
+	EnableConsulDNS      bool
+	ExcludeInboundPorts  []int
+	ExcludeOutboundPorts []int
+	ExcludeOutboundCIDRs []string
+	ExcludeUIDs          []string
+
+	iptablesCfg iptables.Config
+
+	// Fields used only for unit tests
+	iptablesProvider iptables.Provider
+}
+
+type TrafficRedirectionProvider interface {
+	Apply() error
+
+	// Used to fetch the resultant config in unit tests
+	config() iptables.Config
+}
+
+type TrafficRedirectionOpts func(*TrafficRedirectionCfg)
+
+func WithIPTablesProvider(provider iptables.Provider) TrafficRedirectionOpts {
+	return func(c *TrafficRedirectionCfg) {
+		c.iptablesProvider = provider
+	}
+}
+
+func New(cfg *config.Config, proxySvc *api.AgentService, consulServerAddress, clusterARN string, proxyHealthCheckPort int, opts ...TrafficRedirectionOpts) TrafficRedirectionProvider {
+	input := &TrafficRedirectionCfg{
+		ProxySvc:             proxySvc,
+		ConsulServerAddress:  consulServerAddress,
+		ClusterARN:           clusterARN,
+		ProxyHealthCheckPort: proxyHealthCheckPort,
+		EnableConsulDNS:      cfg.ConsulDNSEnabled(),
+		ExcludeInboundPorts:  cfg.TransparentProxy.ExcludeInboundPorts,
+		ExcludeOutboundPorts: cfg.TransparentProxy.ExcludeOutboundPorts,
+		ExcludeOutboundCIDRs: cfg.TransparentProxy.ExcludeOutboundCIDRs,
+		ExcludeUIDs:          cfg.TransparentProxy.ExcludeUIDs,
+	}
+
+	for _, opt := range opts {
+		opt(input)
+	}
+
+	return input
+}
+
+// applyTrafficRedirectionRules creates and applies traffic redirection rules with
+// the help of iptables
+//
+// iptables.Config:
+//
+//	ConsulDNSIP: Consul Dataplane's DNS server (i.e. localhost)
+//	ConsulDNSPort: Consul Dataplane's DNS server's bind port
+//	ProxyUserID: a constant set by default in the mesh-task module for the Consul dataplane's container
+//	ProxyInboundPort: the default inbound port or bind port
+//	ProxyOutboundPort: default transparent proxy outbound port
+//	ExcludeInboundPorts: prometheus, envoy stats, expose paths and `transparentProxy.excludeInboundPorts`
+//	ExcludeOutboundPorts: `transparentProxy.excludeOutboundPorts` in CONSUL_ECS_CONFIG_JSON
+//	ExcludeOutboundCIDRs: TaskMeta IP, Consul Server IP and `transparentProxy.excludeOutboundCIDRs` in CONSUL_ECS_CONFIG_JSON
+//	ExcludeUIDs: `transparentProxy.excludeUIDs` in CONSUL_ECS_CONFIG_JSON
+func (c *TrafficRedirectionCfg) Apply() error {
+	if c.ProxySvc == nil {
+		return fmt.Errorf("proxy service details are required to enable traffic redirection")
+	}
+
+	// Decode proxy's opaque config
+	var trCfg trafficRedirectProxyConfig
+	if err := mapstructure.WeakDecode(c.ProxySvc.Proxy.Config, &trCfg); err != nil {
+		return fmt.Errorf("failed parsing proxy service's Proxy.Config: %w", err)
+	}
+
+	c.iptablesCfg = iptables.Config{
+		ProxyUserID:       strconv.Itoa(defaultProxyUserID),
+		ProxyInboundPort:  defaultProxyInboundPort,
+		ProxyOutboundPort: iptables.DefaultTProxyOutboundPort,
+	}
+
+	// Override proxyInboundPort with bind_port
+	if trCfg.BindPort != 0 {
+		c.iptablesCfg.ProxyInboundPort = trCfg.BindPort
+	}
+
+	// Override the outbound port if the outbound port present in the proxy registration
+	if c.ProxySvc.Proxy.TransparentProxy != nil && c.ProxySvc.Proxy.TransparentProxy.OutboundListenerPort != 0 {
+		c.iptablesCfg.ProxyOutboundPort = c.ProxySvc.Proxy.TransparentProxy.OutboundListenerPort
+	}
+
+	// Inbound ports
+	{
+		for _, port := range c.ExcludeInboundPorts {
+			c.iptablesCfg.ExcludeInboundPorts = append(c.iptablesCfg.ExcludeInboundPorts, strconv.Itoa(port))
+		}
+
+		// Exclude Envoy's ready bind port that indicate envoy's readiness
+		c.iptablesCfg.ExcludeInboundPorts = append(c.iptablesCfg.ExcludeInboundPorts, strconv.Itoa(c.ProxyHealthCheckPort))
+
+		// Exclude envoy_prometheus_bind_addr port from inbound redirection rules.
+		if trCfg.PrometheusBindAddr != "" {
+			_, port, err := net.SplitHostPort(trCfg.PrometheusBindAddr)
+			if err != nil {
+				return fmt.Errorf("failed parsing host and port from envoy_prometheus_bind_addr: %w", err)
+			}
+
+			c.iptablesCfg.ExcludeInboundPorts = append(c.iptablesCfg.ExcludeInboundPorts, port)
+		}
+
+		// Exclude envoy_stats_bind_addr port from inbound redirection rules.
+		if trCfg.StatsBindAddr != "" {
+			_, port, err := net.SplitHostPort(trCfg.StatsBindAddr)
+			if err != nil {
+				return fmt.Errorf("failed parsing host and port from envoy_stats_bind_addr: %w", err)
+			}
+
+			c.iptablesCfg.ExcludeInboundPorts = append(c.iptablesCfg.ExcludeInboundPorts, port)
+		}
+
+		// Exclude expose path ports from inbound traffic redirection
+		for _, exposePath := range c.ProxySvc.Proxy.Expose.Paths {
+			if exposePath.ListenerPort != 0 {
+				c.iptablesCfg.ExcludeInboundPorts = append(c.iptablesCfg.ExcludeInboundPorts, strconv.Itoa(exposePath.ListenerPort))
+			}
+		}
+	}
+
+	// Outbound ports
+	for _, port := range c.ExcludeOutboundPorts {
+		c.iptablesCfg.ExcludeOutboundPorts = append(c.iptablesCfg.ExcludeOutboundPorts, strconv.Itoa(port))
+	}
+
+	// Outbound CIDRs
+	c.iptablesCfg.ExcludeOutboundCIDRs = append(c.iptablesCfg.ExcludeOutboundCIDRs, c.ExcludeOutboundCIDRs...)
+
+	// Exclude TaskMeta and Consul Server IPs from outbound traffic redirection
+	parsedURL, err := url.Parse(os.Getenv(awsutil.ECSMetadataURIEnvVar))
+	if err != nil {
+		return err
+	}
+	c.iptablesCfg.ExcludeOutboundCIDRs = append(c.iptablesCfg.ExcludeOutboundCIDRs, fmt.Sprintf("%s/32", parsedURL.Host))
+	c.iptablesCfg.ExcludeOutboundCIDRs = append(c.iptablesCfg.ExcludeOutboundCIDRs, fmt.Sprintf("%s/32", c.ConsulServerAddress))
+
+	// UIDs
+	c.iptablesCfg.ExcludeUIDs = append(c.iptablesCfg.ExcludeUIDs, c.ExcludeUIDs...)
+
+	// Consul DNS
+	if c.EnableConsulDNS {
+		c.iptablesCfg.ConsulDNSIP = consulDataplaneDNSBindHost
+		c.iptablesCfg.ConsulDNSPort = consulDataplaneDNSBindPort
+	}
+
+	if c.iptablesProvider != nil {
+		c.iptablesCfg.IptablesProvider = c.iptablesProvider
+	}
+
+	err = iptables.Setup(c.iptablesCfg)
+	if err != nil {
+		return fmt.Errorf("failed to setup traffic redirection rules %w", err)
+	}
+
+	return nil
+}
+
+func (c *TrafficRedirectionCfg) config() iptables.Config {
+	return c.iptablesCfg
+}

--- a/internal/redirecttraffic/redirect_traffic_test.go
+++ b/internal/redirecttraffic/redirect_traffic_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redirecttraffic
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/iptables"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	cases := map[string]struct {
+		wantErr              bool
+		proxySvc             *api.AgentService
+		cfg                  *config.Config
+		assertIptablesConfig func(t *testing.T, actual iptables.Config)
+	}{
+		"proxy service is nil": {
+			cfg:     &config.Config{},
+			wantErr: true,
+		},
+		"default redirection behaviour": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled: true,
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				require.Equal(t, defaultProxyInboundPort, cfg.ProxyInboundPort)
+				require.Equal(t, iptables.DefaultTProxyOutboundPort, cfg.ProxyOutboundPort)
+				require.Equal(t, strconv.Itoa(defaultProxyUserID), cfg.ProxyUserID)
+			},
+		},
+		"envoy bind port is present in proxy config": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled: true,
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{
+					Config: map[string]interface{}{
+						"bind_port": 12000,
+					},
+				},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				require.Equal(t, 12000, cfg.ProxyInboundPort)
+			},
+		},
+		"outbound listener port present in proxy config": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled: true,
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{
+					TransparentProxy: &api.TransparentProxyConfig{
+						OutboundListenerPort: 12000,
+					},
+				},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				require.Equal(t, 12000, cfg.ProxyOutboundPort)
+			},
+		},
+		"envoy_stats_bind_addr port, envoy_prometheus_bind_addr port, expose path ports and user specified inbound ports should be excluded": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled:             true,
+					ExcludeInboundPorts: []int{1234, 5678, 8901},
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{
+					Config: map[string]interface{}{
+						"envoy_prometheus_bind_addr": "0.0.0.0:9090",
+						"envoy_stats_bind_addr":      "0.0.0.0:8080",
+					},
+					Expose: api.ExposeConfig{
+						Paths: []api.ExposePath{
+							{
+								ListenerPort: 14000,
+							},
+							{
+								ListenerPort: 15000,
+							},
+						},
+					},
+				},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				expectedPorts := []string{
+					"1234",
+					"5678",
+					"8901",
+					"14000",
+					"15000",
+					"9090",  // Prometheus server port
+					"8080",  // Envoy stats bind port
+					"22000", //Proxy health check port
+				}
+				for _, port := range cfg.ExcludeInboundPorts {
+					require.Contains(t, expectedPorts, port)
+				}
+			},
+		},
+		"user specified outbound ports should be excluded": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled:              true,
+					ExcludeOutboundPorts: []int{1234, 5678, 8901},
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				expectedPorts := []string{
+					"1234",
+					"5678",
+					"8901",
+				}
+				for _, port := range cfg.ExcludeOutboundPorts {
+					require.Contains(t, expectedPorts, port)
+				}
+			},
+		},
+		"user specified UIDs should be excluded": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled:     true,
+					ExcludeUIDs: []string{"1234", "5678"},
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				expectedUIDs := []string{
+					"1234",
+					"5678",
+				}
+				for _, uid := range cfg.ExcludeUIDs {
+					require.Contains(t, expectedUIDs, uid)
+				}
+			},
+		},
+		"user specified CIDRs should be excluded": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled:              true,
+					ExcludeOutboundCIDRs: []string{"1.1.1.1/24", "2.2.2.2/24"},
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				expectedCIDRs := []string{
+					"1.1.1.1/24",
+					"2.2.2.2/24",
+					"172.67.89.20/32",
+					"169.254.170.2/32",
+				}
+				for _, cidr := range cfg.ExcludeOutboundCIDRs {
+					require.Contains(t, expectedCIDRs, cidr)
+				}
+			},
+		},
+		"Consul DNS enabled": {
+			cfg: &config.Config{
+				TransparentProxy: config.TransparentProxyConfig{
+					Enabled: true,
+					ConsulDNS: config.ConsulDNS{
+						Enabled: true,
+					},
+				},
+			},
+			proxySvc: &api.AgentService{
+				Proxy: &api.AgentServiceConnectProxyConfig{},
+			},
+			assertIptablesConfig: func(t *testing.T, cfg iptables.Config) {
+				require.Equal(t, config.ConsulDataplaneDNSBindHost, cfg.ConsulDNSIP)
+				require.Equal(t, config.ConsulDataplaneDNSBindPort, cfg.ConsulDNSPort)
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(awsutil.ECSMetadataURIEnvVar, "http://169.254.170.2/v4/task_id")
+			iptablesProvider := &mockIptablesProvider{}
+			provider := New(c.cfg,
+				c.proxySvc,
+				"172.67.89.20",
+				"arn:aws:ecs:us-east-1:123456789:cluster/test",
+				22000,
+				WithIPTablesProvider(iptablesProvider),
+			)
+
+			err := provider.Apply()
+			if c.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Truef(t, iptablesProvider.applyCalled, "redirect traffic rules were not applied")
+
+				if c.assertIptablesConfig != nil {
+					c.assertIptablesConfig(t, provider.config())
+				}
+			}
+		})
+	}
+}
+
+type mockIptablesProvider struct {
+	applyCalled bool
+	rules       []string
+}
+
+func (f *mockIptablesProvider) AddRule(_ string, args ...string) {
+	f.rules = append(f.rules, strings.Join(args, " "))
+}
+
+func (f *mockIptablesProvider) ApplyRules() error {
+	f.applyCalled = true
+	return nil
+}
+
+func (f *mockIptablesProvider) Rules() []string {
+	return f.rules
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds the `redirecttraffic` package that will support traffic redirection for transparent proxying requests in ECS.
- Makes use of the `iptables` Consul SDK to configure the rules
- Most of the exclusion scenarios are covered in detail in the RFC.
 

## How I've tested this PR:
CI

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
