### PR TITLE
Rename service to proxy in dataplane config json

### DIFF
--- a/internal/dataplane/dataplane_config.go
+++ b/internal/dataplane/dataplane_config.go
@@ -45,11 +45,11 @@ func (i *GetDataplaneConfigJSONInput) GetDataplaneConfigJSON() ([]byte, error) {
 			GRPCPort:        i.ConsulServerConfig.GRPC.Port,
 			SkipServerWatch: i.ConsulServerConfig.SkipServerWatch,
 		},
-		Service: ServiceConfig{
-			NodeName:       i.ProxyRegistration.Node,
-			ProxyServiceID: i.ProxyRegistration.Service.ID,
-			Namespace:      i.ProxyRegistration.Service.Namespace,
-			Partition:      i.ProxyRegistration.Service.Partition,
+		Proxy: ProxyConfig{
+			NodeName:  i.ProxyRegistration.Node,
+			ID:        i.ProxyRegistration.Service.ID,
+			Namespace: i.ProxyRegistration.Service.Namespace,
+			Partition: i.ProxyRegistration.Service.Partition,
 		},
 		XDSServer: XDSServerConfig{
 			Address: localhostAddr,

--- a/internal/dataplane/dataplane_config_test.go
+++ b/internal/dataplane/dataplane_config_test.go
@@ -47,9 +47,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					"disabled": true
 				  }
 				},
-				"service": {
+				"proxy": {
 				  "nodeName": "test-node-name",
-				  "serviceID": "test-side-car-123",
+				  "id": "test-side-car-123",
 				  "namespace": "%s",
 				  "partition": "%s"
 				},
@@ -100,9 +100,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					"tlsServerName": "consul.dc1"
 				  }
 				},
-				"service": {
+				"proxy": {
 				  "nodeName": "test-node-name",
-				  "serviceID": "test-side-car-123",
+				  "id": "test-side-car-123",
 				  "namespace": "%s",
 				  "partition": "%s"
 				},
@@ -155,9 +155,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					}
 				  }
 				},
-				"service": {
+				"proxy": {
 				  "nodeName": "test-node-name",
-				  "serviceID": "test-side-car-123",
+				  "id": "test-side-car-123",
 				  "namespace": "%s",
 				  "partition": "%s"
 				},
@@ -215,9 +215,9 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					}
 				  }
 				},
-				"service": {
+				"proxy": {
 				  "nodeName": "test-node-name",
-				  "serviceID": "test-side-car-123",
+				  "id": "test-side-car-123",
 				  "namespace": "%s",
 				  "partition": "%s"
 				},

--- a/internal/dataplane/dataplane_json.go
+++ b/internal/dataplane/dataplane_json.go
@@ -9,7 +9,7 @@ import (
 
 type dataplaneConfig struct {
 	Consul    ConsulConfig    `json:"consul"`
-	Service   ServiceConfig   `json:"service"`
+	Proxy     ProxyConfig     `json:"proxy"`
 	XDSServer XDSServerConfig `json:"xdsServer"`
 	Envoy     EnvoyConfig     `json:"envoy"`
 	Logging   LoggingConfig   `json:"logging"`
@@ -38,11 +38,11 @@ type StaticCredentialConfig struct {
 	Token string `json:"token"`
 }
 
-type ServiceConfig struct {
-	NodeName       string `json:"nodeName"`
-	ProxyServiceID string `json:"serviceID"`
-	Namespace      string `json:"namespace"`
-	Partition      string `json:"partition"`
+type ProxyConfig struct {
+	NodeName  string `json:"nodeName"`
+	ID        string `json:"id"`
+	Namespace string `json:"namespace"`
+	Partition string `json:"partition"`
 }
 
 type XDSServerConfig struct {

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -1193,9 +1193,9 @@ func getExpectedDataplaneCfgJSON() string {
 		"disabled": true
 	   }%s
 	},
-	"service": {
+	"proxy": {
 	  "nodeName": "arn:aws:ecs:us-east-1:123456789:cluster/test",
-	  "serviceID": "%s",
+	  "id": "%s",
 	  "namespace": "%s",
 	  "partition": "%s"
 	},


### PR DESCRIPTION
## Changes proposed in this PR:
- Renames the service related configs to proxy.
- This is done to adopt the latest changes made to consul-dataplane to support V2. https://github.com/hashicorp/consul-dataplane/pull/242

## How I've tested this PR:
Manual terraform deployment

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
