### PR TITLE
Controller changes to improve UX for setting up TGWs on ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ FEATURES
     - Create the `consul-ecs-api-gateway-role` ACL role and `consul-ecs-api-gateway-policy` ACL policy.
     - Add a new IAM entity tag `consul.hashicorp.name.gateway-kind` to the existing service auth method's config.
     - Add a new binding rule specific to API gateway that helps binding the API gateway's ACL token to the preconfigured `consul-ecs-api-gateway-role`
+  - Add following changes to the controller to support Terminating gateways in ACL enabled clusters [[GH-199](https://github.com/hashicorp/consul-ecs/pull/199)]
+    - Create the `consul-ecs-terminating-gateway-role` ACL role. This role will be assigned to the ACL token obtained by the terminating gateway task after performing a Consul login. Users can assign policies to this role via terraform whenever needed.
+    - Add a new binding rule specific to terminating gateways that helps bind the terminating gateway's ACL token to the preconfigured `consul-ecs-terminating-gateway-role`
 
 ## 0.7.0 (Nov 7, 2023)
 

--- a/subcommand/envoy-entrypoint/command_unix_test.go
+++ b/subcommand/envoy-entrypoint/command_unix_test.go
@@ -152,7 +152,7 @@ func TestRun(t *testing.T) {
 					// Sanity check. We mock two requests with app container running, and the rest with the app container stopped.
 					require.GreaterOrEqual(r, atomic.LoadInt64(&ecsMetaRequestCount), int64(3))
 
-					t.Logf("Check the fake Envoy process exits")
+					r.Logf("Check the fake Envoy process exits")
 					proc, err := os.FindProcess(envoyPid)
 					require.NoError(r, err, "Failed to find fake Envoy process")
 					// A zero-signal checks the validity of the process id.


### PR DESCRIPTION
## Changes proposed in this PR:

**Background**

In an ACL enabled Consul cluster where terminating gateway based ECS workloads are deployed, the ACL token used by the TGW proxy needs `service:write` permission on all the referenced services in the gateway config. This token will be used to pull in relevant information about those services from Consul's catalog. For example, let's consider a case where an `example-client-app` service (present in the mesh) tries to reach to an external `example-server-app` service present outside the mesh through a TGW. The terminating gateway proxy in this case needs a token with the following policy

```hcl
service "example-server-app" {
   policy = "write"
}
```

for the E2E to work. Without making any changes to the ECS controller, the current UX looks like this

1. Users register their external services to Consul's catalog.
2. Users add the name of their external service to the terminating gateway's config entry.
3. Users would then need to add the ☝️ policy to the token that gets created for the terminating gateway's service via the AWS IAM auth method.

The first 2 steps can be automated with terraform but the 3rd one has to be done manually by the operator because it is difficult to get the accessor ID of the token. Only with an accessorID in place will the operator be able to attach a policy to the token.

One possible workaround is to create a wildcard policy that looks something like

```hcl
service "" {
  policy = "write"
}
```

and add a binding rule to the configured auth method via the ECS controller that makes sure to add this policy to the resulting token for the TGW service identity. While this should technically work, it doesn't follow the principle of least privileges.

**Proposed solution**

1. On startup, make the controller create a dummy role without any policies named `consul-ecs-terminating-gateway-role`
2. Add a binding rule to the auth method, that attaches the previously created role in step 1 to the resulting token.
3. Users looking to register external services could automate the policy creation and perform the policy attachment to the role via terraform. A sample terraform looks something like

```hcl
# Create the policy
resource "consul_acl_policy" "external_server_app_policy" {
  name  = "external_server_app_write_policy"
  rules = <<-RULE
    service "${var.name}-external-server-app" {
      policy = "write"
    }
    RULE

  provider = consul.dc1-cluster
}

# Read the pre-created role by the controller
data "consul_acl_role" "ecs_terminating_gateway_default_role" {
  depends_on = [module.ecs_controller]
  name       = "consul-ecs-terminating-gateway-role"

  provider = consul.dc1-cluster
}

# Attach the policy to the role
resource "consul_acl_role_policy_attachment" "external_server_app_role_policy_attachment" {
  role_id = data.consul_acl_role.ecs_terminating_gateway_default_role.id
  policy  = consul_acl_policy.external_server_app_policy.name

  provider = consul.dc1-cluster
}
```

This way the token gets the required permissions to pull in details about the referenced external services. This also reduces manual intervention by operators.

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
