### PR TITLE
Fix envoy graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ FEATURES
     - Create the `consul-ecs-terminating-gateway-role` ACL role. This role will be assigned to the ACL token obtained by the terminating gateway task after performing a Consul login. Users can assign policies to this role via terraform whenever needed.
     - Add a new binding rule specific to terminating gateways that helps bind the terminating gateway's ACL token to the preconfigured `consul-ecs-terminating-gateway-role`
 
+BUG FIXES
+* Fixes a bug which prevented graceful shutdown of the Consul dataplane container. [[GH-200](https://github.com/hashicorp/consul-ecs/pull/200)]
+
 ## 0.7.0 (Nov 7, 2023)
 
 BREAKING CHANGES

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -24,6 +24,10 @@ const (
 	ECSMetadataURIEnvVar = "ECS_CONTAINER_METADATA_URI_V4"
 
 	AWSRegionEnvVar = "AWS_REGION"
+
+	// This is the type assigned to the containers that are
+	// present in the task definition.
+	containerTypeNormal = "NORMAL"
 )
 
 type ECSTaskMeta struct {
@@ -40,6 +44,7 @@ type ECSTaskMetaContainer struct {
 	DesiredStatus string               `json:"DesiredStatus"`
 	KnownStatus   string               `json:"KnownStatus"`
 	Networks      []ECSTaskMetaNetwork `json:"Networks"`
+	Type          string               `json:"Type"`
 }
 
 type ECSTaskMetaHealth struct {
@@ -122,6 +127,10 @@ func (e ECSTaskMeta) HasContainerStopped(name string) bool {
 func (c ECSTaskMetaContainer) HasStopped() bool {
 	return c.DesiredStatus == ecs.DesiredStatusStopped &&
 		c.KnownStatus == ecs.DesiredStatusStopped
+}
+
+func (c ECSTaskMetaContainer) IsNormalType() bool {
+	return c.Type == containerTypeNormal
 }
 
 func ECSTaskMetadata() (ECSTaskMeta, error) {

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -145,6 +145,21 @@ func TestHasStopped(t *testing.T) {
 	require.Equal(t, true, container.HasStopped())
 }
 
+func TestIsNormalType(t *testing.T) {
+	container := ECSTaskMetaContainer{
+		Name:          "container1",
+		DesiredStatus: ecs.DesiredStatusRunning,
+		KnownStatus:   ecs.DesiredStatusRunning,
+		Type:          containerTypeNormal,
+	}
+
+	require.True(t, container.IsNormalType())
+
+	container.Type = "SOME_AWS_MANAGED_TYPE"
+
+	require.False(t, container.IsNormalType())
+}
+
 // Helper to restore the environment after a test.
 func restoreEnv(t *testing.T, env []string) {
 	os.Clearenv()

--- a/subcommand/envoy-entrypoint/command_unix_test.go
+++ b/subcommand/envoy-entrypoint/command_unix_test.go
@@ -116,6 +116,8 @@ func TestRun(t *testing.T) {
 					meta := makeTaskMeta(
 						"some-app-container",
 						"consul-ecs-control-plane",
+						"consul-dataplane",
+						"some-aws-managed-container",
 					)
 
 					if atomic.LoadInt64(&ecsMetaRequestCount) < 2 {
@@ -195,11 +197,17 @@ func TestRun(t *testing.T) {
 func makeTaskMeta(containerNames ...string) awsutil.ECSTaskMeta {
 	var containers []awsutil.ECSTaskMetaContainer
 	for _, name := range containerNames {
-		containers = append(containers, awsutil.ECSTaskMetaContainer{
+		container := awsutil.ECSTaskMetaContainer{
 			Name:          name,
 			DesiredStatus: ecs.DesiredStatusStopped,
 			KnownStatus:   ecs.DesiredStatusRunning,
-		})
+			Type:          "NORMAL",
+		}
+
+		if container.Name == "some-aws-managed-container" {
+			container.Type = "AWS MANAGED"
+		}
+		containers = append(containers, container)
 	}
 
 	return awsutil.ECSTaskMeta{

--- a/subcommand/envoy-entrypoint/task-monitor.go
+++ b/subcommand/envoy-entrypoint/task-monitor.go
@@ -20,6 +20,7 @@ import (
 var (
 	nonAppContainers = map[string]struct{}{
 		"consul-ecs-control-plane": {},
+		"consul-dataplane":         {},
 	}
 )
 
@@ -100,6 +101,12 @@ func allAppContainersStopped(taskMeta awsutil.ECSTaskMeta) bool {
 }
 
 func isApplication(container awsutil.ECSTaskMetaContainer) bool {
+	// ECS might auto-inject some containers that aren't part of
+	// the task definition. We treat them as non app containers.
+	if !container.IsNormalType() {
+		return false
+	}
+
 	_, ok := nonAppContainers[container.Name]
 	return !ok
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds `consul-dataplane` to the non app container's map.
- Add a container `Type` field to the ECS Task meta response payload.
- Add a check to make sure that AWS managed containers are treated as non app container. ECS auto-injects some containers with type other than `NORMAL` to facilitate orchestration. Up until now, we were looking into the status of these containers as well to determine if application containers (added by the users) have terminated. This caused issues with graceful shutdown of Consul dataplane and apparently resulted in a forced shutdown of the task.

This will also be backported to `release/0.7.x`

## How I've tested this PR:

CI, Manual deployment

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
