### PR TITLE
Exclude control-plane health check port from traffic redirection

### DIFF
--- a/internal/redirecttraffic/redirect_traffic.go
+++ b/internal/redirecttraffic/redirect_traffic.go
@@ -78,6 +78,10 @@ func New(cfg *config.Config, proxySvc *api.AgentService, consulServerAddress, cl
 		ExcludeUIDs:          cfg.TransparentProxy.ExcludeUIDs,
 	}
 
+	if len(additionalInboundPortsToExclude) > 0 {
+		trafficRedirectionCfg.ExcludeInboundPorts = append(trafficRedirectionCfg.ExcludeInboundPorts, additionalInboundPortsToExclude...)
+	}
+
 	for _, opt := range opts {
 		opt(trafficRedirectionCfg)
 	}

--- a/internal/redirecttraffic/redirect_traffic.go
+++ b/internal/redirecttraffic/redirect_traffic.go
@@ -78,9 +78,7 @@ func New(cfg *config.Config, proxySvc *api.AgentService, consulServerAddress, cl
 		ExcludeUIDs:          cfg.TransparentProxy.ExcludeUIDs,
 	}
 
-	if len(additionalInboundPortsToExclude) > 0 {
-		trafficRedirectionCfg.ExcludeInboundPorts = append(trafficRedirectionCfg.ExcludeInboundPorts, additionalInboundPortsToExclude...)
-	}
+	trafficRedirectionCfg.ExcludeInboundPorts = append(trafficRedirectionCfg.ExcludeInboundPorts, additionalInboundPortsToExclude...)
 
 	for _, opt := range opts {
 		opt(trafficRedirectionCfg)

--- a/internal/redirecttraffic/redirect_traffic.go
+++ b/internal/redirecttraffic/redirect_traffic.go
@@ -34,9 +34,8 @@ type trafficRedirectProxyConfig struct {
 type TrafficRedirectionCfg struct {
 	ProxySvc *api.AgentService
 
-	ConsulServerAddress  string
-	ClusterARN           string
-	ProxyHealthCheckPort int
+	ConsulServerAddress string
+	ClusterARN          string
 
 	EnableConsulDNS      bool
 	ExcludeInboundPorts  []int
@@ -67,12 +66,11 @@ func WithIPTablesProvider(provider iptables.Provider) TrafficRedirectionOpts {
 	}
 }
 
-func New(cfg *config.Config, proxySvc *api.AgentService, consulServerAddress, clusterARN string, proxyHealthCheckPort int, opts ...TrafficRedirectionOpts) TrafficRedirectionProvider {
+func New(cfg *config.Config, proxySvc *api.AgentService, consulServerAddress, clusterARN string, additionalInboundPortsToExclude []int, opts ...TrafficRedirectionOpts) TrafficRedirectionProvider {
 	trafficRedirectionCfg := &TrafficRedirectionCfg{
 		ProxySvc:             proxySvc,
 		ConsulServerAddress:  consulServerAddress,
 		ClusterARN:           clusterARN,
-		ProxyHealthCheckPort: proxyHealthCheckPort,
 		EnableConsulDNS:      cfg.ConsulDNSEnabled(),
 		ExcludeInboundPorts:  cfg.TransparentProxy.ExcludeInboundPorts,
 		ExcludeOutboundPorts: cfg.TransparentProxy.ExcludeOutboundPorts,
@@ -133,9 +131,6 @@ func (c *TrafficRedirectionCfg) Apply() error {
 		for _, port := range c.ExcludeInboundPorts {
 			c.iptablesCfg.ExcludeInboundPorts = append(c.iptablesCfg.ExcludeInboundPorts, strconv.Itoa(port))
 		}
-
-		// Exclude Envoy's ready bind port that indicate envoy's readiness
-		c.iptablesCfg.ExcludeInboundPorts = append(c.iptablesCfg.ExcludeInboundPorts, strconv.Itoa(c.ProxyHealthCheckPort))
 
 		// Exclude envoy_prometheus_bind_addr port from inbound redirection rules.
 		if trCfg.PrometheusBindAddr != "" {

--- a/internal/redirecttraffic/redirect_traffic_test.go
+++ b/internal/redirecttraffic/redirect_traffic_test.go
@@ -206,7 +206,7 @@ func TestApply(t *testing.T) {
 				c.proxySvc,
 				"172.67.89.20",
 				"arn:aws:ecs:us-east-1:123456789:cluster/test",
-				22000,
+				[]int{22000},
 				WithIPTablesProvider(iptablesProvider),
 			)
 

--- a/subcommand/control-plane/command.go
+++ b/subcommand/control-plane/command.go
@@ -78,7 +78,7 @@ const (
 	caCertFileName          = "consul-grpc-ca-cert.pem"
 
 	defaultHealthCheckBindAddr = "127.0.0.1"
-	defaultHealthCheckBindPort = "10000"
+	defaultHealthCheckBindPort = 10000
 )
 
 func (c *Command) init() {
@@ -325,7 +325,7 @@ func (c *Command) startHealthCheckServer() {
 	mux.HandleFunc("/consul-ecs/health", c.handleHealthCheck)
 	var handler http.Handler = mux
 
-	listenerBindAddr := net.JoinHostPort(defaultHealthCheckBindAddr, defaultHealthCheckBindPort)
+	listenerBindAddr := net.JoinHostPort(defaultHealthCheckBindAddr, strconv.Itoa(defaultHealthCheckBindPort))
 	if c.healthCheckListenerAddr != "" {
 		listenerBindAddr = c.healthCheckListenerAddr
 	}
@@ -631,7 +631,10 @@ func (c *Command) applyTrafficRedirectionRules(consulClient *api.Client, proxyRe
 			proxySvc,
 			consulServerIP,
 			clusterARN,
-			config.GetHealthCheckPort(c.config.Proxy.HealthCheckPort),
+			[]int{
+				config.GetHealthCheckPort(c.config.Proxy.HealthCheckPort),
+				defaultHealthCheckBindPort,
+			},
 		)
 	}
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Excludes the default health check port of the control-plane from traffic redirection. The port will be used by the ECS agent to mark the control plane healthy and start dataplane container which depends on it.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
