### PR TITLE
Add changes to ECS controller to support API gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+FEATURES
+* API and terminating gateways
+  - Add support for configuring API and terminating gateways as ECS tasks [[GH-192](https://github.com/hashicorp/consul-ecs/pull/192)]
+  - Add following changes to the controller to support API gateways in ACL enabled clusters [[GH-198](https://github.com/hashicorp/consul-ecs/pull/198)]
+    - Create the `consul-ecs-api-gateway-role` ACL role and `consul-ecs-api-gateway-policy` ACL policy.
+    - Add a new IAM entity tag `consul.hashicorp.name.gateway-kind` to the existing service auth method's config.
+    - Add a new binding rule specific to API gateway that helps binding the API gateway's ACL token to the preconfigured `consul-ecs-api-gateway-role`
+
 ## 0.7.0 (Nov 7, 2023)
 
 BREAKING CHANGES

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -423,7 +423,7 @@ namespace_prefix "" {
 		policy = "read"
 	}
 	service_prefix "" {
-		policy = "write"
+		policy = "read"
 	}
 {{- if .Enterprise }}
 }

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -488,19 +487,6 @@ func uniqueStrings(strs []string) []string {
 	}
 	sort.Strings(result)
 	return result
-}
-
-func writeToFile(str string) {
-	f, err := os.OpenFile("log.txt", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-	if err != nil {
-		panic(err)
-	}
-
-	defer f.Close()
-
-	if _, err = f.WriteString(str + "\n"); err != nil {
-		panic(err)
-	}
 }
 
 func forceStringSlice(val interface{}) ([]string, error) {

--- a/subcommand/controller/command_ent_test.go
+++ b/subcommand/controller/command_ent_test.go
@@ -38,3 +38,11 @@ func TestUpsertAnonymousTokenPolicyEnt(t *testing.T) {
 		},
 	})
 }
+
+func TestUpsertAPIGatewayTokenPolicyAndRole(t *testing.T) {
+	testUpsertAPIGatewayPolicyAndRole(t, map[string]apiGatewayTokenTest{
+		"test creation": {
+			partitionsEnabled: true,
+		},
+	})
+}

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -53,14 +53,14 @@ partition_prefix "" {
 		policy = "write"
 	}`
 	expEntAPIGatewayPolicy = `mesh = "read"
-	namespace_prefix "" {
-		node_prefix "" {
-			policy = "read"
-		}
-		service_prefix "" {
-			policy = "write"
-		}
-	}`
+namespace_prefix "" {
+	node_prefix "" {
+		policy = "read"
+	}
+	service_prefix "" {
+		policy = "write"
+	}
+}`
 )
 
 var (

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -50,7 +50,7 @@ partition_prefix "" {
 		policy = "read"
 	}
 	service_prefix "" {
-		policy = "write"
+		policy = "read"
 	}`
 	expEntAPIGatewayPolicy = `mesh = "read"
 namespace_prefix "" {
@@ -58,7 +58,7 @@ namespace_prefix "" {
 		policy = "read"
 	}
 	service_prefix "" {
-		policy = "write"
+		policy = "read"
 	}
 }`
 )

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -44,6 +44,23 @@ partition_prefix "" {
     service_prefix "" {
       policy = "read"
     }`
+
+	expOSSAPIGatewayPolicy = `mesh = "read"
+	node_prefix "" {
+		policy = "read"
+	}
+	service_prefix "" {
+		policy = "write"
+	}`
+	expEntAPIGatewayPolicy = `mesh = "read"
+	namespace_prefix "" {
+		node_prefix "" {
+			policy = "read"
+		}
+		service_prefix "" {
+			policy = "write"
+		}
+	}`
 )
 
 var (
@@ -277,6 +294,14 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnab
 		require.Contains(t, policyNames, "global-management")
 	}
 
+	require.Contains(t, policyNames, apiGatewayPolicyName)
+
+	// Check for the presence of API gateway role
+	roles, _, err := consulClient.ACL().RoleList(nil)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	require.Equal(t, apiGatewayRoleName, roles[0].Name)
+
 	// Check the auth methods are created
 	methods, _, err := consulClient.ACL().AuthMethodList(nil)
 	require.NoError(t, err)
@@ -304,20 +329,31 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnab
 			},
 			"EnableIAMEntityDetails": true,
 			"IAMEntityTags": []interface{}{
-				authMethodServiceNameTag,
+				authMethodGatewayKindTag,
 				authMethodNamespaceTag,
+				authMethodServiceNameTag,
 			},
 		})
 
 		// Check the binding rule is created.
 		rules, _, err := consulClient.ACL().BindingRuleList(method.Name, nil)
 		require.NoError(t, err)
-		require.Len(t, rules, 1)
+		require.Len(t, rules, 2)
 
-		rule, _, err := consulClient.ACL().BindingRuleRead(rules[0].ID, nil)
-		require.NoError(t, err)
-		require.Equal(t, rule.BindType, api.BindingRuleBindTypeService)
-		require.Equal(t, rule.BindName, fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag))
+		var serviceBindingRule, gatewayBindingRule *api.ACLBindingRule
+		for _, rule := range rules {
+			switch rule.BindType {
+			case api.BindingRuleBindTypeService:
+				serviceBindingRule = rule
+			case api.BindingRuleBindTypeRole:
+				gatewayBindingRule = rule
+			}
+		}
+		require.NotNil(t, serviceBindingRule)
+		require.Equal(t, serviceBindingRule.BindName, fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag))
+
+		require.NotNil(t, gatewayBindingRule)
+		require.Equal(t, gatewayBindingRule.BindName, apiGatewayRoleName)
 	}
 }
 
@@ -348,7 +384,6 @@ func TestUpsertAuthMethod(t *testing.T) {
 		},
 	}
 
-	// Simulate two controllers adding auth method config.
 	allPrincipals := []interface{}{
 		"arn:aws:iam::123456789:role/path/1/*",
 		"arn:aws:iam::123456789:role/path/2/*",
@@ -356,30 +391,69 @@ func TestUpsertAuthMethod(t *testing.T) {
 		"arn:aws:iam::123456789:role/path/4/*",
 	}
 
-	methodOne := makeAuthMethod(allPrincipals[0:3])
-	methodTwo := makeAuthMethod(allPrincipals[1:])
-
-	// Upsert once - one controller starting up.
-	{
-		err := cmd.upsertAuthMethod(consulClient, methodOne)
-		require.NoError(t, err)
-
-		upserted, _, err := consulClient.ACL().AuthMethodRead(methodOne.Name, nil)
-		require.NoError(t, err)
-		require.Equal(t, methodOne.Config, upserted.Config)
+	allIAMEntityTags := []interface{}{
+		"consul.hashicorp.com.gateway-kind",
+		"consul.hashicorp.com.namespace",
+		"consul.hashicorp.com.service",
+		"consul.hashicorp.com.some-tag-1",
+		"consul.hashicorp.com.some-tag-2",
 	}
 
-	// Upsert again - another controller starting up.
-	{
-		err := cmd.upsertAuthMethod(consulClient, methodTwo)
-		require.NoError(t, err)
+	cases := map[string]struct {
+		authMethodOne *api.ACLAuthMethod
+		authMethodTwo *api.ACLAuthMethod
+	}{
+		"only Principals differs": {
+			authMethodOne: makeAuthMethod(allPrincipals[0:3], allIAMEntityTags),
+			authMethodTwo: makeAuthMethod(allPrincipals[1:], allIAMEntityTags),
+		},
+		"only IAM Entity Tags differs": {
+			authMethodOne: makeAuthMethod(allPrincipals, allIAMEntityTags[0:3]),
+			authMethodTwo: makeAuthMethod(allPrincipals, allIAMEntityTags[2:]),
+		},
+		"both Principals and IAM Entity Tags differ": {
+			authMethodOne: makeAuthMethod(allPrincipals[0:3], allIAMEntityTags[0:3]),
+			authMethodTwo: makeAuthMethod(allPrincipals[1:], allIAMEntityTags[2:]),
+		},
+		"nothing differs": {
+			authMethodOne: makeAuthMethod(allPrincipals, allIAMEntityTags),
+			authMethodTwo: makeAuthMethod(allPrincipals, allIAMEntityTags),
+		},
+	}
 
-		upserted, _, err := consulClient.ACL().AuthMethodRead(methodTwo.Name, nil)
-		require.NoError(t, err)
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			// Simulate two controllers adding auth method config.
 
-		// BoundIAMPrincipalARNs should be merged together.
-		expected := makeAuthMethod(allPrincipals)
-		require.Equal(t, expected.Config, upserted.Config)
+			t.Cleanup(func() {
+				_, err := consulClient.ACL().AuthMethodDelete(c.authMethodOne.Name, nil)
+				require.NoError(t, err)
+			})
+
+			// Upsert once - one controller starting up.
+			{
+				err := cmd.upsertAuthMethod(consulClient, c.authMethodOne)
+				require.NoError(t, err)
+
+				upserted, _, err := consulClient.ACL().AuthMethodRead(c.authMethodOne.Name, nil)
+				require.NoError(t, err)
+				require.Equal(t, c.authMethodOne.Config, upserted.Config)
+			}
+
+			// Upsert again - another controller starting up.
+			{
+				err := cmd.upsertAuthMethod(consulClient, c.authMethodTwo)
+				require.NoError(t, err)
+
+				upserted, _, err := consulClient.ACL().AuthMethodRead(c.authMethodTwo.Name, nil)
+				require.NoError(t, err)
+
+				// BoundIAMPrincipalARNs, IAMEntityTags should be merged together.
+				expected := makeAuthMethod(allPrincipals, allIAMEntityTags)
+				require.Equal(t, expected.Config, upserted.Config)
+			}
+		})
 	}
 }
 
@@ -448,7 +522,7 @@ func TestUniqueStrings(t *testing.T) {
 	}
 }
 
-func makeAuthMethod(principals interface{}) *api.ACLAuthMethod {
+func makeAuthMethod(principals, iamEntityTags interface{}) *api.ACLAuthMethod {
 	return &api.ACLAuthMethod{
 		Name:        "test-method",
 		Type:        "aws-iam",
@@ -457,6 +531,7 @@ func makeAuthMethod(principals interface{}) *api.ACLAuthMethod {
 			// This is the only field that matters.
 			"BoundIAMPrincipalARNs":  principals,
 			"EnableIAMEntityDetails": true,
+			"IAMEntityTags":          iamEntityTags,
 		},
 	}
 }
@@ -595,6 +670,117 @@ func testUpsertAnonymousTokenPolicy(t *testing.T, cases map[string]anonTokenTest
 				require.Error(t, err)
 				require.Contains(t, err.Error(), c.expErr)
 			}
+		})
+	}
+}
+
+type apiGatewayTokenTest struct {
+	partitionsEnabled bool
+	policyExists      bool
+	roleExists        bool
+	wantErr           bool
+}
+
+func TestUpsertAPIGatewayPolicyAndRole(t *testing.T) {
+	testUpsertAPIGatewayPolicyAndRole(t, map[string]apiGatewayTokenTest{
+		"both policy and role doesn't exist": {},
+		"policy already exists": {
+			policyExists: true,
+		},
+		"role already exists": {
+			roleExists: true,
+			wantErr:    true,
+		},
+		"role already exists and policy also exists": {
+			roleExists:   true,
+			policyExists: true,
+		},
+	})
+}
+
+func testUpsertAPIGatewayPolicyAndRole(t *testing.T, cases map[string]apiGatewayTokenTest) {
+	t.Parallel()
+	t.Helper()
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			server, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
+			consulClient, err := api.NewClient(cfg)
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				role, _, err := consulClient.ACL().RoleReadByName(apiGatewayRoleName, nil)
+				require.NoError(t, err)
+				require.NotNil(t, role)
+
+				_, err = consulClient.ACL().RoleDelete(role.ID, nil)
+				require.NoError(t, err)
+
+				policy, _, err := consulClient.ACL().PolicyReadByName(apiGatewayPolicyName, nil)
+				require.NoError(t, err)
+				require.NotNil(t, policy)
+
+				_, err = consulClient.ACL().PolicyDelete(policy.ID, nil)
+				require.NoError(t, err)
+			})
+
+			serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
+			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
+
+			cmd := Command{
+				log: hclog.Default().Named("controller"),
+				config: &config.Config{
+					Controller: config.Controller{
+						PartitionsEnabled: c.partitionsEnabled,
+					},
+					ConsulServers: config.ConsulServers{
+						Hosts: serverHost,
+						GRPC: config.GRPCSettings{
+							Port:      serverGRPCPort,
+							EnableTLS: testutil.BoolPtr(false),
+						},
+						HTTP: config.HTTPSettings{
+							Port:      serverHTTPPort,
+							EnableTLS: testutil.BoolPtr(false),
+						},
+						SkipServerWatch: true,
+					},
+				},
+			}
+
+			if c.policyExists {
+				err = cmd.upsertAPIGatewayPolicy(consulClient, apiGatewayPolicyName)
+				require.NoError(t, err)
+			}
+
+			if c.roleExists {
+				err = cmd.upsertAPIGatewayRole(consulClient, apiGatewayRoleName, apiGatewayPolicyName)
+				if c.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			err = cmd.upsertAPIGatewayPolicyAndRole(consulClient, apiGatewayRoleName, apiGatewayPolicyName)
+			require.NoError(t, err)
+
+			roles, _, err := consulClient.ACL().RoleList(nil)
+			require.NoError(t, err)
+			require.Len(t, roles, 1)
+			require.Equal(t, apiGatewayRoleName, roles[0].Name)
+			require.NotNil(t, roles[0].Policies)
+
+			policy, _, err := consulClient.ACL().PolicyReadByName(apiGatewayPolicyName, nil)
+			require.NoError(t, err)
+			require.NotNil(t, policy)
+
+			expPolicy := expOSSAPIGatewayPolicy
+			if c.partitionsEnabled {
+				expPolicy = expEntAPIGatewayPolicy
+			}
+
+			require.Equal(t, expPolicy, policy.Rules)
 		})
 	}
 }


### PR DESCRIPTION
## Changes proposed in this PR:

**Background**

In an ACL enabled cluster, API gateways require `mesh:read` permissions to pull in resources from the server. To achieve this, we would need to ensure that the token generated by the API gateway task after performing a Consul Login with the configured AWS IAM Auth method has the adequate permissions. Without these permissions, API gateways won't be able to set up routes to make traffic flow into the mesh.

**Solution**

The controller on start up does the following

- Create a `consul-ecs-api-gateway-policy` with the required rules.
- Create a `consul-ecs-api-gateway-role` and attach the policy to the same.
- Add a new tag `consul.hashicorp.com.gateway-kind` to the `IAMEntityTags` of the Auth method. This tag will hold the type of the gateway and will be passed on to the task's role via terraform.
- Attach a new binding rule to the existing auth method of type `Role` with the selector  `entity_tags["consul.hashicorp.com.gateway-kind"] == "api-gateway"`
- Modify the `UpsertAuthMethod` logic to make sure that the newly added entity tag gets updated in a setup that has the auth method preconfigured. This typically happens when users upgrade their Consul ECS versions from `0.x.x` to `0.8.x`.

**How it works?**

- When a task of type `api-gateway` tries to perform a Consul login with the auth method, the selector for the newly added binding rule gets satisfied and the preconfigured `consul-ecs-api-gateway-role` gets attached to the token. 

**Future work**

- Currently the ECS controller creates the role and policies required for the API gateway to work. This will soon be replaced by builtin template policies whenever the template for API gateways get added to the Consul repo. Post that the role, policy creation logic can be removed from the controller.

## How I've tested this PR:

Manually deploying API gateways on ECS

## How I expect reviewers to test this PR:

👁️ 

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
