### PR TITLE
Bump Consul to 1.17

### DIFF
--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.17.0
+        - 1.17.0-rc1
         #- 1.16.2+ent
     env:
       TEST_RESULTS_DIR: /tmp/test-results

--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         consul-version:
         - 1.17.0-rc1
-        #- 1.16.2+ent
+        - 1.17.0-rc1+ent
     env:
       TEST_RESULTS_DIR: /tmp/test-results
       GOTESTSUM_VERSION: 1.8.2

--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -53,8 +53,8 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.16.0
-        - 1.16.0+ent
+        - 1.17.0
+        #- 1.16.2+ent
     env:
       TEST_RESULTS_DIR: /tmp/test-results
       GOTESTSUM_VERSION: 1.8.2

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -154,7 +154,7 @@ func testUpsertConsulResources(t *testing.T, cases map[string]iamAuthTestCase) {
 				policies, _, err := consulClient.ACL().PolicyList(nil)
 				require.NoError(t, err)
 				for _, policy := range policies {
-					if policy.Name != "global-management" {
+					if policy.Name != "global-management" && policy.Name != "builtin/global-read-only" {
 						_, err := consulClient.ACL().PolicyDelete(policy.ID, nil)
 						require.NoError(t, err)
 					}


### PR DESCRIPTION
## Changes proposed in this PR:
- Bumps Consul to 1.17
- Makes Consul ECS aware of the new builtin policy added in 1.17 and prevents tests from deleting it

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
