### PR TITLE
Add health-sync command to ECS

### DIFF
--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -98,12 +98,11 @@ jobs:
         PACKAGE_NAMES=$(go list ./... | grep -v 'mocks\|hack\|testing' | tr '\n' ' ')
         echo "Testing $(echo $PACKAGE_NAMES | wc -w) packages"
         if [[ "${{ matrix.consul-version }}" == *ent ]]; then
-          FLAGS=-enterprise
+          FLAGS=-enterprise -timeout 3m
           TAGS=-tags=enterprise
         fi
         gotestsum \
           --format=short-verbose \
-          --timeout=3m \
           --jsonfile $TEST_RESULTS_DIR/${{ matrix.consul-version }}/json/go-test-race.log \
           --junitfile $TEST_RESULTS_DIR/${{ matrix.consul-version }}/gotestsum-report.xml \
           -- $PACKAGE_NAMES $TAGS -- $FLAGS

--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -103,6 +103,7 @@ jobs:
         fi
         gotestsum \
           --format=short-verbose \
+          --timeout=3m \
           --jsonfile $TEST_RESULTS_DIR/${{ matrix.consul-version }}/json/go-test-race.log \
           --junitfile $TEST_RESULTS_DIR/${{ matrix.consul-version }}/gotestsum-report.xml \
           -- $PACKAGE_NAMES $TAGS -- $FLAGS

--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -98,7 +98,7 @@ jobs:
         PACKAGE_NAMES=$(go list ./... | grep -v 'mocks\|hack\|testing' | tr '\n' ' ')
         echo "Testing $(echo $PACKAGE_NAMES | wc -w) packages"
         if [[ "${{ matrix.consul-version }}" == *ent ]]; then
-          FLAGS=-enterprise -timeout 3m
+          FLAGS=-enterprise
           TAGS=-tags=enterprise
         fi
         gotestsum \

--- a/commands.go
+++ b/commands.go
@@ -9,6 +9,7 @@ import (
 	cmdAppEntrypoint "github.com/hashicorp/consul-ecs/subcommand/app-entrypoint"
 	cmdController "github.com/hashicorp/consul-ecs/subcommand/controller"
 	cmdEnvoyEntrypoint "github.com/hashicorp/consul-ecs/subcommand/envoy-entrypoint"
+	cmdHealthSync "github.com/hashicorp/consul-ecs/subcommand/health-sync"
 	cmdMeshInit "github.com/hashicorp/consul-ecs/subcommand/mesh-init"
 	cmdNetDial "github.com/hashicorp/consul-ecs/subcommand/net-dial"
 	cmdVersion "github.com/hashicorp/consul-ecs/subcommand/version"
@@ -40,6 +41,9 @@ func init() {
 		},
 		"net-dial": func() (cli.Command, error) {
 			return &cmdNetDial.Command{UI: ui}, nil
+		},
+		"health-sync": func() (cli.Command, error) {
+			return &cmdHealthSync.Command{UI: ui}, nil
 		},
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -247,7 +247,7 @@ func TestConsulServerConnManagerConfig(t *testing.T) {
 				_, apiCfg := testutil.ConsulServer(t, srvConfig)
 				consulClient, err := api.NewClient(apiCfg)
 				require.NoError(t, err)
-				fakeAws := testutil.AuthMethodInit(t, consulClient, c.taskMeta.Family, c.cfg.ConsulLogin.Method)
+				fakeAws := testutil.AuthMethodInit(t, consulClient, c.taskMeta.Family, c.cfg.ConsulLogin.Method, nil)
 
 				// Use the fake local AWS server.
 				c.cfg.ConsulLogin.STSEndpoint = fakeAws.URL + "/sts"

--- a/subcommand/envoy-entrypoint/task-monitor.go
+++ b/subcommand/envoy-entrypoint/task-monitor.go
@@ -19,8 +19,9 @@ import (
 
 var (
 	nonAppContainers = map[string]struct{}{
-		"consul-ecs-mesh-init": {},
-		"consul-dataplane":     {},
+		"consul-ecs-mesh-init":   {},
+		"consul-dataplane":       {},
+		"consul-ecs-health-sync": {},
 	}
 )
 

--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -1,0 +1,255 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package healthsync
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-multierror"
+)
+
+// fetchHealthChecks fetches the Consul health checks for both the service
+// and proxy registrations
+func (c *Command) fetchHealthChecks(consulClient *api.Client, taskMeta awsutil.ECSTaskMeta) (map[string]*api.HealthCheck, error) {
+	serviceName := c.constructServiceName(taskMeta.Family)
+	serviceID := makeServiceID(serviceName, taskMeta.TaskID())
+	proxySvcID, proxySvcName := makeProxySvcIDAndName(serviceID, serviceName)
+
+	healthCheckMap := make(map[string]*api.HealthCheck)
+	var queryOpts *api.QueryOptions
+	if c.config.IsGateway() {
+		queryOpts = &api.QueryOptions{
+			Namespace: c.config.Gateway.Namespace,
+			Partition: c.config.Gateway.Partition,
+		}
+	} else {
+		queryOpts = &api.QueryOptions{
+			Namespace: c.config.Service.Namespace,
+			Partition: c.config.Service.Partition,
+		}
+	}
+
+	checks, err := getServiceHealthChecks(consulClient, serviceName, serviceID, queryOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, check := range checks {
+		healthCheckMap[check.CheckID] = check
+	}
+
+	if c.config.IsGateway() {
+		return healthCheckMap, nil
+	}
+
+	// Get the health checks associated with the sidecar
+	checks, err = getServiceHealthChecks(consulClient, proxySvcName, proxySvcID, queryOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(checks) != 1 {
+		return nil, fmt.Errorf("only one check should be associated with the sidecar proxy service")
+	}
+
+	healthCheckMap[checks[0].CheckID] = checks[0]
+
+	return healthCheckMap, nil
+}
+
+// setChecksCritical sets checks for all of the containers to critical
+func (c *Command) setChecksCritical(consulClient *api.Client, taskMeta awsutil.ECSTaskMeta, clusterARN string, parsedContainerNames []string) error {
+	var result error
+
+	taskID := taskMeta.TaskID()
+	serviceName := c.constructServiceName(taskMeta.Family)
+
+	for _, containerName := range parsedContainerNames {
+		var err error
+		if containerName == config.ConsulDataplaneContainerName {
+			err = c.handleHealthForDataplaneContainer(consulClient, taskID, serviceName, clusterARN, containerName, ecs.HealthStatusUnhealthy)
+		} else {
+			checkID := constructCheckID(makeServiceID(serviceName, taskID), containerName)
+			err = c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecs.HealthStatusUnhealthy)
+		}
+
+		if err == nil {
+			c.log.Info("set Consul health status to critical",
+				"container", containerName)
+		} else {
+			c.log.Warn("failed to set Consul health status to critical",
+				"err", err,
+				"container", containerName)
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result
+}
+
+// syncChecks fetches metadata for the ECS task and uses that metadata to
+// updates the Consul TTL checks for the containers specified in
+// `parsedContainerNames`. Checks are only updated if they have changed since
+// the last invocation of this function.
+func (c *Command) syncChecks(consulClient *api.Client,
+	currentStatuses map[string]string,
+	clusterARN string,
+	parsedContainerNames []string) map[string]string {
+	// Fetch task metadata to get latest health of the containers
+	taskMeta, err := awsutil.ECSTaskMetadata()
+	if err != nil {
+		c.log.Error("unable to get task metadata", "err", err)
+		return currentStatuses
+	}
+
+	serviceName := c.constructServiceName(taskMeta.Family)
+
+	containersToSync, missingContainers := findContainersToSync(parsedContainerNames, taskMeta)
+
+	// Mark the Consul health status as critical for missing containers
+	for _, name := range missingContainers {
+		checkID := constructCheckID(makeServiceID(serviceName, taskMeta.TaskID()), name)
+		c.log.Debug("marking container as unhealthy since it wasn't found in the task metadata", "name", name)
+
+		var err error
+		if name == config.ConsulDataplaneContainerName {
+			err = c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, name, ecs.HealthStatusUnhealthy)
+		} else {
+			err = c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecs.HealthStatusUnhealthy)
+		}
+
+		if err != nil {
+			c.log.Error("failed to update Consul health status for missing container", "err", err, "container", name)
+		} else {
+			c.log.Info("container health check updated in Consul for missing container", "container", name)
+			currentStatuses[name] = api.HealthCritical
+		}
+	}
+
+	for _, container := range containersToSync {
+		c.log.Debug("updating Consul check from ECS container health",
+			"name", container.Name,
+			"status", container.Health.Status,
+			"statusSince", container.Health.StatusSince,
+			"exitCode", container.Health.ExitCode,
+		)
+
+		previousStatus := currentStatuses[container.Name]
+		if container.Health.Status != previousStatus {
+			var err error
+			if container.Name == config.ConsulDataplaneContainerName {
+				err = c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, container.Name, container.Health.Status)
+			} else {
+				checkID := constructCheckID(makeServiceID(serviceName, taskMeta.TaskID()), container.Name)
+				err = c.updateConsulHealthStatus(consulClient, checkID, clusterARN, container.Health.Status)
+			}
+
+			if err != nil {
+				c.log.Warn("failed to update Consul health status", "err", err)
+			} else {
+				c.log.Info("container health check updated in Consul",
+					"name", container.Name,
+					"status", container.Health.Status,
+					"statusSince", container.Health.StatusSince,
+					"exitCode", container.Health.ExitCode,
+				)
+				currentStatuses[container.Name] = container.Health.Status
+			}
+		}
+	}
+
+	return currentStatuses
+}
+
+// handleHealthForDataplaneContainer takes care of the special handling needed for syncing
+// the health of consul-dataplane container. We register two checks (one for the service
+// and the other for proxy) when registering a typical service to the catalog. Updates
+// should also happen twice in such cases.
+func (c *Command) handleHealthForDataplaneContainer(consulClient *api.Client, taskID, serviceName, clusterARN, containerName, ecsHealthStatus string) error {
+	var checkID string
+	serviceID := makeServiceID(serviceName, taskID)
+	if c.config.IsGateway() {
+		checkID = constructCheckID(serviceID, containerName)
+		return c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
+	}
+
+	checkID = constructCheckID(serviceID, containerName)
+	err := c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
+	if err != nil {
+		return err
+	}
+
+	proxySvcID, _ := makeProxySvcIDAndName(serviceID, "")
+	checkID = constructCheckID(proxySvcID, containerName)
+	return c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
+}
+
+func (c *Command) updateConsulHealthStatus(consulClient *api.Client, checkID string, clusterARN string, ecsHealthStatus string) error {
+	consulHealthStatus := ecsHealthToConsulHealth(ecsHealthStatus)
+
+	check, ok := c.checks[checkID]
+	if !ok {
+		return fmt.Errorf("unable to find check with ID %s", checkID)
+	}
+
+	check.Status = consulHealthStatus
+	check.Output = fmt.Sprintf("ECS health status is %q for container %q", ecsHealthStatus, checkID)
+	c.checks[checkID] = check
+
+	updateCheckReq := &api.CatalogRegistration{
+		Node:           clusterARN,
+		SkipNodeUpdate: true,
+		Checks:         api.HealthChecks{check},
+	}
+
+	_, err := consulClient.Catalog().Register(updateCheckReq, nil)
+	return err
+}
+
+func getServiceHealthChecks(consulClient *api.Client, serviceName, serviceID string, opts *api.QueryOptions) (api.HealthChecks, error) {
+	opts.Filter = fmt.Sprintf("ServiceID == `%s`", serviceID)
+	checks, _, err := consulClient.Health().Checks(serviceName, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return checks, nil
+}
+
+func constructCheckID(serviceID, containerName string) string {
+	return fmt.Sprintf("%s-%s", serviceID, containerName)
+}
+
+func findContainersToSync(containerNames []string, taskMeta awsutil.ECSTaskMeta) ([]awsutil.ECSTaskMetaContainer, []string) {
+	var ecsContainers []awsutil.ECSTaskMetaContainer
+	var missing []string
+
+	for _, container := range containerNames {
+		found := false
+		for _, ecsContainer := range taskMeta.Containers {
+			if ecsContainer.Name == container {
+				ecsContainers = append(ecsContainers, ecsContainer)
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, container)
+		}
+	}
+	return ecsContainers, missing
+}
+
+func ecsHealthToConsulHealth(ecsHealth string) string {
+	// `HEALTHY`, `UNHEALTHY`, and `UNKNOWN` are the valid ECS health statuses.
+	// This assumes that the only passing status is `HEALTHY`
+	if ecsHealth != ecs.HealthStatusHealthy {
+		return api.HealthCritical
+	}
+	return api.HealthPassing
+}

--- a/subcommand/health-sync/checks_test.go
+++ b/subcommand/health-sync/checks_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package healthsync
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEcsHealthToConsulHealth(t *testing.T) {
+	require.Equal(t, api.HealthPassing, ecsHealthToConsulHealth(ecs.HealthStatusHealthy))
+	require.Equal(t, api.HealthCritical, ecsHealthToConsulHealth(ecs.HealthStatusUnknown))
+	require.Equal(t, api.HealthCritical, ecsHealthToConsulHealth(ecs.HealthStatusUnhealthy))
+	require.Equal(t, api.HealthCritical, ecsHealthToConsulHealth(""))
+}
+
+func TestFindContainersToSync(t *testing.T) {
+	taskMetaContainer1 := awsutil.ECSTaskMetaContainer{
+		Name: "container1",
+	}
+
+	cases := map[string]struct {
+		containerNames []string
+		taskMeta       awsutil.ECSTaskMeta
+		missing        []string
+		found          []awsutil.ECSTaskMetaContainer
+	}{
+		"A container isn't in the metadata": {
+			containerNames: []string{"container1"},
+			taskMeta:       awsutil.ECSTaskMeta{},
+			missing:        []string{"container1"},
+			found:          nil,
+		},
+		"The metadata has an extra container": {
+			containerNames: []string{},
+			taskMeta: awsutil.ECSTaskMeta{
+				Containers: []awsutil.ECSTaskMetaContainer{
+					taskMetaContainer1,
+				},
+			},
+			missing: nil,
+			found:   nil,
+		},
+		"some found and some not found": {
+			containerNames: []string{"container1", "container2"},
+			taskMeta: awsutil.ECSTaskMeta{
+				Containers: []awsutil.ECSTaskMetaContainer{
+					taskMetaContainer1,
+				},
+			},
+			missing: []string{"container2"},
+			found: []awsutil.ECSTaskMetaContainer{
+				taskMetaContainer1,
+			},
+		},
+	}
+
+	for name, testData := range cases {
+		t.Run(name, func(t *testing.T) {
+			found, missing := findContainersToSync(testData.containerNames, testData.taskMeta)
+			require.Equal(t, testData.missing, missing)
+			require.Equal(t, testData.found, found)
+		})
+	}
+}

--- a/subcommand/health-sync/command.go
+++ b/subcommand/health-sync/command.go
@@ -1,0 +1,297 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package healthsync
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
+	"github.com/hashicorp/consul-ecs/logging"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/cli"
+)
+
+const (
+	// syncChecksInterval is how often we poll the container health endpoint.
+	// The rate limit is about 40 per second, so 1 second polling seems reasonable.
+	syncChecksInterval = 1 * time.Second
+)
+
+type Command struct {
+	UI     cli.Ui
+	config *config.Config
+	log    hclog.Logger
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	sigs   chan os.Signal
+	once   sync.Once
+
+	checks           map[string]*api.HealthCheck
+	dataplaneMonitor *dataplaneMonitor
+	watcherCh        <-chan discovery.State
+
+	// Following fields are only needed for unit tests
+
+	// health-sync signals to this channel whenever it has completed
+	// all the prerequisites before entering the reconciliation loop.
+	doneChan chan struct{}
+
+	// health-sync waits for someone to signal to this channel before
+	// entering the checks reconcilation loop.
+	proceedChan chan struct{}
+
+	// Indicates that the command is run from a unit test
+	isTestEnv bool
+}
+
+func (c *Command) init() {
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.sigs = make(chan os.Signal, 1)
+}
+
+func (c *Command) Run(args []string) int {
+	c.once.Do(c.init)
+	if len(args) > 0 {
+		c.UI.Error(fmt.Sprintf("unexpected argument: %s", args[0]))
+		return 1
+	}
+
+	conf, err := config.FromEnv()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("invalid config: %s", err))
+		return 1
+	}
+	c.config = conf
+
+	c.log = logging.FromConfig(c.config).Logger()
+	c.dataplaneMonitor = newDataplaneMonitor(c.ctx, c.log)
+
+	if err := c.realRun(); err != nil {
+		c.log.Error("error running main", "err", err)
+		return 1
+	}
+
+	return 0
+}
+
+func (c *Command) realRun() error {
+	signal.Notify(c.sigs, syscall.SIGTERM)
+	defer c.cleanup()
+
+	go c.dataplaneMonitor.run()
+
+	taskMeta, err := awsutil.ECSTaskMetadata()
+	if err != nil {
+		return err
+	}
+
+	clusterARN, err := taskMeta.ClusterARN()
+	if err != nil {
+		return err
+	}
+
+	serverConnMgrCfg, err := c.config.ConsulServerConnMgrConfig(taskMeta)
+	if err != nil {
+		return fmt.Errorf("constructing server connection manager config: %w", err)
+	}
+
+	watcher, err := discovery.NewWatcher(c.ctx, serverConnMgrCfg, c.log)
+	if err != nil {
+		return fmt.Errorf("unable to create consul server watcher: %w", err)
+	}
+
+	go watcher.Run()
+	defer watcher.Stop()
+
+	state, err := watcher.State()
+	if err != nil {
+		return fmt.Errorf("unable to fetch consul server watcher state: %w", err)
+	}
+
+	consulClient, err := c.setupConsulAPIClient(state)
+	if err != nil {
+		return fmt.Errorf("unable to setup Consul API client: %w", err)
+	}
+
+	if !c.isTestEnv {
+		c.watcherCh = watcher.Subscribe()
+	}
+
+	var healthSyncContainers []string
+	healthSyncContainers = append(healthSyncContainers, c.config.HealthSyncContainers...)
+	healthSyncContainers = append(healthSyncContainers, config.ConsulDataplaneContainerName)
+	currentHealthStatuses := make(map[string]string)
+
+	c.checks, err = c.fetchHealthChecks(consulClient, taskMeta)
+	if err != nil {
+		return fmt.Errorf("unable to fetch checks before the reconciliation loop %w", err)
+	}
+
+	if c.isTestEnv {
+		close(c.doneChan)
+		<-c.proceedChan
+	}
+
+	for {
+		select {
+		case <-time.After(syncChecksInterval):
+			currentHealthStatuses = c.syncChecks(consulClient, currentHealthStatuses, clusterARN, healthSyncContainers)
+		case watcherState := <-c.watcherCh:
+			c.log.Info("Switching to Consul server", "address", watcherState.Address.String())
+			client, err := c.setupConsulAPIClient(watcherState)
+			if err != nil {
+				c.log.Error("error re-configuring consul client %s", err.Error())
+			} else {
+				consulClient = client
+			}
+		case <-c.sigs:
+			c.log.Info("Received SIGTERM. Beginning graceful shutdown by first marking all checks as critical.")
+			err := c.setChecksCritical(consulClient, taskMeta, clusterARN, healthSyncContainers)
+			if err != nil {
+				c.log.Error("Error marking the status of checks as critical: %s", err.Error())
+			}
+		case <-c.dataplaneMonitor.done():
+			var result error
+			c.log.Info("Dataplane has successfully shutdown. Deregistering services and terminating health-sync")
+
+			if c.config.IsGateway() {
+				err = c.deregisterGatewayProxy(consulClient, taskMeta, clusterARN)
+				if err != nil {
+					c.log.Error("error deregistering gateway %s", err.Error())
+					result = multierror.Append(result, err)
+				}
+			} else {
+				err = c.deregisterServiceAndProxy(consulClient, taskMeta, clusterARN)
+				if err != nil {
+					c.log.Error("error deregistering service and proxy %s", err.Error())
+					result = multierror.Append(result, err)
+				}
+			}
+
+			if c.config.ConsulLogin.Enabled {
+				_, err = consulClient.ACL().Logout(nil)
+				if err != nil {
+					c.log.Error("error logging out of consul %s", err.Error())
+					result = multierror.Append(result, err)
+				}
+			}
+
+			return result
+		}
+	}
+}
+
+func (c *Command) Synopsis() string {
+	return "Syncs ECS container's health status into Consul"
+}
+
+func (c *Command) Help() string {
+	return ""
+}
+
+func (c *Command) cleanup() {
+	c.cancel()
+}
+
+func (c *Command) setupConsulAPIClient(state discovery.State) (*api.Client, error) {
+	if c.isTestEnv && c.config.ConsulLogin.Enabled {
+		tokenFile := filepath.Join(c.config.BootstrapDir, config.ServiceTokenFilename)
+		err := os.WriteFile(tokenFile, []byte(state.Token), 0644)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Client config for the client that talks directly to the server agent
+	cfg := c.config.ClientConfig()
+	cfg.Address = net.JoinHostPort(state.Address.IP.String(), strconv.FormatInt(int64(c.config.ConsulServers.HTTP.Port), 10))
+	if state.Token != "" {
+		cfg.Token = state.Token
+	}
+
+	return api.NewClient(cfg)
+}
+
+func (c *Command) deregisterServiceAndProxy(consulClient *api.Client, taskMeta awsutil.ECSTaskMeta, clusterARN string) error {
+	var result error
+	serviceName := c.constructServiceName(taskMeta.Family)
+	taskID := taskMeta.TaskID()
+	serviceID := makeServiceID(serviceName, taskID)
+
+	service := c.config.Service.ToConsulType()
+
+	err := deregisterConsulService(consulClient, serviceID, service.Namespace, service.Partition, clusterARN)
+	if err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	// Proxy deregistration
+	proxySvcID, _ := makeProxySvcIDAndName(serviceID, serviceName)
+	err = deregisterConsulService(consulClient, proxySvcID, service.Namespace, service.Partition, clusterARN)
+	if err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result
+}
+
+func (c *Command) deregisterGatewayProxy(consulClient *api.Client, taskMeta awsutil.ECSTaskMeta, clusterARN string) error {
+	gatewaySvcName := c.constructServiceName(taskMeta.Family)
+	taskID := taskMeta.TaskID()
+	gatewaySvcID := makeServiceID(gatewaySvcName, taskID)
+
+	gatewaySvc := c.config.Gateway.ToConsulType()
+
+	return deregisterConsulService(consulClient, gatewaySvcID, gatewaySvc.Namespace, gatewaySvc.Partition, clusterARN)
+}
+
+func (c *Command) constructServiceName(family string) string {
+	var configName string
+	if c.config.IsGateway() {
+		configName = c.config.Gateway.Name
+	} else {
+		configName = c.config.Service.Name
+	}
+
+	if configName == "" {
+		return strings.ToLower(family)
+	}
+	return configName
+}
+
+func makeServiceID(serviceName, taskID string) string {
+	return fmt.Sprintf("%s-%s", serviceName, taskID)
+}
+
+func makeProxySvcIDAndName(serviceID, serviceName string) (string, string) {
+	fmtStr := "%s-sidecar-proxy"
+	return fmt.Sprintf(fmtStr, serviceID), fmt.Sprintf(fmtStr, serviceName)
+}
+
+func deregisterConsulService(client *api.Client, svcID, namespace, partition, node string) error {
+	deregInput := &api.CatalogDeregistration{
+		Node:      node,
+		ServiceID: svcID,
+		Namespace: namespace,
+		Partition: partition,
+	}
+
+	_, err := client.Catalog().Deregister(deregInput, nil)
+	return err
+}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -226,7 +226,7 @@ func TestRun(t *testing.T) {
 
 			if testutil.EnterpriseFlag() {
 				partition = "foo"
-				namespace = "bar"
+				namespace = "default"
 			}
 
 			apiQueryOptions := &api.QueryOptions{
@@ -514,7 +514,7 @@ func TestRunGateways(t *testing.T) {
 
 			if testutil.EnterpriseFlag() {
 				partition = "foo"
-				namespace = "bar"
+				namespace = "default"
 			}
 
 			apiQueryOptions := &api.QueryOptions{

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -820,7 +820,7 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 		// Check if checks are in the expected state for services
 		for _, expCheck := range expectedServiceChecks {
 			filter := fmt.Sprintf("CheckID == `%s`", expCheck.CheckID)
-			checks, _, err := consulClient.Health().Checks(expCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expCheck.Namespace})
+			checks, _, err := consulClient.Health().Checks(expCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expCheck.Namespace, Partition: expCheck.Partition})
 			require.NoError(r, err)
 
 			for _, check := range checks {
@@ -830,7 +830,7 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 
 		// Check if the check for proxy is in the expected state
 		filter := fmt.Sprintf("CheckID == `%s`", expectedProxyCheck.CheckID)
-		checks, _, err := consulClient.Health().Checks(expectedProxyCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expectedProxyCheck.Namespace})
+		checks, _, err := consulClient.Health().Checks(expectedProxyCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expectedProxyCheck.Namespace, Partition: expectedProxyCheck.Partition})
 		require.NoError(r, err)
 		require.Equal(r, 1, len(checks))
 		require.Equal(r, expectedProxyCheck.Status, checks[0].Status)

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -1,0 +1,869 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package healthsync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
+	meshinit "github.com/hashicorp/consul-ecs/subcommand/mesh-init"
+	"github.com/hashicorp/consul-ecs/testutil"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/serf/testutil/retry"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+type healthSyncContainerMetaData struct {
+	// Indicates if we should mark this container missing in ECS
+	// when we fetch data before syncing checks
+	missing bool
+
+	// Status of the container when we first fetch task meta info
+	// from ECS
+	status string
+}
+
+func TestNoCLIFlagsSupported(t *testing.T) {
+	ui := cli.NewMockUi()
+	cmd := Command{UI: ui}
+	code := cmd.Run([]string{"some-arg"})
+	require.Equal(t, 1, code)
+	require.Equal(t, "unexpected argument: some-arg\n", ui.ErrorWriter.String())
+}
+
+func TestConfigValidation(t *testing.T) {
+	t.Run("CONSUL_ECS_CONFIG_JSON unset", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		cmd := Command{UI: ui}
+		code := cmd.Run(nil)
+		require.Equal(t, code, 1)
+		require.Contains(t, ui.ErrorWriter.String(),
+			fmt.Sprintf(`invalid config: "%s" isn't populated`, config.ConfigEnvironmentVariable))
+
+	})
+	t.Run("CONSUL_ECS_CONFIG_JSON is empty json", func(t *testing.T) {
+		testutil.SetECSConfigEnvVar(t, map[string]interface{}{})
+		ui := cli.NewMockUi()
+		cmd := Command{UI: ui}
+		code := cmd.Run(nil)
+		require.Equal(t, code, 1)
+		require.Contains(t, ui.ErrorWriter.String(), "invalid config: 2 errors occurred:")
+	})
+}
+
+func TestConstructServiceName(t *testing.T) {
+}
+
+func TestMakeServiceID(t *testing.T) {
+	expectedID := "test-service-12345"
+	require.Equal(t, expectedID, makeServiceID("test-service", "12345"))
+}
+
+func TestMakeProxyServiceIDAndName(t *testing.T) {
+	expectedID := "test-service-12345-sidecar-proxy"
+	expectedName := "test-service-sidecar-proxy"
+
+	actualID, actualName := makeProxySvcIDAndName("test-service-12345", "test-service")
+	require.Equal(t, expectedID, actualID)
+	require.Equal(t, expectedName, actualName)
+}
+
+// TestRun tests the behaviour of the health-sync container
+// for a mesh service based task
+func TestRun(t *testing.T) {
+	family := "family-SERVICE-name"
+	serviceName := "service-name"
+	proxyServiceName := fmt.Sprintf("%s-sidecar-proxy", serviceName)
+	servicePort := 8080
+	taskARN := "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+	consulLoginCfg := config.ConsulLogin{
+		Enabled:       true,
+		IncludeEntity: true,
+		Meta: map[string]string{
+			"unittest-tag": "12345",
+		},
+	}
+
+	cases := map[string]struct {
+		consulLogin                     config.ConsulLogin
+		healthSyncContainers            map[string]healthSyncContainerMetaData
+		missingDataplaneContainer       bool
+		shouldMissingContainersReappear bool
+	}{
+		"no additional health sync containers": {},
+		"one healthy health sync container": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+			},
+			consulLogin: consulLoginCfg,
+		},
+		"two healthy health sync containers": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+				"container-2": {
+					status: ecs.HealthStatusHealthy,
+				},
+			},
+		},
+		"one healthy and one unhealthy health sync containers": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+				"container-2": {
+					status: ecs.HealthStatusUnhealthy,
+				},
+			},
+		},
+		"one healthy and one missing health sync containers": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+				"container-2": {
+					missing: true,
+					status:  ecs.HealthStatusUnhealthy,
+				},
+			},
+			consulLogin: consulLoginCfg,
+		},
+		"two unhealthy health sync containers": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusUnhealthy,
+				},
+				"container-2": {
+					status: ecs.HealthStatusUnhealthy,
+				},
+			},
+		},
+		"missing dataplane container": {
+			missingDataplaneContainer: true,
+		},
+		"missing dataplane container and two healthy health sync containers": {
+			missingDataplaneContainer: true,
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+				"container-2": {
+					status: ecs.HealthStatusHealthy,
+				},
+			},
+		},
+		"missing dataplane container and one healthy and one unhealthy health sync containers": {
+			missingDataplaneContainer: true,
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+				"container-2": {
+					status: ecs.HealthStatusUnhealthy,
+				},
+			},
+			consulLogin: consulLoginCfg,
+		},
+		"missing dataplane container and one missing health sync containers": {
+			missingDataplaneContainer: true,
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status:  ecs.HealthStatusHealthy,
+					missing: true,
+				},
+			},
+		},
+		"missing healthy sync container which gets synced as healthy after it reappears": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+				"container-2": {
+					missing: true,
+					status:  ecs.HealthStatusUnhealthy,
+				},
+			},
+			shouldMissingContainersReappear: true,
+			consulLogin:                     consulLoginCfg,
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			var (
+				partition = ""
+				namespace = ""
+
+				upstreams = []config.Upstream{
+					{
+						DestinationName: "upstream1",
+						LocalBindPort:   1234,
+					},
+					{
+						DestinationName: "upstream2",
+						LocalBindPort:   1235,
+					},
+				}
+			)
+
+			if testutil.EnterpriseFlag() {
+				partition = "foo"
+				namespace = "bar"
+			}
+
+			apiQueryOptions := &api.QueryOptions{
+				Namespace: namespace,
+				Partition: partition,
+			}
+
+			var srvConfig testutil.ServerConfigCallback
+			if c.consulLogin.Enabled {
+				// Enable ACLs to test with the auth method
+				srvConfig = testutil.ConsulACLConfigFn
+			}
+
+			// Start the Consul server
+			server, cfg := testutil.ConsulServer(t, srvConfig)
+			consulClient, err := api.NewClient(cfg)
+			require.NoError(t, err)
+
+			// Set up ECS container metadata server. This sets ECS_CONTAINER_METADATA_URI_V4.
+			taskMetadataResponse := &awsutil.ECSTaskMeta{
+				Cluster: "test",
+				TaskARN: taskARN,
+				Family:  family,
+			}
+			taskID := taskMetadataResponse.TaskID()
+			taskMetaRespStr, err := constructTaskMetaResponseString(taskMetadataResponse)
+			require.NoError(t, err)
+
+			var currentTaskMetaResp atomic.Value
+			currentTaskMetaResp.Store(taskMetaRespStr)
+			testutil.TaskMetaServer(t, testutil.TaskMetaHandlerFn(t,
+				func() string {
+					return currentTaskMetaResp.Load().(string)
+				},
+			))
+
+			if c.consulLogin.Enabled {
+				fakeAws := testutil.AuthMethodInit(t, consulClient, serviceName, config.DefaultAuthMethodName)
+
+				// Use the fake local AWS server.
+				c.consulLogin.STSEndpoint = fakeAws.URL + "/sts"
+
+				registerNode(t, consulClient, *taskMetadataResponse, apiQueryOptions.Partition)
+			}
+
+			envoyBootstrapDir := testutil.TempDir(t)
+			serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
+			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
+
+			containersToSync := make([]string, 0)
+			for name := range c.healthSyncContainers {
+				containersToSync = append(containersToSync, name)
+			}
+			consulEcsConfig := config.Config{
+				LogLevel:             "DEBUG",
+				BootstrapDir:         envoyBootstrapDir,
+				HealthSyncContainers: containersToSync,
+				ConsulLogin:          c.consulLogin,
+				ConsulServers: config.ConsulServers{
+					Hosts: "127.0.0.1",
+					GRPC: config.GRPCSettings{
+						Port: serverGRPCPort,
+					},
+					HTTP: config.HTTPSettings{
+						Port: serverHTTPPort,
+					},
+					SkipServerWatch: true,
+				},
+				Proxy: &config.AgentServiceConnectProxyConfig{
+					PublicListenerPort: config.DefaultPublicListenerPort,
+					Upstreams:          upstreams,
+				},
+				Service: config.ServiceRegistration{
+					Name: serviceName,
+					Port: servicePort,
+					Tags: []string{"tag1", "tag2"},
+					Meta: map[string]string{"a": "1", "b": "2"},
+				},
+			}
+
+			if testutil.EnterpriseFlag() {
+				consulEcsConfig.Service.Namespace = namespace
+				consulEcsConfig.Service.Partition = partition
+			}
+
+			testutil.SetECSConfigEnvVar(t, &consulEcsConfig)
+
+			// Run the mesh-init command first because
+			// it sets up the necessary prerequisites for
+			// running the health sync command like registering
+			// the proxy and the service and constructing
+			// preliminary health checks.
+
+			ui := cli.NewMockUi()
+			ctrlPlaneCmd := meshinit.Command{UI: ui}
+			code := ctrlPlaneCmd.Run(nil)
+
+			require.Equal(t, code, 0, ui.ErrorWriter.String())
+			verifyMeshInitCommandSideEffects(t, consulClient, serviceName, proxyServiceName, apiQueryOptions)
+
+			cmd := Command{UI: ui, isTestEnv: true}
+			cmd.ctx, cmd.cancel = context.WithCancel(context.Background())
+			cmd.doneChan = make(chan struct{})
+			cmd.proceedChan = make(chan struct{})
+
+			watcherCh := make(chan discovery.State, 1)
+			cmd.watcherCh = watcherCh
+			go func() {
+				testutil.SetECSConfigEnvVar(t, &consulEcsConfig)
+				code := cmd.Run(nil)
+				require.Equal(t, 0, code, ui.ErrorWriter.String())
+			}()
+
+			// We wait till the mesh-init process completes all the prerequisites
+			// before entering into the checks reconcilation loop
+			<-cmd.doneChan
+
+			expectedSvcChecks, expectedProxyCheck := fetchSvcAndProxyHealthChecks(t, consulClient, serviceName, proxyServiceName, apiQueryOptions)
+
+			// Verify the accumulated health checks
+			require.Equal(t, len(expectedSvcChecks)+1, len(cmd.checks))
+			for _, expCheck := range append(expectedSvcChecks, expectedProxyCheck) {
+				require.NotNil(t, expCheck)
+				check, ok := cmd.checks[expCheck.CheckID]
+				require.True(t, ok)
+				require.Empty(t, cmp.Diff(check, expCheck))
+			}
+
+			// Add the containers data into task meta response
+			taskMetaRespStr = injectContainersIntoTaskMetaResponse(t, taskMetadataResponse, c.missingDataplaneContainer, c.healthSyncContainers)
+			currentTaskMetaResp.Store(taskMetaRespStr)
+
+			// Trigger health-sync to enter it's reconciliation loop
+			close(cmd.proceedChan)
+
+			// Align the expectations for checks according to the
+			// state of health sync containers
+			for _, expCheck := range expectedSvcChecks {
+				found := false
+				for name, hsc := range c.healthSyncContainers {
+					checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
+					if expCheck.CheckID == checkID {
+						if hsc.missing {
+							expCheck.Status = api.HealthCritical
+						} else {
+							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
+						}
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					if c.missingDataplaneContainer {
+						expCheck.Status = api.HealthCritical
+					} else {
+						expCheck.Status = api.HealthPassing
+					}
+				}
+			}
+			expectedProxyCheck.Status = api.HealthPassing
+			if c.missingDataplaneContainer {
+				expectedProxyCheck.Status = api.HealthCritical
+			}
+
+			assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
+
+			// Test server watch
+			{
+				addr, err := discovery.MakeAddr(serverHost, serverGRPCPort)
+				require.NoError(t, err)
+
+				newServerState := discovery.State{
+					Address: addr,
+				}
+				if c.consulLogin.Enabled {
+					newServerState.Token = getACLToken(t, envoyBootstrapDir)
+				}
+
+				watcherCh <- newServerState
+			}
+
+			// Some containers might reappear after sometime they went missing.
+			// This block makes a missing reappear in the task meta response and
+			// tests if the healthy-sync process is able to sync back the status of the
+			// container to Consul servers.
+			if c.shouldMissingContainersReappear {
+				// Mark all containers as non missing
+				c.missingDataplaneContainer = false
+				for _, hsc := range c.healthSyncContainers {
+					hsc.missing = false
+				}
+
+				// Add the containers data into task meta response
+				taskMetaRespStr = injectContainersIntoTaskMetaResponse(t, taskMetadataResponse, c.missingDataplaneContainer, c.healthSyncContainers)
+				currentTaskMetaResp.Store(taskMetaRespStr)
+
+				// Align the expectations for checks according to the
+				// state of health sync containers
+				for _, expCheck := range expectedSvcChecks {
+					found := false
+					for name, hsc := range c.healthSyncContainers {
+						checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
+						if expCheck.CheckID == checkID {
+							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
+							found = true
+							break
+						}
+					}
+
+					if !found {
+						expCheck.Status = api.HealthPassing
+					}
+				}
+				expectedProxyCheck.Status = api.HealthPassing
+				assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
+			}
+
+			// Send SIGTERM and verify the status of checks
+			signalSIGTERM(t)
+
+			for _, expCheck := range expectedSvcChecks {
+				expCheck.Status = api.HealthCritical
+			}
+			expectedProxyCheck.Status = api.HealthCritical
+
+			assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
+
+			// Stop dataplane container manually because
+			// health-sync waits for it before deregistering
+			// the service and the proxy.
+			taskMetaRespStr, err = stopDataplaneContainer(taskMetadataResponse)
+			require.NoError(t, err)
+			currentTaskMetaResp.Store(taskMetaRespStr)
+
+			assertServiceAndProxyInstances(t, consulClient, serviceName, proxyServiceName, 0, apiQueryOptions)
+			if c.consulLogin.Enabled {
+				assertConsulLogout(t, cfg, consulEcsConfig.BootstrapDir)
+			}
+		})
+	}
+}
+
+// TestRunGateways tests the behaviour of the health-sync container
+// for a gateway based task
+func TestRunGateways(t *testing.T) {
+	family := "family-name-mesh-gateway"
+	taskARN := "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+	consulLoginCfg := config.ConsulLogin{
+		Enabled:       true,
+		IncludeEntity: true,
+		Meta: map[string]string{
+			"unittest-tag": "12345",
+		},
+	}
+
+	cases := map[string]struct {
+		consulLogin                     config.ConsulLogin
+		healthSyncContainers            map[string]healthSyncContainerMetaData
+		missingDataplaneContainer       bool
+		shouldMissingContainersReappear bool
+	}{
+		"happy path": {},
+		"missing dataplane container": {
+			missingDataplaneContainer: true,
+		},
+		"missing healthy sync container which gets synced as healthy after it reappears": {
+			missingDataplaneContainer:       true,
+			shouldMissingContainersReappear: true,
+			consulLogin:                     consulLoginCfg,
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			var (
+				partition = ""
+				namespace = ""
+			)
+
+			if testutil.EnterpriseFlag() {
+				partition = "foo"
+				namespace = "bar"
+			}
+
+			apiQueryOptions := &api.QueryOptions{
+				Namespace: namespace,
+				Partition: partition,
+			}
+
+			var srvConfig testutil.ServerConfigCallback
+			if c.consulLogin.Enabled {
+				// Enable ACLs to test with the auth method
+				srvConfig = testutil.ConsulACLConfigFn
+			}
+
+			// Start the Consul server
+			server, cfg := testutil.ConsulServer(t, srvConfig)
+			consulClient, err := api.NewClient(cfg)
+			require.NoError(t, err)
+
+			// Set up ECS container metadata server. This sets ECS_CONTAINER_METADATA_URI_V4.
+			taskMetadataResponse := &awsutil.ECSTaskMeta{
+				Cluster: "test",
+				TaskARN: taskARN,
+				Family:  family,
+			}
+			taskMetaRespStr, err := constructTaskMetaResponseString(taskMetadataResponse)
+			require.NoError(t, err)
+
+			var currentTaskMetaResp atomic.Value
+			currentTaskMetaResp.Store(taskMetaRespStr)
+			testutil.TaskMetaServer(t, testutil.TaskMetaHandlerFn(t,
+				func() string {
+					return currentTaskMetaResp.Load().(string)
+				},
+			))
+
+			if c.consulLogin.Enabled {
+				fakeAws := testutil.AuthMethodInit(t, consulClient, family, config.DefaultAuthMethodName)
+
+				// Use the fake local AWS server.
+				c.consulLogin.STSEndpoint = fakeAws.URL + "/sts"
+
+				registerNode(t, consulClient, *taskMetadataResponse, apiQueryOptions.Partition)
+			}
+
+			envoyBootstrapDir := testutil.TempDir(t)
+			serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
+			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
+
+			consulEcsConfig := config.Config{
+				LogLevel:     "DEBUG",
+				BootstrapDir: envoyBootstrapDir,
+				ConsulLogin:  c.consulLogin,
+				ConsulServers: config.ConsulServers{
+					Hosts: "127.0.0.1",
+					GRPC: config.GRPCSettings{
+						Port: serverGRPCPort,
+					},
+					HTTP: config.HTTPSettings{
+						Port: serverHTTPPort,
+					},
+					SkipServerWatch: true,
+				},
+				Gateway: &config.GatewayRegistration{
+					Kind: api.ServiceKindMeshGateway,
+					LanAddress: &config.GatewayAddress{
+						Port: 12345,
+					},
+				},
+			}
+
+			if testutil.EnterpriseFlag() {
+				consulEcsConfig.Service.Namespace = namespace
+				consulEcsConfig.Service.Partition = partition
+			}
+
+			testutil.SetECSConfigEnvVar(t, &consulEcsConfig)
+
+			// Run the mesh-init command first because
+			// it sets up the necessary prerequisites for
+			// running the health sync command like registering
+			// the proxy and the service and constructing
+			// preliminary health checks.
+
+			ui := cli.NewMockUi()
+			ctrlPlaneCmd := meshinit.Command{UI: ui}
+			code := ctrlPlaneCmd.Run(nil)
+
+			require.Equal(t, code, 0, ui.ErrorWriter.String())
+			verifyMeshInitCommandSideEffects(t, consulClient, "", family, apiQueryOptions)
+
+			cmd := Command{UI: ui, isTestEnv: true}
+			cmd.ctx, cmd.cancel = context.WithCancel(context.Background())
+			cmd.doneChan = make(chan struct{})
+			cmd.proceedChan = make(chan struct{})
+
+			watcherCh := make(chan discovery.State, 1)
+			cmd.watcherCh = watcherCh
+			go func() {
+				testutil.SetECSConfigEnvVar(t, &consulEcsConfig)
+				code := cmd.Run(nil)
+				require.Equal(t, 0, code, ui.ErrorWriter.String())
+			}()
+
+			// We wait till the mesh-init process completes all the prerequisites
+			// before entering into the checks reconcilation loop
+			<-cmd.doneChan
+
+			_, expectedProxyCheck := fetchSvcAndProxyHealthChecks(t, consulClient, "", family, apiQueryOptions)
+
+			// Verify the accumulated health checks
+			require.Len(t, cmd.checks, 1)
+			require.NotNil(t, expectedProxyCheck)
+			check, ok := cmd.checks[expectedProxyCheck.CheckID]
+			require.True(t, ok)
+			require.Empty(t, cmp.Diff(check, expectedProxyCheck))
+
+			// Add the containers data into task meta response
+			taskMetaRespStr = injectContainersIntoTaskMetaResponse(t, taskMetadataResponse, c.missingDataplaneContainer, c.healthSyncContainers)
+			currentTaskMetaResp.Store(taskMetaRespStr)
+
+			// Trigger health-sync to enter it's reconciliation loop
+			close(cmd.proceedChan)
+
+			expectedProxyCheck.Status = api.HealthPassing
+			if c.missingDataplaneContainer {
+				expectedProxyCheck.Status = api.HealthCritical
+			}
+
+			assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
+
+			// Test server watch
+			{
+				addr, err := discovery.MakeAddr(serverHost, serverGRPCPort)
+				require.NoError(t, err)
+
+				newServerState := discovery.State{
+					Address: addr,
+				}
+				if c.consulLogin.Enabled {
+					newServerState.Token = getACLToken(t, envoyBootstrapDir)
+				}
+
+				watcherCh <- newServerState
+			}
+
+			// Some containers might reappear after sometime they went missing.
+			// This block makes a missing reappear in the task meta response and
+			// tests if the healthy-sync process is able to sync back the status of the
+			// container to Consul servers.
+			if c.shouldMissingContainersReappear {
+				// Mark all containers as non missing
+				c.missingDataplaneContainer = false
+
+				// Add the containers data into task meta response
+				taskMetaRespStr = injectContainersIntoTaskMetaResponse(t, taskMetadataResponse, c.missingDataplaneContainer, nil)
+				currentTaskMetaResp.Store(taskMetaRespStr)
+
+				expectedProxyCheck.Status = api.HealthPassing
+				assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
+			}
+
+			// Send SIGTERM and verify the status of checks
+			signalSIGTERM(t)
+
+			expectedProxyCheck.Status = api.HealthCritical
+
+			assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
+
+			// Stop dataplane container manually because
+			// health-sync waits for it before deregistering
+			// the service and the proxy.
+			taskMetaRespStr, err = stopDataplaneContainer(taskMetadataResponse)
+			require.NoError(t, err)
+			currentTaskMetaResp.Store(taskMetaRespStr)
+
+			assertServiceAndProxyInstances(t, consulClient, "", family, 0, apiQueryOptions)
+			if c.consulLogin.Enabled {
+				assertConsulLogout(t, cfg, consulEcsConfig.BootstrapDir)
+			}
+		})
+	}
+}
+
+func verifyMeshInitCommandSideEffects(t *testing.T, consulClient *api.Client, serviceName, proxyServiceName string, queryOpts *api.QueryOptions) {
+	assertServiceAndProxyInstances(t, consulClient, serviceName, proxyServiceName, 1, queryOpts)
+
+	areAllChecksCriticalFn := func(checks api.HealthChecks) bool {
+		if checks == nil {
+			return true
+		}
+
+		areChecksCritical := true
+		for _, check := range checks {
+			if check.Status == api.HealthCritical {
+				continue
+			}
+
+			areChecksCritical = false
+		}
+		return areChecksCritical
+	}
+
+	svcChecks, proxyCheck := fetchSvcAndProxyHealthChecks(t, consulClient, serviceName, proxyServiceName, queryOpts)
+	require.True(t, areAllChecksCriticalFn(svcChecks))
+	require.True(t, areAllChecksCriticalFn([]*api.HealthCheck{proxyCheck}))
+}
+
+func assertServiceAndProxyInstances(t *testing.T, consulClient *api.Client, serviceName, proxyName string, expectedCount int, opts *api.QueryOptions) {
+	timer := &retry.Timer{Timeout: 5 * time.Second, Wait: 500 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		if serviceName != "" {
+			serviceInstances, _, err := consulClient.Catalog().Service(serviceName, "", opts)
+			require.NoError(r, err)
+			require.Equal(r, expectedCount, len(serviceInstances))
+		}
+
+		serviceInstances, _, err := consulClient.Catalog().Service(proxyName, "", opts)
+		require.NoError(r, err)
+		require.Equal(r, expectedCount, len(serviceInstances))
+	})
+}
+
+func fetchSvcAndProxyHealthChecks(t *testing.T, consulClient *api.Client, svcName, proxyName string, opts *api.QueryOptions) (api.HealthChecks, *api.HealthCheck) {
+	healthChecksFn := func(svc string) api.HealthChecks {
+		if svc == "" {
+			return nil
+		}
+
+		return fetchHealthChecks(t, consulClient, svc, opts)
+	}
+
+	proxyHealthChecks := healthChecksFn(proxyName)
+	require.Len(t, proxyHealthChecks, 1)
+	return healthChecksFn(svcName), proxyHealthChecks[0]
+}
+
+func fetchHealthChecks(t *testing.T, consulClient *api.Client, serviceName string, apiQueryOpts *api.QueryOptions) api.HealthChecks {
+	checks, _, err := consulClient.Health().Checks(serviceName, apiQueryOpts)
+	require.NoError(t, err)
+	return checks
+}
+
+func constructTaskMetaResponseString(resp *awsutil.ECSTaskMeta) (string, error) {
+	byteStr, err := json.Marshal(resp)
+	if err != nil {
+		return "", err
+	}
+
+	return string(byteStr), nil
+}
+
+func injectContainersIntoTaskMetaResponse(t *testing.T, taskMetadataResponse *awsutil.ECSTaskMeta, missingDataplaneContainer bool, healthSyncContainers map[string]healthSyncContainerMetaData) string {
+	var taskMetaContainersResponse []awsutil.ECSTaskMetaContainer
+	if !missingDataplaneContainer {
+		taskMetaContainersResponse = append(taskMetaContainersResponse, constructContainerResponse(config.ConsulDataplaneContainerName, ecs.HealthStatusHealthy))
+	}
+
+	for name, hsc := range healthSyncContainers {
+		if hsc.missing {
+			continue
+		}
+
+		taskMetaContainersResponse = append(taskMetaContainersResponse, constructContainerResponse(name, hsc.status))
+	}
+	taskMetadataResponse.Containers = taskMetaContainersResponse
+	taskMetaRespStr, err := constructTaskMetaResponseString(taskMetadataResponse)
+	require.NoError(t, err)
+
+	return taskMetaRespStr
+}
+
+func constructContainerResponse(name, health string) awsutil.ECSTaskMetaContainer {
+	return awsutil.ECSTaskMetaContainer{
+		Name: name,
+		Health: awsutil.ECSTaskMetaHealth{
+			Status: health,
+		},
+	}
+}
+
+func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceChecks api.HealthChecks, expectedProxyCheck *api.HealthCheck) {
+	timer := &retry.Timer{Timeout: 5 * time.Second, Wait: 500 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		// Check if checks are in the expected state for services
+		for _, expCheck := range expectedServiceChecks {
+			filter := fmt.Sprintf("CheckID == `%s`", expCheck.CheckID)
+			checks, _, err := consulClient.Health().Checks(expCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expCheck.Namespace})
+			require.NoError(r, err)
+
+			for _, check := range checks {
+				require.Equal(r, expCheck.Status, check.Status)
+			}
+		}
+
+		// Check if the check for proxy is in the expected state
+		filter := fmt.Sprintf("CheckID == `%s`", expectedProxyCheck.CheckID)
+		checks, _, err := consulClient.Health().Checks(expectedProxyCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expectedProxyCheck.Namespace})
+		require.NoError(r, err)
+		require.Equal(r, 1, len(checks))
+		require.Equal(r, expectedProxyCheck.Status, checks[0].Status)
+	})
+}
+
+// stopDataplaneContainer marks the dataplane container's status as STOPPED in the
+// task meta response
+func stopDataplaneContainer(taskMetadataResp *awsutil.ECSTaskMeta) (string, error) {
+	for i, c := range taskMetadataResp.Containers {
+		if c.Name == config.ConsulDataplaneContainerName {
+			taskMetadataResp.Containers[i].DesiredStatus = ecs.DesiredStatusStopped
+			taskMetadataResp.Containers[i].KnownStatus = ecs.DesiredStatusStopped
+			break
+		}
+	}
+	return constructTaskMetaResponseString(taskMetadataResp)
+}
+
+func signalSIGTERM(t *testing.T) {
+	err := syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	require.NoError(t, err)
+	// Give it time to react
+	time.Sleep(100 * time.Millisecond)
+}
+
+func assertConsulLogout(t *testing.T, cfg *api.Config, bootstrapDir string) {
+	cfg.Token = getACLToken(t, bootstrapDir)
+	client, err := api.NewClient(cfg)
+	require.NoError(t, err)
+
+	tok, _, err := client.ACL().TokenReadSelf(nil)
+	require.Error(t, err)
+	require.Nil(t, tok)
+}
+
+func getACLToken(t *testing.T, bootstrapDir string) string {
+	tokenFile := filepath.Join(bootstrapDir, config.ServiceTokenFilename)
+	token, err := os.ReadFile(tokenFile)
+	require.NoError(t, err)
+	return string(token)
+}
+
+func registerNode(t *testing.T, consulClient *api.Client, taskMeta awsutil.ECSTaskMeta, partition string) {
+	clusterARN, err := taskMeta.ClusterARN()
+	require.NoError(t, err)
+
+	payload := &api.CatalogRegistration{
+		Node: clusterARN,
+		NodeMeta: map[string]string{
+			config.SyntheticNode: "true",
+		},
+		Address:   taskMeta.NodeIP(),
+		Partition: partition,
+	}
+
+	_, err = consulClient.Catalog().Register(payload, nil)
+	require.NoError(t, err)
+}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -268,7 +268,7 @@ func TestRun(t *testing.T) {
 			))
 
 			if c.consulLogin.Enabled {
-				fakeAws := testutil.AuthMethodInit(t, consulClient, serviceName, config.DefaultAuthMethodName)
+				fakeAws := testutil.AuthMethodInit(t, consulClient, serviceName, config.DefaultAuthMethodName, &api.WriteOptions{Partition: partition})
 
 				// Use the fake local AWS server.
 				c.consulLogin.STSEndpoint = fakeAws.URL + "/sts"
@@ -555,7 +555,7 @@ func TestRunGateways(t *testing.T) {
 			))
 
 			if c.consulLogin.Enabled {
-				fakeAws := testutil.AuthMethodInit(t, consulClient, family, config.DefaultAuthMethodName)
+				fakeAws := testutil.AuthMethodInit(t, consulClient, family, config.DefaultAuthMethodName, &api.WriteOptions{Partition: partition})
 
 				// Use the fake local AWS server.
 				c.consulLogin.STSEndpoint = fakeAws.URL + "/sts"

--- a/subcommand/health-sync/dataplane_monitor.go
+++ b/subcommand/health-sync/dataplane_monitor.go
@@ -1,0 +1,81 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package healthsync
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/hashicorp/consul-ecs/awsutil"
+	"github.com/hashicorp/consul-ecs/config"
+	"github.com/hashicorp/go-hclog"
+)
+
+type dataplaneMonitor struct {
+	ctx context.Context
+	log hclog.Logger
+
+	doneCh chan struct{}
+}
+
+func newDataplaneMonitor(ctx context.Context, logger hclog.Logger) *dataplaneMonitor {
+	return &dataplaneMonitor{
+		ctx:    ctx,
+		log:    logger,
+		doneCh: make(chan struct{}),
+	}
+}
+
+func (d *dataplaneMonitor) done() chan struct{} {
+	return d.doneCh
+}
+
+// Run will wake up when SIGTERM is received. Then, it polls task metadata
+// until the dataplane container stops. Use the Done() channel to wait
+// until it has finished.
+func (d *dataplaneMonitor) run() {
+	defer close(d.doneCh)
+
+	if !d.waitForSIGTERM() {
+		return
+	}
+
+	d.log.Info("waiting for dataplane container to stop")
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-time.After(1 * time.Second):
+			taskMeta, err := awsutil.ECSTaskMetadata()
+			if err != nil {
+				d.log.Error("fetching task metadata", "err", err.Error())
+				break
+			}
+
+			d.log.Info("Waiting for dataplane container to stop")
+			if taskMeta.HasContainerStopped(config.ConsulDataplaneContainerName) {
+				d.log.Info("dataplane container has stopped, terminating health-sync")
+				return
+			}
+		}
+	}
+}
+
+func (d *dataplaneMonitor) waitForSIGTERM() bool {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+	defer signal.Stop(sigs)
+
+	for {
+		select {
+		case <-sigs:
+			return true
+		case <-d.ctx.Done():
+			return false
+		}
+	}
+}

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -232,7 +232,7 @@ func TestRun(t *testing.T) {
 			))
 
 			if c.consulLogin.Enabled {
-				fakeAws := testutil.AuthMethodInit(t, consulClient, expectedServiceName, config.DefaultAuthMethodName)
+				fakeAws := testutil.AuthMethodInit(t, consulClient, expectedServiceName, config.DefaultAuthMethodName, nil)
 
 				// Use the fake local AWS server.
 				c.consulLogin.STSEndpoint = fakeAws.URL + "/sts"
@@ -662,7 +662,7 @@ func TestGateway(t *testing.T) {
 			c.config.Gateway.Partition = partition
 
 			if c.config.ConsulLogin.Enabled {
-				fakeAws := testutil.AuthMethodInit(t, consulClient, c.expServiceName, config.DefaultAuthMethodName)
+				fakeAws := testutil.AuthMethodInit(t, consulClient, c.expServiceName, config.DefaultAuthMethodName, nil)
 				// Use the fake local AWS server.
 				c.config.ConsulLogin.STSEndpoint = fakeAws.URL + "/sts"
 

--- a/testutil/aws.go
+++ b/testutil/aws.go
@@ -118,6 +118,7 @@ func AuthMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName,
 			"STSEndpoint": fakeAws.URL + "/sts",
 			"IAMEndpoint": fakeAws.URL + "/iam",
 		},
+		Partition: opts.Partition,
 	}, opts)
 	require.NoError(t, err)
 

--- a/testutil/aws.go
+++ b/testutil/aws.go
@@ -118,7 +118,6 @@ func AuthMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName,
 			"STSEndpoint": fakeAws.URL + "/sts",
 			"IAMEndpoint": fakeAws.URL + "/iam",
 		},
-		Partition: opts.Partition,
 	}, opts)
 	require.NoError(t, err)
 

--- a/testutil/aws.go
+++ b/testutil/aws.go
@@ -85,7 +85,7 @@ func TaskMetaServer(t *testing.T, handler http.Handler) {
 //
 //	fakeAws := authMethodInit(...)
 //	consulLogin.ExtraLoginFlags = []string{"-aws-sts-endpoint", fakeAws.URL + "/sts"}
-func AuthMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName, authMethodName string) *httptest.Server {
+func AuthMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName, authMethodName string, opts *api.WriteOptions) *httptest.Server {
 	arn := "arn:aws:iam::1234567890:role/my-role"
 	uniqueId := "AAAsomeuniqueid"
 
@@ -118,7 +118,7 @@ func AuthMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName,
 			"STSEndpoint": fakeAws.URL + "/sts",
 			"IAMEndpoint": fakeAws.URL + "/iam",
 		},
-	}, nil)
+	}, opts)
 	require.NoError(t, err)
 
 	_, _, err = consulClient.ACL().BindingRuleCreate(&api.ACLBindingRule{
@@ -126,7 +126,7 @@ func AuthMethodInit(t *testing.T, consulClient *api.Client, expectedServiceName,
 		BindType:   api.BindingRuleBindTypeService,
 		// Pull the service name from the IAM role `service-name` tag.
 		BindName: "${entity_tags.service-name}",
-	}, nil)
+	}, opts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds a new command `health-sync` to the command factory.
- Adds back most of the code removed in https://github.com/hashicorp/consul-ecs/pull/207 but in the `healthsync` package.
- Health sync container now does the following
   - Performs Consul login with the connection manager library
   - Sets up the Consul client
   - Accumulates all the health checks from the catalog for the service/proxy registered by `mesh-init`
   - Enters into a long running reconciliation loop where it (Most of the code is a copy paste of the reconciliation logic that was previously present in Control plane removed in https://github.com/hashicorp/consul-ecs/pull/207)
      - Periodically syncs back ECS container health checks into Consul. 
      - Marks all the checks as critical on receiving SIGTERM
      - Implements a server watch where it listens for changes to the Consul servers and reconfigures the Consul client when such a change happens
      - Implements graceful shutdown where it waits for Consul dataplane to terminate. Once dataplane terminates, it deregisters the service and proxy and finally performs a Consul logout.

## How I've tested this PR:

- Tests were inspired from the code removed in https://github.com/hashicorp/consul-ecs/pull/207 and added here according to the changes.

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
