### PR TITLE
Add proxy.localServiceAddress to enable configuration of Envoy local_app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ BREAKING CHANGES
    - Add the `proxy.healthCheckPort` field which can be hit to determine Envoy's readiness.
    - Add the `proxy.upstreams.destinationPeer` field to enable the proxy to hit upstreams present in peer Consul clusters.
    - Add the `meshGateway.healthCheckPort` field which can be hit to determine Envoy's readiness.
+   - Add the `proxy.localServiceAddress` field to configure Envoy to use a different address for the local service.
 * Add the [go-discover](https://github.com/hashicorp/go-discover) binary to the Consul ECS image to better support [cloud auto-join](https://developer.hashicorp.com/consul/docs/install/cloud-auto-join).[[GH-160](https://github.com/hashicorp/consul-ecs/pull/160)]
 
 ## 0.6.0 (Mar 15, 2023)

--- a/config/resources/test_config_additional_properties_service.json
+++ b/config/resources/test_config_additional_properties_service.json
@@ -89,6 +89,7 @@
     "proxy": {
       "publicListenerPort": 21000,
       "healthCheckPort": 22000,
+      "localServiceAddress": "10.10.10.10",
       "config": {
         "data": "some-config-data"
       },

--- a/config/resources/test_extensive_config.json
+++ b/config/resources/test_extensive_config.json
@@ -90,6 +90,7 @@
   "proxy": {
     "publicListenerPort": 21000,
     "healthCheckPort": 22000,
+    "localServiceAddress": "10.10.10.10",
     "config": {
       "data": "some-config-data"
     },

--- a/config/schema.json
+++ b/config/schema.json
@@ -238,6 +238,10 @@
           "description": "Object value that specifies an opaque JSON configuration. The JSON is stored and returned along with the service instance when called from the API.",
           "type": ["object", "null"]
         },
+        "localServiceAddress": {
+          "description": "The IP address or hostname that Envoy should use to connect to the local service. Defaults to localhost.",
+          "type": ["string", "null"]
+        },
         "publicListenerPort": {
           "description": "The public listener port for Envoy used for service-to-service communication. Defaults to 20000.",
           "type": ["integer", "null"]

--- a/config/types.go
+++ b/config/types.go
@@ -376,18 +376,22 @@ func (w *AgentWeights) ToConsulType() api.AgentWeights {
 //   - Checks are excluded. control-plane automatically configures useful checks for the proxy.
 //   - TProxy is not supported on ECS, so the Mode and TransparentProxy fields are excluded.
 type AgentServiceConnectProxyConfig struct {
-	Config             map[string]interface{} `json:"config,omitempty"`
-	PublicListenerPort int                    `json:"publicListenerPort,omitempty"`
-	HealthCheckPort    int                    `json:"healthCheckPort,omitempty"`
-	Upstreams          []Upstream             `json:"upstreams,omitempty"`
-	MeshGateway        *MeshGatewayConfig     `json:"meshGateway,omitempty"`
-	Expose             *ExposeConfig          `json:"expose,omitempty"`
+	Config              map[string]interface{} `json:"config,omitempty"`
+	LocalServiceAddress string                 `json:"localServiceAddress,omitempty"`
+	PublicListenerPort  int                    `json:"publicListenerPort,omitempty"`
+	HealthCheckPort     int                    `json:"healthCheckPort,omitempty"`
+	Upstreams           []Upstream             `json:"upstreams,omitempty"`
+	MeshGateway         *MeshGatewayConfig     `json:"meshGateway,omitempty"`
+	Expose              *ExposeConfig          `json:"expose,omitempty"`
 }
 
 func (a *AgentServiceConnectProxyConfig) ToConsulType() *api.AgentServiceConnectProxyConfig {
 	result := &api.AgentServiceConnectProxyConfig{
 		Config:    a.Config,
 		Upstreams: nil,
+	}
+	if a.LocalServiceAddress != "" {
+		result.LocalServiceAddress = a.LocalServiceAddress
 	}
 	if a.MeshGateway != nil {
 		result.MeshGateway = a.MeshGateway.ToConsulType()

--- a/config/types.go
+++ b/config/types.go
@@ -362,7 +362,8 @@ func (w *AgentWeights) ToConsulType() api.AgentWeights {
 //   - The Kind and Port are set by control-plane, so these fields are not configurable.
 //   - The ID, Name, Tags, Meta, EnableTagOverride, and Weights fields are inferred or copied
 //     from the service registration by control-plane.
-//   - The bind address is always localhost in ECS, so the Address and SocketPath are excluded.
+//   - The bind address defaults to localhost in ECS but can be overridden with LocalServiceAddress and
+//     SocketPath is excluded.
 //   - The Connect field is excluded. Since the sidecar proxy is being used, it's not a Connect-native
 //     service, and we don't need the nested proxy config included in the Connect field.
 //   - The Partition field is excluded. control-plane will use the partition from the service registration.

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -22,6 +22,11 @@ func TestProxyRegistrationToConsulType(t *testing.T) {
 	require.Equal(t, consulType, expectedConsulProxyRegistration)
 }
 
+func TestProxyRegistrationLocalServiceAddressToConsulType(t *testing.T) {
+	consulType := testProxyRegistrationLocalServiceAddress.ToConsulType()
+	require.Equal(t, consulType, expectedConsulProxyRegistrationLocalServiceAddress)
+}
+
 // Test that IncludEntity defaults to true.
 func TestConsulLoginIncludeEntity(t *testing.T) {
 	cases := map[string]struct {
@@ -603,10 +608,92 @@ var (
 		},
 	}
 
+	testProxyRegistrationLocalServiceAddress = &AgentServiceConnectProxyConfig{
+		Config: map[string]interface{}{
+			"data": "some-test-data",
+		},
+		LocalServiceAddress: "10.10.10.10",
+		Upstreams: []Upstream{
+			{
+				DestinationType:      api.UpstreamDestTypeService,
+				DestinationNamespace: "test-ns-2",
+				DestinationPartition: "test-partition-2",
+				DestinationName:      "upstream-svc",
+				Datacenter:           "dc2",
+				LocalBindAddress:     "localhost",
+				LocalBindPort:        1235,
+				Config: map[string]interface{}{
+					"data": "some-upstream-test-data",
+				},
+				MeshGateway: &MeshGatewayConfig{
+					Mode: api.MeshGatewayModeLocal,
+				},
+			},
+		},
+		MeshGateway: &MeshGatewayConfig{
+			Mode: api.MeshGatewayModeLocal,
+		},
+		Expose: &ExposeConfig{
+			Checks: true,
+			Paths: []ExposePath{
+				{
+					ListenerPort:  2345,
+					Path:          "/test",
+					LocalPathPort: 2346,
+					Protocol:      "http",
+				},
+			},
+		},
+	}
+
 	expectedConsulProxyRegistration = &api.AgentServiceConnectProxyConfig{
 		DestinationServiceName: "",
 		DestinationServiceID:   "",
 		LocalServiceAddress:    "",
+		LocalServicePort:       0,
+		LocalServiceSocketPath: "",
+		Config: map[string]interface{}{
+			"data": "some-test-data",
+		},
+		Upstreams: []api.Upstream{
+			{
+				DestinationType:      api.UpstreamDestTypeService,
+				DestinationNamespace: "test-ns-2",
+				DestinationPartition: "test-partition-2",
+				DestinationName:      "upstream-svc",
+				Datacenter:           "dc2",
+				LocalBindAddress:     "localhost",
+				LocalBindPort:        1235,
+				LocalBindSocketPath:  "",
+				LocalBindSocketMode:  "",
+				Config: map[string]interface{}{
+					"data": "some-upstream-test-data",
+				},
+				MeshGateway: api.MeshGatewayConfig{
+					Mode: api.MeshGatewayModeLocal,
+				},
+			},
+		},
+		MeshGateway: api.MeshGatewayConfig{
+			Mode: api.MeshGatewayModeLocal,
+		},
+		Expose: api.ExposeConfig{
+			Checks: true,
+			Paths: []api.ExposePath{
+				{
+					ListenerPort:  2345,
+					Path:          "/test",
+					LocalPathPort: 2346,
+					Protocol:      "http",
+				},
+			},
+		},
+	}
+
+	expectedConsulProxyRegistrationLocalServiceAddress = &api.AgentServiceConnectProxyConfig{
+		DestinationServiceName: "",
+		DestinationServiceID:   "",
+		LocalServiceAddress:    "10.10.10.10",
 		LocalServicePort:       0,
 		LocalServiceSocketPath: "",
 		Config: map[string]interface{}{

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -276,8 +276,9 @@ var (
 			Config: map[string]interface{}{
 				"data": "some-config-data",
 			},
-			PublicListenerPort: 21000,
-			HealthCheckPort:    22000,
+			PublicListenerPort:  21000,
+			HealthCheckPort:     22000,
+			LocalServiceAddress: "10.10.10.10",
 			Upstreams: []Upstream{
 				{
 					DestinationType:      api.UpstreamDestTypeService,


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds a `proxy.localServiceAddress` field to configure Envoy's local_app endpoint address


## How I've tested this PR:

1. Deployed the [cluster-peering example](https://github.com/hashicorp/terraform-aws-consul-ecs/tree/main/examples/cluster-peering) example with a image built from this PR.
2. Modified CONSUL_ECS_CONFIG_JSON to include a `proxy.localServiceAddress` field set to the IP of the Fargate task.
3. Verified that the consul-dataplane containers Envoy config specified the task ip in the local_app cluster rather than localhost.

```
      "load_assignment": {
       "cluster_name": "local_app",
       "endpoints": [
        {
         "lb_endpoints": [
          {
           "endpoint": {
            "address": {
             "socket_address": {
              "address": "10.0.1.140",
              "port_value": 7933
             }
            }
           }
          }
         ]
        }
```

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
