### PR TITLE
Pass dynamic login config to Dataplane instead of static credentials

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,10 @@ const (
 	// Cert used for internal RPC communication to the servers
 	ConsulGRPCCACertPemEnvVar = "CONSUL_GRPC_CACERT_PEM"
 
+	// Login meta fields added to the token
+	ConsulTokenTaskIDMeta    = "consul.hashicorp.com/task-id"
+	ConsulTokenClusterIDMeta = "consul.hashicorp.com/cluster"
+
 	defaultGRPCPort    = 8503
 	defaultHTTPPort    = 8501
 	defaultIAMRolePath = "/consul-ecs/"
@@ -179,8 +183,8 @@ func (c *Config) getLoginDiscoveryCredentials(taskMeta awsutil.ECSTaskMeta) (dis
 
 	cfg.Login.Meta = mergeMeta(
 		map[string]string{
-			"consul.hashicorp.com/task-id": taskMeta.TaskID(),
-			"consul.hashicorp.com/cluster": clusterARN,
+			ConsulTokenTaskIDMeta:    taskMeta.TaskID(),
+			ConsulTokenClusterIDMeta: clusterARN,
 		},
 		c.ConsulLogin.Meta,
 	)

--- a/internal/dataplane/dataplane_config_test.go
+++ b/internal/dataplane/dataplane_config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul-ecs/testutil"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 )
@@ -136,7 +137,20 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 						EnableTLS: testutil.BoolPtr(false),
 					},
 				},
-				ConsulToken:          "test-token-123",
+				ConsulLoginCredentials: &discovery.Credentials{
+					Type: "login",
+					Login: discovery.LoginCredential{
+						AuthMethod:  "test-auth-method",
+						BearerToken: "bearer-token",
+						Datacenter:  "dc1",
+						Namespace:   "foo",
+						Partition:   "bar",
+						Meta: map[string]string{
+							"consul.hashicorp.com/task-id": "my-task-id",
+							"consul.hashicorp.com/cluster": "test-cluster-arn",
+						},
+					},
+				},
 				ProxyHealthCheckPort: 22000,
 				LogLevel:             "WARN",
 			},
@@ -149,9 +163,17 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					"disabled": true
 				  },
 				  "credentials": {
-					"type": "static",
-					"static": {
-						"token": "test-token-123"
+					"type": "login",
+					"login": {
+						"authMethod": "test-auth-method",
+						"bearerToken": "bearer-token",
+						"datacenter": "dc1",
+						"namespace": "foo",
+						"partition": "bar",
+						"meta": {
+							"consul.hashicorp.com/task-id": "my-task-id",
+							"consul.hashicorp.com/cluster": "test-cluster-arn"
+						}
 					}
 				  }
 				},
@@ -193,7 +215,18 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 						EnableTLS:     testutil.BoolPtr(true),
 					},
 				},
-				ConsulToken:          "test-token-123",
+				ConsulLoginCredentials: &discovery.Credentials{
+					Type: "login",
+					Login: discovery.LoginCredential{
+						AuthMethod:  "test-auth-method",
+						BearerToken: "bearer-token",
+						Datacenter:  "dc1",
+						Meta: map[string]string{
+							"consul.hashicorp.com/task-id": "my-task-id",
+							"consul.hashicorp.com/cluster": "test-cluster-arn",
+						},
+					},
+				},
 				CACertFile:           "/consul/ca-cert.pem",
 				ProxyHealthCheckPort: 23000,
 				LogLevel:             "TRACE",
@@ -209,9 +242,15 @@ func TestGetDataplaneConfigJSON(t *testing.T) {
 					"tlsServerName": "consul.dc1"
 				  },
 				  "credentials": {
-					"type": "static",
-					"static": {
-						"token": "test-token-123"
+					"type": "login",
+					"login": {
+						"authMethod": "test-auth-method",
+						"bearerToken": "bearer-token",
+						"datacenter": "dc1",
+						"meta": {
+							"consul.hashicorp.com/task-id": "my-task-id",
+							"consul.hashicorp.com/cluster": "test-cluster-arn"
+						}
 					}
 				  }
 				},

--- a/internal/dataplane/dataplane_json.go
+++ b/internal/dataplane/dataplane_json.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 )
 
-type dataplaneConfig struct {
+type DataplaneConfig struct {
 	Consul    ConsulConfig    `json:"consul"`
 	Proxy     ProxyConfig     `json:"proxy"`
 	XDSServer XDSServerConfig `json:"xdsServer"`
@@ -31,11 +31,16 @@ type TLSConfig struct {
 
 type CredentialsConfig struct {
 	CredentialType string                 `json:"type"`
-	Static         StaticCredentialConfig `json:"static"`
+	Login          LoginCredentialsConfig `json:"login"`
 }
 
-type StaticCredentialConfig struct {
-	Token string `json:"token"`
+type LoginCredentialsConfig struct {
+	AuthMethod  string            `json:"authMethod"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Partition   string            `json:"partition,omitempty"`
+	Datacenter  string            `json:"datacenter"`
+	BearerToken string            `json:"bearerToken"`
+	Meta        map[string]string `json:"meta"`
 }
 
 type ProxyConfig struct {
@@ -58,7 +63,7 @@ type LoggingConfig struct {
 	LogLevel string `json:"logLevel"`
 }
 
-func (d *dataplaneConfig) generateJSON() ([]byte, error) {
+func (d *DataplaneConfig) generateJSON() ([]byte, error) {
 	dataplaneJSON, err := json.Marshal(&d)
 	if err != nil {
 		return nil, err

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -399,7 +399,7 @@ func TestRun(t *testing.T) {
 			assertServiceAndProxyRegistrations(t, consulClient, expectedService, expectedProxy, expectedServiceName, expectedProxy.ServiceName)
 			assertCheckRegistration(t, consulClient, expectedServiceChecks, expectedProxyCheck)
 			assertWrittenFiles(t, expectedFileMeta)
-			assertDataplaneConfig(t, taskMetadataResponse, consulEcsConfig, c.skipServerWatch, serverGRPCPort, envoyBootstrapDir, dataplaneConfigJSONFile, expectedProxy.ServiceID, expectedNamespace, expectedPartition, consulEcsConfig.LogLevel)
+			assertDataplaneConfig(t, taskMetadataResponse, consulEcsConfig, c.skipServerWatch, serverGRPCPort, dataplaneConfigJSONFile, expectedProxy.ServiceID, expectedNamespace, expectedPartition, consulEcsConfig.LogLevel)
 
 			for _, expCheck := range expectedServiceChecks {
 				expCheck.Status = api.HealthCritical
@@ -720,7 +720,7 @@ func TestGateway(t *testing.T) {
 			assertServiceAndProxyRegistrations(t, consulClient, nil, expectedService, "", c.expServiceName)
 			assertCheckRegistration(t, consulClient, nil, expectedCheck)
 			assertWrittenFiles(t, expectedFileMeta)
-			assertDataplaneConfig(t, taskMetadataResponse, c.config, true, serverGRPCPort, c.config.BootstrapDir, dataplaneConfigJSONFile, expectedService.ServiceID, namespace, partition, "INFO")
+			assertDataplaneConfig(t, taskMetadataResponse, c.config, true, serverGRPCPort, dataplaneConfigJSONFile, expectedService.ServiceID, namespace, partition, "INFO")
 
 			expectedCheck.Status = api.HealthCritical
 			assertHealthChecks(t, consulClient, nil, expectedCheck)
@@ -896,7 +896,7 @@ func assertWrittenFiles(t *testing.T, expectedFiles []*fileMeta) {
 	}
 }
 
-func assertDataplaneConfig(t *testing.T, ecsTaskMeta *awsutil.ECSTaskMeta, cfg *config.Config, skipServerWatch bool, grpcPort int, bootstrapDir, dataplaneConfigJSONFile, proxySvcID, namespace, partition, logLevel string) {
+func assertDataplaneConfig(t *testing.T, ecsTaskMeta *awsutil.ECSTaskMeta, cfg *config.Config, skipServerWatch bool, grpcPort int, dataplaneConfigJSONFile, proxySvcID, namespace, partition, logLevel string) {
 	clusterARN, err := ecsTaskMeta.ClusterARN()
 	require.NoError(t, err)
 

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -4,7 +4,6 @@
 package controlplane
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul-ecs/config"
+	"github.com/hashicorp/consul-ecs/internal/dataplane"
 	"github.com/hashicorp/consul-ecs/testutil"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -145,6 +145,7 @@ func TestRun(t *testing.T) {
 		},
 		"auth method enabled": {
 			consulLogin: config.ConsulLogin{
+				Datacenter:    "dc1",
 				Enabled:       true,
 				IncludeEntity: true,
 				Meta: map[string]string{
@@ -242,11 +243,6 @@ func TestRun(t *testing.T) {
 			ui := cli.NewMockUi()
 			cmd := Command{UI: ui}
 
-			cmd.ctx, cmd.cancel = context.WithCancel(context.Background())
-			t.Cleanup(func() {
-				cmd.cancel()
-			})
-
 			envoyBootstrapDir := testutil.TempDir(t)
 			dataplaneConfigJSONFile := filepath.Join(envoyBootstrapDir, dataplaneConfigFileName)
 			expectedFileMeta := []*fileMeta{
@@ -265,7 +261,7 @@ func TestRun(t *testing.T) {
 			_, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
 			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
 
-			consulEcsConfig := config.Config{
+			consulEcsConfig := &config.Config{
 				LogLevel:             "DEBUG",
 				BootstrapDir:         envoyBootstrapDir,
 				HealthSyncContainers: c.healthSyncContainers,
@@ -296,7 +292,7 @@ func TestRun(t *testing.T) {
 				consulEcsConfig.Service.Namespace = expectedNamespace
 				consulEcsConfig.Service.Partition = expectedPartition
 			}
-			testutil.SetECSConfigEnvVar(t, &consulEcsConfig)
+			testutil.SetECSConfigEnvVar(t, consulEcsConfig)
 
 			if !c.missingAWSRegion {
 				t.Setenv(awsutil.AWSRegionEnvVar, testRegion)
@@ -403,7 +399,7 @@ func TestRun(t *testing.T) {
 			assertServiceAndProxyRegistrations(t, consulClient, expectedService, expectedProxy, expectedServiceName, expectedProxy.ServiceName)
 			assertCheckRegistration(t, consulClient, expectedServiceChecks, expectedProxyCheck)
 			assertWrittenFiles(t, expectedFileMeta)
-			assertDataplaneConfigJSON(t, c.skipServerWatch, serverGRPCPort, c.consulLogin.Enabled, envoyBootstrapDir, dataplaneConfigJSONFile, expectedProxy.ServiceID, expectedNamespace, expectedPartition, consulEcsConfig.LogLevel)
+			assertDataplaneConfig(t, taskMetadataResponse, consulEcsConfig, c.skipServerWatch, serverGRPCPort, envoyBootstrapDir, dataplaneConfigJSONFile, expectedProxy.ServiceID, expectedNamespace, expectedPartition, consulEcsConfig.LogLevel)
 
 			for _, expCheck := range expectedServiceChecks {
 				expCheck.Status = api.HealthCritical
@@ -412,7 +408,6 @@ func TestRun(t *testing.T) {
 
 			// Verify with retries that the checks have reached the expected state
 			assertHealthChecks(t, consulClient, expectedServiceChecks, expectedProxyCheck)
-			cmd.cancel()
 		})
 	}
 }
@@ -679,11 +674,6 @@ func TestGateway(t *testing.T) {
 			ui := cli.NewMockUi()
 			cmd := Command{UI: ui}
 
-			cmd.ctx, cmd.cancel = context.WithCancel(context.Background())
-			t.Cleanup(func() {
-				cmd.cancel()
-			})
-
 			code := cmd.Run(nil)
 			require.Equal(t, code, 0, ui.ErrorWriter.String())
 
@@ -730,12 +720,10 @@ func TestGateway(t *testing.T) {
 			assertServiceAndProxyRegistrations(t, consulClient, nil, expectedService, "", c.expServiceName)
 			assertCheckRegistration(t, consulClient, nil, expectedCheck)
 			assertWrittenFiles(t, expectedFileMeta)
-			assertDataplaneConfigJSON(t, true, serverGRPCPort, c.config.ConsulLogin.Enabled, c.config.BootstrapDir, dataplaneConfigJSONFile, expectedService.ServiceID, namespace, partition, "INFO")
+			assertDataplaneConfig(t, taskMetadataResponse, c.config, true, serverGRPCPort, c.config.BootstrapDir, dataplaneConfigJSONFile, expectedService.ServiceID, namespace, partition, "INFO")
 
 			expectedCheck.Status = api.HealthCritical
 			assertHealthChecks(t, consulClient, nil, expectedCheck)
-
-			cmd.cancel()
 		})
 	}
 }
@@ -908,23 +896,72 @@ func assertWrittenFiles(t *testing.T, expectedFiles []*fileMeta) {
 	}
 }
 
-func assertDataplaneConfigJSON(t *testing.T, skipServerWatch bool, grpcPort int, loginEnabled bool, bootstrapDir, dataplaneConfigJSONFile, proxySvcID, namespace, partition, logLevel string) {
-	var credentialsConfigJSON string
-	if loginEnabled {
-		token := getACLToken(t, bootstrapDir)
-		credentialsConfigJSON = fmt.Sprintf(`,
-		"credentials": {
-			"type": "static",
-			"static": {
-				"token": "%s"
-			}
-		}`, token)
+func assertDataplaneConfig(t *testing.T, ecsTaskMeta *awsutil.ECSTaskMeta, cfg *config.Config, skipServerWatch bool, grpcPort int, bootstrapDir, dataplaneConfigJSONFile, proxySvcID, namespace, partition, logLevel string) {
+	clusterARN, err := ecsTaskMeta.ClusterARN()
+	require.NoError(t, err)
+
+	expectedCfg := &dataplane.DataplaneConfig{
+		Consul: dataplane.ConsulConfig{
+			Addresses:       "127.0.0.1",
+			GRPCPort:        grpcPort,
+			SkipServerWatch: skipServerWatch,
+			TLS: &dataplane.TLSConfig{
+				Disabled: true,
+			},
+		},
+		Proxy: dataplane.ProxyConfig{
+			NodeName:  clusterARN,
+			ID:        proxySvcID,
+			Partition: partition,
+			Namespace: namespace,
+		},
+		XDSServer: dataplane.XDSServerConfig{
+			Address: "127.0.0.1",
+		},
+		Envoy: dataplane.EnvoyConfig{
+			ReadyBindAddr: "127.0.0.1",
+			ReadyBindPort: 22000,
+		},
+		Logging: dataplane.LoggingConfig{
+			LogLevel: logLevel,
+		},
 	}
 
-	expectedDataplaneConfigJSON := fmt.Sprintf(getExpectedDataplaneCfgJSON(), grpcPort, skipServerWatch, credentialsConfigJSON, proxySvcID, namespace, partition, logLevel)
-	actualDataplaneConfig, err := os.ReadFile(dataplaneConfigJSONFile)
+	if cfg.ConsulLogin.Enabled {
+		meta := make(map[string]string)
+
+		for k, v := range cfg.ConsulLogin.Meta {
+			meta[k] = v
+		}
+		meta[config.ConsulTokenTaskIDMeta] = ecsTaskMeta.TaskID()
+		meta[config.ConsulTokenClusterIDMeta] = clusterARN
+
+		// We intentionally ignore the bearer token from this config
+		// because it gets generated in a random fashion.
+		expectedCfg.Consul.Credentials = &dataplane.CredentialsConfig{
+			CredentialType: "login",
+			Login: dataplane.LoginCredentialsConfig{
+				AuthMethod: config.DefaultAuthMethodName,
+				Datacenter: cfg.ConsulLogin.Datacenter,
+				Partition:  partition,
+				Meta:       meta,
+			},
+		}
+	}
+
+	actualDataplaneJSON, err := os.ReadFile(dataplaneConfigJSONFile)
 	require.NoError(t, err)
-	require.JSONEq(t, expectedDataplaneConfigJSON, string(actualDataplaneConfig))
+	require.NotNil(t, actualDataplaneJSON)
+
+	var actualDataplaneConfig *dataplane.DataplaneConfig
+	err = json.Unmarshal(actualDataplaneJSON, &actualDataplaneConfig)
+	require.NoError(t, err)
+
+	ignoreFields := cmpopts.IgnoreFields(dataplane.DataplaneConfig{}, "Consul.Credentials.Login.BearerToken")
+	require.Empty(t, cmp.Diff(expectedCfg, actualDataplaneConfig, ignoreFields))
+
+	// Assert if the bearer token is present
+	require.NotEmpty(t, actualDataplaneConfig.Consul.Credentials.Login.BearerToken)
 }
 
 // In a ACL enabled cluster, we expect the node to be preregistered by the ecs-controller.
@@ -968,14 +1005,6 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 	})
 }
 
-func getACLToken(t *testing.T, bootstrapDir string) string {
-	tokenFile := filepath.Join(bootstrapDir, config.ServiceTokenFilename)
-	token, err := os.ReadFile(tokenFile)
-	require.NoError(t, err)
-
-	return string(token)
-}
-
 func constructTaskMetaResponseString(resp *awsutil.ECSTaskMeta) (string, error) {
 	byteStr, err := json.Marshal(resp)
 	if err != nil {
@@ -983,33 +1012,4 @@ func constructTaskMetaResponseString(resp *awsutil.ECSTaskMeta) (string, error) 
 	}
 
 	return string(byteStr), nil
-}
-
-func getExpectedDataplaneCfgJSON() string {
-	return `{
-	"consul": {
-	  "addresses": "127.0.0.1",
-	  "grpcPort": %d,
-	  "serverWatchDisabled": %t,
-	  "tls": {
-		"disabled": true
-	   }%s
-	},
-	"proxy": {
-	  "nodeName": "arn:aws:ecs:us-east-1:123456789:cluster/test",
-	  "id": "%s",
-	  "namespace": "%s",
-	  "partition": "%s"
-	},
-	"xdsServer": {
-	  "bindAddress": "127.0.0.1"
-	},
-	"envoy": {
-		"readyBindAddress": "127.0.0.1",
-		"readyBindPort": 22000
-	},
-	"logging": {
-		"logLevel": "%s"
-	}
-  }`
 }

--- a/subcommand/control-plane/command_test.go
+++ b/subcommand/control-plane/command_test.go
@@ -961,7 +961,9 @@ func assertDataplaneConfig(t *testing.T, ecsTaskMeta *awsutil.ECSTaskMeta, cfg *
 	require.Empty(t, cmp.Diff(expectedCfg, actualDataplaneConfig, ignoreFields))
 
 	// Assert if the bearer token is present
-	require.NotEmpty(t, actualDataplaneConfig.Consul.Credentials.Login.BearerToken)
+	if cfg.ConsulLogin.Enabled {
+		require.NotEmpty(t, actualDataplaneConfig.Consul.Credentials.Login.BearerToken)
+	}
 }
 
 // In a ACL enabled cluster, we expect the node to be preregistered by the ecs-controller.


### PR DESCRIPTION
## Changes proposed in this PR:
- With the new architecture, consul control-plane/mesh-init will no longer pass a static Consul ACL token to Consul dataplane. The moment control-plane exits (being a short lived container now) the Consul ACL token gets invalidated by the server connection manager. This makes the token unusable and there is no point in writing it to a shared volume and passing it across dependent containers.
- We instead pass the `LoginCredentialConfig` to dataplane (the same one passed to ControlPlane) and ask dataplane itself to initiate the login. This means that dataplane gets its standalone token going forward.
- Modified the way we perform assertion of the generated dataplane configs in tests. Earlier we operated on a json string which was fragile and hard to test. This PR modifies the same to unmarshal the resultant json into a struct and compare it with an expected config struct.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
