### PR TITLE
Invoke traffic redirection modules from control plane

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -24,15 +24,15 @@ const (
 
 type ConfigureConsulDNSInput struct {
 	// Used only for unit tests
-	etcResolvConfFile string
+	ETCResolvConfFile string
 }
 
 // ConfigureConsulDNS reconstructs the /etc/resolv.conf file by setting the
 // consul-dataplane's DNS server (i.e. localhost) as the first nameserver in the list.
 func (i *ConfigureConsulDNSInput) ConfigureConsulDNS() error {
 	etcResolvConfFile := defaultEtcResolvConfFile
-	if i.etcResolvConfFile != "" {
-		etcResolvConfFile = i.etcResolvConfFile
+	if i.ETCResolvConfFile != "" {
+		etcResolvConfFile = i.ETCResolvConfFile
 	}
 
 	cfg, err := dns.ClientConfigFromFile(etcResolvConfFile)

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -59,13 +59,13 @@ options ndots:5 timeout:6 attempts:3`,
 			require.NoError(t, err)
 
 			inp := &ConfigureConsulDNSInput{
-				etcResolvConfFile: etcResolvFile.Name(),
+				ETCResolvConfFile: etcResolvFile.Name(),
 			}
 
 			require.NoError(t, inp.ConfigureConsulDNS())
 
 			// Assert the DNS config
-			cfg, err := dns.ClientConfigFromFile(inp.etcResolvConfFile)
+			cfg, err := dns.ClientConfigFromFile(inp.ETCResolvConfFile)
 			require.NoError(t, err)
 			c.assertDNSConfig(t, cfg)
 		})

--- a/internal/redirecttraffic/redirect_traffic.go
+++ b/internal/redirecttraffic/redirect_traffic.go
@@ -51,10 +51,12 @@ type TrafficRedirectionCfg struct {
 }
 
 type TrafficRedirectionProvider interface {
+	// Apply applies the traffic redirection with iptables
 	Apply() error
 
-	// Used to fetch the resultant config in unit tests
-	config() iptables.Config
+	// Config returns the resultant iptables config that gets
+	// applied by the provider
+	Config() iptables.Config
 }
 
 type TrafficRedirectionOpts func(*TrafficRedirectionCfg)
@@ -199,6 +201,6 @@ func (c *TrafficRedirectionCfg) Apply() error {
 	return nil
 }
 
-func (c *TrafficRedirectionCfg) config() iptables.Config {
+func (c *TrafficRedirectionCfg) Config() iptables.Config {
 	return c.iptablesCfg
 }

--- a/internal/redirecttraffic/redirect_traffic_test.go
+++ b/internal/redirecttraffic/redirect_traffic_test.go
@@ -218,7 +218,7 @@ func TestApply(t *testing.T) {
 				require.Truef(t, iptablesProvider.applyCalled, "redirect traffic rules were not applied")
 
 				if c.assertIptablesConfig != nil {
-					c.assertIptablesConfig(t, provider.config())
+					c.assertIptablesConfig(t, provider.Config())
 				}
 			}
 		})


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds changes to the control-plane subcommand's implementation to invoke traffic redirection rules.
- Adds changes to configure Consul DNS.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
