### PR TITLE
Offload tons of responsibilities from control-plane

### DIFF
--- a/subcommand/control-plane/checks.go
+++ b/subcommand/control-plane/checks.go
@@ -5,13 +5,9 @@ package controlplane
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -20,20 +16,13 @@ const (
 	consulHealthSyncCheckName = "Consul ECS health check synced"
 
 	consulDataplaneReadinessCheckName = "Consul dataplane readiness"
-
-	// syncChecksInterval is how often we poll the container health endpoint and
-	// sync the checks back to the Consul servers.
-	//
-	// The rate limit for the health endpoint is about 40 per second,
-	// so 1 second polling seems reasonable.
-	syncChecksInterval = 1 * time.Second
 )
 
 func (c *Command) constructChecks(service *api.AgentService) api.HealthChecks {
 	checks := make(api.HealthChecks, 0)
 	if service.Kind == api.ServiceKindTypical {
 		for _, containerName := range c.config.HealthSyncContainers {
-			check := &api.HealthCheck{
+			checks = append(checks, &api.HealthCheck{
 				CheckID:   constructCheckID(service.ID, containerName),
 				Name:      consulHealthSyncCheckName,
 				Type:      consulECSCheckType,
@@ -42,14 +31,12 @@ func (c *Command) constructChecks(service *api.AgentService) api.HealthChecks {
 				Status:    api.HealthCritical,
 				Output:    healthCheckOutputReason(api.HealthCritical, service.Service),
 				Notes:     fmt.Sprintf("consul-ecs created and updates this check because the %s container has an ECS health check.", containerName),
-			}
-			c.checks[check.CheckID] = check
-			checks = append(checks, check)
+			})
 		}
 	}
 
 	// Add a custom check that indicates dataplane readiness
-	dataplaneCheck := &api.HealthCheck{
+	checks = append(checks, &api.HealthCheck{
 		CheckID:   constructCheckID(service.ID, config.ConsulDataplaneContainerName),
 		Name:      consulDataplaneReadinessCheckName,
 		Type:      consulECSCheckType,
@@ -58,156 +45,8 @@ func (c *Command) constructChecks(service *api.AgentService) api.HealthChecks {
 		Status:    api.HealthCritical,
 		Output:    healthCheckOutputReason(api.HealthCritical, service.Service),
 		Notes:     "consul-ecs created and updates this check to indicate consul-dataplane container's readiness",
-	}
-	c.checks[dataplaneCheck.CheckID] = dataplaneCheck
-	checks = append(checks, dataplaneCheck)
+	})
 	return checks
-}
-
-// syncChecks fetches metadata for the ECS task and uses that metadata to
-// updates the Consul TTL checks for the containers specified in
-// `parsedContainerNames`. Checks are only updated if they have changed since
-// the last invocation of this function.
-func (c *Command) syncChecks(consulClient *api.Client,
-	currentStatuses map[string]string,
-	serviceName string,
-	clusterARN string,
-	parsedContainerNames []string) map[string]string {
-	// Fetch task metadata to get latest health of the containers
-	taskMeta, err := awsutil.ECSTaskMetadata()
-	if err != nil {
-		c.log.Error("unable to get task metadata", "err", err)
-		return currentStatuses
-	}
-
-	containersToSync, missingContainers := findContainersToSync(parsedContainerNames, taskMeta)
-
-	// Mark the Consul health status as critical for missing containers
-	for _, name := range missingContainers {
-		checkID := constructCheckID(makeServiceID(serviceName, taskMeta.TaskID()), name)
-		c.log.Debug("marking container as unhealthy since it wasn't found in the task metadata", "name", name)
-
-		var err error
-		if name == config.ConsulDataplaneContainerName {
-			err = c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, name, ecs.HealthStatusUnhealthy)
-		} else {
-			err = c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecs.HealthStatusUnhealthy)
-		}
-
-		if err != nil {
-			c.log.Error("failed to update Consul health status for missing container", "err", err, "container", name)
-		} else {
-			c.log.Info("container health check updated in Consul for missing container", "container", name)
-			currentStatuses[name] = api.HealthCritical
-		}
-	}
-
-	for _, container := range containersToSync {
-		c.log.Debug("updating Consul check from ECS container health",
-			"name", container.Name,
-			"status", container.Health.Status,
-			"statusSince", container.Health.StatusSince,
-			"exitCode", container.Health.ExitCode,
-		)
-
-		previousStatus := currentStatuses[container.Name]
-		if container.Health.Status != previousStatus {
-			var err error
-			if container.Name == config.ConsulDataplaneContainerName {
-				err = c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, container.Name, container.Health.Status)
-			} else {
-				checkID := constructCheckID(makeServiceID(serviceName, taskMeta.TaskID()), container.Name)
-				err = c.updateConsulHealthStatus(consulClient, checkID, clusterARN, container.Health.Status)
-			}
-
-			if err != nil {
-				c.log.Warn("failed to update Consul health status", "err", err)
-			} else {
-				c.log.Info("container health check updated in Consul",
-					"name", container.Name,
-					"status", container.Health.Status,
-					"statusSince", container.Health.StatusSince,
-					"exitCode", container.Health.ExitCode,
-				)
-				currentStatuses[container.Name] = container.Health.Status
-			}
-		}
-	}
-
-	return currentStatuses
-}
-
-// setChecksCritical sets checks for all of the containers to critical
-func (c *Command) setChecksCritical(consulClient *api.Client, taskID, serviceName, clusterARN string, parsedContainerNames []string) error {
-	var result error
-
-	for _, containerName := range parsedContainerNames {
-
-		var err error
-		if containerName == config.ConsulDataplaneContainerName {
-			err = c.handleHealthForDataplaneContainer(consulClient, taskID, serviceName, clusterARN, containerName, ecs.HealthStatusUnhealthy)
-		} else {
-			checkID := constructCheckID(makeServiceID(serviceName, taskID), containerName)
-			err = c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecs.HealthStatusUnhealthy)
-		}
-
-		if err == nil {
-			c.log.Info("set Consul health status to critical",
-				"container", containerName)
-		} else {
-			c.log.Warn("failed to set Consul health status to critical",
-				"err", err,
-				"container", containerName)
-			result = multierror.Append(result, err)
-		}
-	}
-
-	return result
-}
-
-// handleHealthForDataplaneContainer takes care of the special handling needed for syncing
-// the health of consul-dataplane container. We register two checks (one for the service
-// and the other for proxy) when registering a typical service to the catalog. Updates
-// should also happen twice in such cases.
-func (c *Command) handleHealthForDataplaneContainer(consulClient *api.Client, taskID, serviceName, clusterARN, containerName, ecsHealthStatus string) error {
-	var checkID string
-	serviceID := makeServiceID(serviceName, taskID)
-	if c.config.IsGateway() {
-		checkID = constructCheckID(serviceID, containerName)
-		return c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
-	}
-
-	checkID = constructCheckID(serviceID, containerName)
-	err := c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
-	if err != nil {
-		return err
-	}
-
-	proxySvcID, _ := makeProxySvcIDAndName(serviceID, "")
-	checkID = constructCheckID(proxySvcID, containerName)
-	return c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
-}
-
-func (c *Command) updateConsulHealthStatus(consulClient *api.Client, checkID string, clusterARN string, ecsHealthStatus string) error {
-	consulHealthStatus := ecsHealthToConsulHealth(ecsHealthStatus)
-
-	check, ok := c.checks[checkID]
-	if !ok {
-		return fmt.Errorf("unable to find check with ID %s", checkID)
-	}
-
-	check.Status = consulHealthStatus
-	check.Output = fmt.Sprintf("ECS health status is %q for container %q", ecsHealthStatus, checkID)
-	c.checks[checkID] = check
-
-	updateCheckReq := &api.CatalogRegistration{
-		Node:           clusterARN,
-		SkipNodeUpdate: true,
-		Checks:         api.HealthChecks{check},
-	}
-
-	_, err := consulClient.Catalog().Register(updateCheckReq, nil)
-	return err
 }
 
 func constructCheckID(serviceID, containerName string) string {
@@ -220,33 +59,4 @@ func healthCheckOutputReason(status, serviceName string) string {
 	}
 
 	return fmt.Sprintf("Service %s is not ready", serviceName)
-}
-
-func findContainersToSync(containerNames []string, taskMeta awsutil.ECSTaskMeta) ([]awsutil.ECSTaskMetaContainer, []string) {
-	var ecsContainers []awsutil.ECSTaskMetaContainer
-	var missing []string
-
-	for _, container := range containerNames {
-		found := false
-		for _, ecsContainer := range taskMeta.Containers {
-			if ecsContainer.Name == container {
-				ecsContainers = append(ecsContainers, ecsContainer)
-				found = true
-				break
-			}
-		}
-		if !found {
-			missing = append(missing, container)
-		}
-	}
-	return ecsContainers, missing
-}
-
-func ecsHealthToConsulHealth(ecsHealth string) string {
-	// `HEALTHY`, `UNHEALTHY`, and `UNKNOWN` are the valid ECS health statuses.
-	// This assumes that the only passing status is `HEALTHY`
-	if ecsHealth != ecs.HealthStatusHealthy {
-		return api.HealthCritical
-	}
-	return api.HealthPassing
 }

--- a/subcommand/control-plane/checks_test.go
+++ b/subcommand/control-plane/checks_test.go
@@ -6,8 +6,6 @@ package controlplane
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
@@ -120,66 +118,7 @@ func TestConstructChecks(t *testing.T) {
 				HealthSyncContainers: c.healthSyncContainers,
 			}
 
-			cmd.checks = make(map[string]*api.HealthCheck)
-
 			require.Equal(t, c.expectedChecks, cmd.constructChecks(c.service))
-		})
-	}
-}
-
-func TestEcsHealthToConsulHealth(t *testing.T) {
-	require.Equal(t, api.HealthPassing, ecsHealthToConsulHealth(ecs.HealthStatusHealthy))
-	require.Equal(t, api.HealthCritical, ecsHealthToConsulHealth(ecs.HealthStatusUnknown))
-	require.Equal(t, api.HealthCritical, ecsHealthToConsulHealth(ecs.HealthStatusUnhealthy))
-	require.Equal(t, api.HealthCritical, ecsHealthToConsulHealth(""))
-}
-
-func TestFindContainersToSync(t *testing.T) {
-	taskMetaContainer1 := awsutil.ECSTaskMetaContainer{
-		Name: "container1",
-	}
-
-	cases := map[string]struct {
-		containerNames []string
-		taskMeta       awsutil.ECSTaskMeta
-		missing        []string
-		found          []awsutil.ECSTaskMetaContainer
-	}{
-		"A container isn't in the metadata": {
-			containerNames: []string{"container1"},
-			taskMeta:       awsutil.ECSTaskMeta{},
-			missing:        []string{"container1"},
-			found:          nil,
-		},
-		"The metadata has an extra container": {
-			containerNames: []string{},
-			taskMeta: awsutil.ECSTaskMeta{
-				Containers: []awsutil.ECSTaskMetaContainer{
-					taskMetaContainer1,
-				},
-			},
-			missing: nil,
-			found:   nil,
-		},
-		"some found and some not found": {
-			containerNames: []string{"container1", "container2"},
-			taskMeta: awsutil.ECSTaskMeta{
-				Containers: []awsutil.ECSTaskMetaContainer{
-					taskMetaContainer1,
-				},
-			},
-			missing: []string{"container2"},
-			found: []awsutil.ECSTaskMetaContainer{
-				taskMetaContainer1,
-			},
-		},
-	}
-
-	for name, testData := range cases {
-		t.Run(name, func(t *testing.T) {
-			found, missing := findContainersToSync(testData.containerNames, testData.taskMeta)
-			require.Equal(t, testData.missing, missing)
-			require.Equal(t, testData.found, found)
 		})
 	}
 }

--- a/subcommand/control-plane/command.go
+++ b/subcommand/control-plane/command.go
@@ -7,16 +7,12 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
-	"os/signal"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -27,7 +23,6 @@ import (
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/cli"
 )
 
@@ -38,45 +33,16 @@ type Command struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
-	sigs   chan os.Signal
 	once   sync.Once
-
-	isHealthy atomic.Bool
-	checks    map[string]*api.HealthCheck
-
-	dataplaneMonitor *dataplaneMonitor
-
-	watcherCh <-chan discovery.State
-
-	// Following fields are only needed for unit tests
-
-	// control plane signals to this channel whenever it has completed
-	// registration of service and proxy to the server. Used only for unit tests
-	doneChan chan struct{}
-
-	// control plane waits for someone to signal to this channel before
-	// entering the checks reconcilation loop. Used only for unit tests
-	proceedChan chan struct{}
-
-	// Indicates that the command is run from a unit test
-	isTestEnv bool
-
-	// Health check address assigned via unit tests
-	healthCheckListenerAddr string
 }
 
 const (
 	dataplaneConfigFileName = "consul-dataplane.json"
 	caCertFileName          = "consul-grpc-ca-cert.pem"
-
-	defaultHealthCheckBindAddr = "127.0.0.1"
-	defaultHealthCheckBindPort = "10000"
 )
 
 func (c *Command) init() {
 	c.ctx, c.cancel = context.WithCancel(context.Background())
-	c.sigs = make(chan os.Signal, 1)
-	c.isHealthy.Store(false)
 }
 
 func (c *Command) Run(args []string) int {
@@ -95,7 +61,6 @@ func (c *Command) Run(args []string) int {
 	c.config = config
 
 	c.log = logging.FromConfig(c.config).Logger()
-	c.dataplaneMonitor = newDataplaneMonitor(c.ctx, c.log)
 
 	err = c.realRun()
 	if err != nil {
@@ -106,13 +71,7 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) realRun() error {
-	signal.Notify(c.sigs, syscall.SIGTERM)
 	defer c.cleanup()
-
-	// Register and start health check handler.
-	go c.startHealthCheckServer()
-
-	go c.dataplaneMonitor.run()
 
 	taskMeta, err := awsutil.ECSTaskMetadata()
 	if err != nil {
@@ -146,12 +105,6 @@ func (c *Command) realRun() error {
 	if err != nil {
 		return fmt.Errorf("constructing consul client from config: %s", err)
 	}
-
-	if !c.isTestEnv {
-		c.watcherCh = watcher.Subscribe()
-	}
-
-	c.checks = make(map[string]*api.HealthCheck)
 
 	var serviceRegistration, proxyRegistration *api.CatalogRegistration
 	if c.config.Gateway != nil && c.config.Gateway.Kind != "" {
@@ -202,66 +155,12 @@ func (c *Command) realRun() error {
 		return err
 	}
 
-	// Marking the control plane healthy so that ECS can start
-	// other containers within the task depending on this.
-	c.isHealthy.Store(true)
-
-	serviceName := c.constructServiceName(taskMeta.Family)
-	currentHealthStatuses := make(map[string]string)
-
-	var healthSyncContainers []string
-	healthSyncContainers = append(healthSyncContainers, c.config.HealthSyncContainers...)
-	healthSyncContainers = append(healthSyncContainers, config.ConsulDataplaneContainerName)
-
-	if c.isTestEnv {
-		close(c.doneChan)
-		<-c.proceedChan
-	}
-
-	for {
-		select {
-		case <-time.After(syncChecksInterval):
-			currentHealthStatuses = c.syncChecks(consulClient, currentHealthStatuses, serviceName, clusterARN, healthSyncContainers)
-		case watcherState := <-c.watcherCh:
-			c.log.Info("Switching to Consul server", "address", watcherState.Address.String())
-			client, err := c.setupConsulAPIClient(watcherState)
-			if err != nil {
-				c.log.Error("error re-configuring consul client %s", err.Error())
-			} else {
-				consulClient = client
-			}
-		case <-c.sigs:
-			c.log.Info("Received SIGTERM. Beginning graceful shutdown by first marking all checks as critical.")
-
-			err := c.setChecksCritical(consulClient, taskMeta.TaskID(), serviceName, clusterARN, healthSyncContainers)
-			if err != nil {
-				c.log.Error("Error marking the status of checks as critical: %s", err.Error())
-			}
-		case <-c.dataplaneMonitor.done():
-			var result error
-			c.log.Info("Dataplane has successfully shutdown. Deregistering services and terminating control plane")
-
-			err = c.deregisterServiceAndProxy(consulClient, clusterARN, serviceRegistration, proxyRegistration)
-			if err != nil {
-				c.log.Error("error deregistering service and proxy %s", err.Error())
-				result = multierror.Append(result, err)
-			}
-
-			if c.config.ConsulLogin.Enabled {
-				_, err = consulClient.ACL().Logout(nil)
-				if err != nil {
-					c.log.Error("error logging out of consul %s", err.Error())
-					result = multierror.Append(result, err)
-				}
-			}
-
-			return result
-		}
-	}
+	c.log.Info("successfully initialized the task to operate as part of the mesh")
+	return nil
 }
 
 func (c *Command) Synopsis() string {
-	return "Initializes and monitors a mesh app"
+	return "Initializes a mesh app"
 }
 
 func (c *Command) Help() string {
@@ -269,7 +168,6 @@ func (c *Command) Help() string {
 }
 
 func (c *Command) cleanup() {
-	signal.Stop(c.sigs)
 	// Cancel background goroutines
 	c.cancel()
 }
@@ -278,35 +176,6 @@ func retryLogger(log hclog.Logger) backoff.Notify {
 	return func(err error, duration time.Duration) {
 		log.Error(err.Error(), "retry", duration.String())
 	}
-}
-
-// startHealthCheckServer registers a custom health check handler
-// that indicates the control plane's readiness. The endpoint becomes
-// healthy when the control plane successfully registers the service
-// and proxy configurations and writes the dataplane's configuration
-// to a shared volume.
-func (c *Command) startHealthCheckServer() {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/consul-ecs/health", c.handleHealthCheck)
-	var handler http.Handler = mux
-
-	listenerBindAddr := net.JoinHostPort(defaultHealthCheckBindAddr, defaultHealthCheckBindPort)
-	if c.healthCheckListenerAddr != "" {
-		listenerBindAddr = c.healthCheckListenerAddr
-	}
-	c.UI.Info(fmt.Sprintf("Listening on %q...", listenerBindAddr))
-	if err := http.ListenAndServe(listenerBindAddr, handler); err != nil {
-		c.UI.Error(fmt.Sprintf("Error listening: %s", err))
-	}
-}
-
-func (c *Command) handleHealthCheck(rw http.ResponseWriter, _ *http.Request) {
-	if !c.isHealthy.Load() {
-		c.UI.Error("[GET /consul-ecs/health] consul-ecs control plane is not yet healthy")
-		rw.WriteHeader(500)
-		return
-	}
-	rw.WriteHeader(200)
 }
 
 func (c *Command) setupConsulAPIClient(state discovery.State) (*api.Client, error) {
@@ -555,36 +424,6 @@ func (c *Command) writeRPCCACertToSharedVolume() (string, error) {
 	}
 
 	return caCertPath, nil
-}
-
-func (c *Command) deregisterServiceAndProxy(consulClient *api.Client, clusterARN string, serviceRegistration, proxyRegistration *api.CatalogRegistration) error {
-	var result error
-	if serviceRegistration != nil {
-		err := deregisterConsulService(consulClient, serviceRegistration, clusterARN)
-		if err != nil {
-			result = multierror.Append(result, err)
-		}
-	}
-
-	// Proxy deregistration
-	err := deregisterConsulService(consulClient, proxyRegistration, clusterARN)
-	if err != nil {
-		result = multierror.Append(result, err)
-	}
-
-	return result
-}
-
-func deregisterConsulService(client *api.Client, reg *api.CatalogRegistration, node string) error {
-	deregInput := &api.CatalogDeregistration{
-		Node:      node,
-		ServiceID: reg.Service.ID,
-		Namespace: reg.Service.Namespace,
-		Partition: reg.Service.Partition,
-	}
-
-	_, err := client.Catalog().Deregister(deregInput, nil)
-	return err
 }
 
 func getNodeMeta() map[string]string {


### PR DESCRIPTION
## Changes proposed in this PR:

One of many PRs that involved remodelling Consul on ECS to support TProxy. This PR focusses on removing the following functionalities from the control-plane container.

- Made it a short lived container
- Removed custom health check server
- Removed dataplane monitor to facilitate graceful shutdown
- Removed reconciliation loop that sync back ECS health checks into Consul.
- Removed logic to deregisterServiceAndProxy and Consul logout from control plane.
- Lots of code related to syncing ECS health checks into Consul
- Bunch of test code that is related to ☝️ 


In the new architecture, control plane will only do the following

- Perform a consul login and write the token to a shared volume
- Register server and proxy
- Write the ECS binary to a shared volume
- Write dataplane config to a shared volume

All this logic that got removed will be added back as part of a new `health-sync` command in the same binary. `Control-plane` will be renamed to mesh-init in the next PR


## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added (Rather it should be tests removed :))
- [ ] CHANGELOG entry added N/A. This is only against a feature branch for now.

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
