### PR TITLE
Fix missing permissions for mesh gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ FEATURES
     - Create the `consul-ecs-terminating-gateway-role` ACL role. This role will be assigned to the ACL token obtained by the terminating gateway task after performing a Consul login. Users can assign policies to this role via terraform whenever needed.
     - Add a new binding rule specific to terminating gateways that helps bind the terminating gateway's ACL token to the preconfigured `consul-ecs-terminating-gateway-role`
 
+BUG FIXES
+* Fix permissions given to the ACL token generated for a Mesh gateway based ECS task. Following are the changes made to add additional permissions [[GH-215](https://github.com/hashicorp/consul-ecs/pull/215)]
+  - Create the `consul-ecs-mesh-gateway-role` ACL role and `consul-ecs-mesh-gateway-policy` ACL policy with the `mesh:write` and `peering:read` permissions.
+  - Add a new binding rule specific to Mesh gateway that helps binding the Mesh gateway's ACL token to the preconfigured `consul-ecs-mesh-gateway-role`
+
 ## 0.7.1 (Dec 18, 2023)
 
 BUG FIXES

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -478,7 +478,7 @@ func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, polic
 	// If the policy already exists, we're done.
 	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
 	if err != nil && !controller.IsACLNotFoundError(err) {
-		return fmt.Errorf("reading API Gateway ACL policy: %w", err)
+		return fmt.Errorf("reading %s ACL policy: %w", policyName, err)
 	} else if err == nil && policy != nil {
 		c.log.Info("ACL policy already exists; skipping policy creation", "name", policyName)
 		return nil
@@ -488,7 +488,7 @@ func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, polic
 	c.log.Info("creating ACL policy", "name", policyName)
 	rules, err := c.getRulesForPolicy(policyName)
 	if err != nil {
-		return fmt.Errorf("failed to generate API gateway token policy rules: %w", err)
+		return fmt.Errorf("failed to generate %s policy rules: %w", policyName, err)
 	}
 
 	_, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -408,7 +408,7 @@ func (c *Command) upsertAuthMethod(consulClient *api.Client, authMethod *api.ACL
 
 // upsertAPIGatewayPolicyAndRole creates or updates the Consul ACL role for the API Gateway token.
 func (c *Command) upsertAPIGatewayPolicyAndRole(consulClient *api.Client) error {
-	if err := c.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription, c.writeOptions()); err != nil {
+	if err := c.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription); err != nil {
 		return err
 	}
 	if err := c.upsertRole(consulClient, apiGatewayRoleName, apiGatewayPolicyName, apiGatewayRoleDescription); err != nil {
@@ -463,7 +463,7 @@ func (c *Command) upsertRole(consulClient *api.Client, roleName, policyName, rol
 
 // upsertMeshGatewayPolicyAndRole creates or updates the Consul ACL role for the Mesh Gateway token.
 func (c *Command) upsertMeshGatewayPolicyAndRole(consulClient *api.Client) error {
-	if err := c.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription, nil); err != nil {
+	if err := c.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription); err != nil {
 		return err
 	}
 	if err := c.upsertRole(consulClient, meshGatewayRoleName, meshGatewayPolicyName, meshGatewayRoleDescription); err != nil {
@@ -474,7 +474,7 @@ func (c *Command) upsertMeshGatewayPolicyAndRole(consulClient *api.Client) error
 
 // upsertConsulPolicy creates the ACL policy and the associated rules with the given name,
 // if the policy does not exist.
-func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, policyDescription string, opts *api.WriteOptions) error {
+func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, policyDescription string) error {
 	// If the policy already exists, we're done.
 	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
 	if err != nil && !controller.IsACLNotFoundError(err) {
@@ -495,7 +495,7 @@ func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, polic
 		Name:        policyName,
 		Description: policyDescription,
 		Rules:       rules,
-	}, opts)
+	}, c.writeOptions())
 	if err != nil {
 		return fmt.Errorf("creating ACL policy: %w", err)
 	}

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -536,11 +536,10 @@ namespace_prefix "" {
 func (c *Command) meshGatewayPolicyRules() (string, error) {
 	rules := `
 mesh = "write"
-{{- if .Enterprise }}
+peering = "read"
+{{- if eq .Partition "default" }}
 partition_prefix "" {
-{{- end }}
 	peering = "read"
-{{- if .Enterprise }}
 }
 {{- end }}
 `
@@ -759,10 +758,14 @@ type Config struct {
 
 type templateData struct {
 	Enterprise bool
+	Partition  string
 }
 
 func (c *Command) templateData() templateData {
-	return templateData{Enterprise: c.config.Controller.PartitionsEnabled}
+	return templateData{
+		Enterprise: c.config.Controller.PartitionsEnabled,
+		Partition:  c.config.Controller.Partition,
+	}
 }
 
 func (c *Command) anonymousPolicyRules() (string, error) {

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -39,9 +39,10 @@ const (
 	anonPolicyDesc = "Anonymous token Policy"
 
 	// Role and Policy for API Gateways
-	apiGatewayRoleName        = "consul-ecs-api-gateway-role"
-	apiGatewayPolicyName      = "consul-ecs-api-gateway-policy"
-	apiGatewayRoleDescription = "API Gateway Role for ECS"
+	apiGatewayRoleName          = "consul-ecs-api-gateway-role"
+	apiGatewayPolicyName        = "consul-ecs-api-gateway-policy"
+	apiGatewayRoleDescription   = "API Gateway Role for ECS"
+	apiGatewayPolicyDescription = "API Gateway token Policy"
 
 	// Role for terminating gateways. This role will be
 	// bound to the token created by the auth method for
@@ -49,6 +50,11 @@ const (
 	// to this role via terraform.
 	terminatingGatewayRoleName        = "consul-ecs-terminating-gateway-role"
 	terminatingGatewayRoleDescription = "Terminating Gateway Role for ECS"
+
+	meshGatewayRoleName          = "consul-ecs-mesh-gateway-role"
+	meshGatewayRoleDescription   = "Mesh Gateway Role for ECS"
+	meshGatewayPolicyName        = "consul-ecs-mesh-gateway-policy"
+	meshGatewayPolicyDescription = "Mesh Gateway token Policy"
 )
 
 type Command struct {
@@ -239,6 +245,13 @@ func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsuti
 			Selector:    fmt.Sprintf(`entity_tags["%s"] == "terminating-gateway"`, authMethodGatewayKindTag),
 			BindName:    terminatingGatewayRoleName,
 		},
+		{
+			Description: "Bind a Consul role from IAM role tag for ECS based mesh gateways",
+			AuthMethod:  serviceAuthMethod.Name,
+			BindType:    api.BindingRuleBindTypeRole,
+			Selector:    fmt.Sprintf(`entity_tags["%s"] == "mesh-gateway"`, authMethodGatewayKindTag),
+			BindName:    meshGatewayRoleName,
+		},
 	}
 
 	agentSelf, err := consulClient.Agent().Self()
@@ -264,6 +277,9 @@ func (c *Command) upsertConsulResources(consulClient *api.Client, ecsMeta awsuti
 	}
 
 	if err := c.upsertAPIGatewayPolicyAndRole(consulClient); err != nil {
+		return err
+	}
+	if err := c.upsertMeshGatewayPolicyAndRole(consulClient); err != nil {
 		return err
 	}
 	if err := c.upsertRole(consulClient, terminatingGatewayRoleName, "", terminatingGatewayRoleDescription); err != nil {
@@ -392,62 +408,13 @@ func (c *Command) upsertAuthMethod(consulClient *api.Client, authMethod *api.ACL
 
 // upsertAPIGatewayPolicyAndRole creates or updates the Consul ACL role for the API Gateway token.
 func (c *Command) upsertAPIGatewayPolicyAndRole(consulClient *api.Client) error {
-	if err := c.upsertAPIGatewayPolicy(consulClient, apiGatewayPolicyName); err != nil {
+	if err := c.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription); err != nil {
 		return err
 	}
 	if err := c.upsertRole(consulClient, apiGatewayRoleName, apiGatewayPolicyName, apiGatewayRoleDescription); err != nil {
 		return err
 	}
 	return nil
-}
-
-// upsertAPIGatewayPolicy creates the ACL policy for the API gateway, if the policy does not exist.
-func (c *Command) upsertAPIGatewayPolicy(consulClient *api.Client, policyName string) error {
-	// If the policy already exists, we're done.
-	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
-	if err != nil && !controller.IsACLNotFoundError(err) {
-		return fmt.Errorf("reading API Gateway ACL policy: %w", err)
-	} else if err == nil && policy != nil { // returns policy=nil and err=nil if not found
-		c.log.Info("ACL policy already exists; skipping policy creation", "name", policyName)
-		return nil
-	}
-
-	// Otherwise, the policy is not found, so create it.
-	c.log.Info("creating ACL policy", "name", policyName)
-	apiGatewayRules, err := c.apiGatewayPolicyRules()
-	if err != nil {
-		return fmt.Errorf("failed to generate API gateway token policy rules: %w", err)
-	}
-
-	_, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{
-		Name:        policyName,
-		Description: "API Gateway token Policy",
-		Rules:       apiGatewayRules,
-	}, c.writeOptions())
-	if err != nil {
-		return fmt.Errorf("creating API Gateway token ACL policy: %w", err)
-	}
-	c.log.Info("ACL policy created successfully", "name", policyName)
-	return nil
-}
-
-func (c *Command) apiGatewayPolicyRules() (string, error) {
-	rules := `
-mesh = "read"
-{{- if .Enterprise }}
-namespace_prefix "" {
-{{- end }}
-	node_prefix "" {
-		policy = "read"
-	}
-	service_prefix "" {
-		policy = "read"
-	}
-{{- if .Enterprise }}
-}
-{{- end }}
-`
-	return RenderTemplate(rules, c.templateData())
 }
 
 // upsertRole creates the ACL role, if the role does not exist.
@@ -492,6 +459,92 @@ func (c *Command) upsertRole(consulClient *api.Client, roleName, policyName, rol
 	c.log.Info("ACL role created successfully", "name", roleName)
 
 	return nil
+}
+
+// upsertMeshGatewayPolicyAndRole creates or updates the Consul ACL role for the Mesh Gateway token.
+func (c *Command) upsertMeshGatewayPolicyAndRole(consulClient *api.Client) error {
+	if err := c.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription); err != nil {
+		return err
+	}
+	if err := c.upsertRole(consulClient, meshGatewayRoleName, meshGatewayPolicyName, meshGatewayRoleDescription); err != nil {
+		return err
+	}
+	return nil
+}
+
+// upsertConsulPolicy creates the ACL policy and the associated rules with the given name,
+// if the policy does not exist.
+func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, policyDescription string) error {
+	// If the policy already exists, we're done.
+	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
+	if err != nil && !controller.IsACLNotFoundError(err) {
+		return fmt.Errorf("reading API Gateway ACL policy: %w", err)
+	} else if err == nil && policy != nil {
+		c.log.Info("ACL policy already exists; skipping policy creation", "name", policyName)
+		return nil
+	}
+
+	// Otherwise, the policy is not found, so create it.
+	c.log.Info("creating ACL policy", "name", policyName)
+	rules, err := c.getRulesForPolicy(policyName)
+	if err != nil {
+		return fmt.Errorf("failed to generate API gateway token policy rules: %w", err)
+	}
+
+	_, _, err = consulClient.ACL().PolicyCreate(&api.ACLPolicy{
+		Name:        policyName,
+		Description: policyDescription,
+		Rules:       rules,
+	}, c.writeOptions())
+	if err != nil {
+		return fmt.Errorf("creating ACL policy: %w", err)
+	}
+	c.log.Info("ACL policy created successfully", "name", policyName)
+	return nil
+}
+
+func (c *Command) getRulesForPolicy(policy string) (string, error) {
+	switch policy {
+	case meshGatewayPolicyName:
+		return c.meshGatewayPolicyRules()
+	case apiGatewayPolicyName:
+		return c.apiGatewayPolicyRules()
+	default:
+		return "", fmt.Errorf("failed to fetch rules for the given policy %s", policy)
+	}
+}
+
+func (c *Command) apiGatewayPolicyRules() (string, error) {
+	rules := `
+mesh = "read"
+{{- if .Enterprise }}
+namespace_prefix "" {
+{{- end }}
+	node_prefix "" {
+		policy = "read"
+	}
+	service_prefix "" {
+		policy = "read"
+	}
+{{- if .Enterprise }}
+}
+{{- end }}
+`
+	return RenderTemplate(rules, c.templateData())
+}
+
+func (c *Command) meshGatewayPolicyRules() (string, error) {
+	rules := `
+mesh = "write"
+{{- if .Enterprise }}
+partition_prefix "" {
+{{- end }}
+	peering = "read"
+{{- if .Enterprise }}
+}
+{{- end }}
+`
+	return RenderTemplate(rules, c.templateData())
 }
 
 func uniqueStrings(strs []string) []string {

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -424,7 +424,7 @@ func (c *Command) upsertRole(consulClient *api.Client, roleName, policyName, rol
 	// If the role already exists, we're done.
 	role, _, err := consulClient.ACL().RoleReadByName(roleName, c.queryOptions())
 	if err != nil && !controller.IsACLNotFoundError(err) {
-		return fmt.Errorf("reading API Gateway ACL role: %w", err)
+		return fmt.Errorf("reading %s ACL role: %w", roleName, err)
 	} else if err == nil && role != nil { // returns role=nil and err=nil if not found
 		c.log.Info("ACL role already exists; skipping role creation", "name", roleName)
 

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -408,7 +408,7 @@ func (c *Command) upsertAuthMethod(consulClient *api.Client, authMethod *api.ACL
 
 // upsertAPIGatewayPolicyAndRole creates or updates the Consul ACL role for the API Gateway token.
 func (c *Command) upsertAPIGatewayPolicyAndRole(consulClient *api.Client) error {
-	if err := c.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription); err != nil {
+	if err := c.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription, c.writeOptions()); err != nil {
 		return err
 	}
 	if err := c.upsertRole(consulClient, apiGatewayRoleName, apiGatewayPolicyName, apiGatewayRoleDescription); err != nil {
@@ -463,7 +463,7 @@ func (c *Command) upsertRole(consulClient *api.Client, roleName, policyName, rol
 
 // upsertMeshGatewayPolicyAndRole creates or updates the Consul ACL role for the Mesh Gateway token.
 func (c *Command) upsertMeshGatewayPolicyAndRole(consulClient *api.Client) error {
-	if err := c.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription); err != nil {
+	if err := c.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription, nil); err != nil {
 		return err
 	}
 	if err := c.upsertRole(consulClient, meshGatewayRoleName, meshGatewayPolicyName, meshGatewayRoleDescription); err != nil {
@@ -474,7 +474,7 @@ func (c *Command) upsertMeshGatewayPolicyAndRole(consulClient *api.Client) error
 
 // upsertConsulPolicy creates the ACL policy and the associated rules with the given name,
 // if the policy does not exist.
-func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, policyDescription string) error {
+func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, policyDescription string, opts *api.WriteOptions) error {
 	// If the policy already exists, we're done.
 	policy, _, err := consulClient.ACL().PolicyReadByName(policyName, c.queryOptions())
 	if err != nil && !controller.IsACLNotFoundError(err) {
@@ -495,7 +495,7 @@ func (c *Command) upsertConsulPolicy(consulClient *api.Client, policyName, polic
 		Name:        policyName,
 		Description: policyDescription,
 		Rules:       rules,
-	}, c.writeOptions())
+	}, opts)
 	if err != nil {
 		return fmt.Errorf("creating ACL policy: %w", err)
 	}

--- a/subcommand/controller/command_ent_test.go
+++ b/subcommand/controller/command_ent_test.go
@@ -40,7 +40,15 @@ func TestUpsertAnonymousTokenPolicyEnt(t *testing.T) {
 }
 
 func TestUpsertAPIGatewayTokenPolicyAndRole(t *testing.T) {
-	testUpsertAPIGatewayPolicyAndRole(t, map[string]apiGatewayTokenTest{
+	testUpsertAPIGatewayPolicyAndRole(t, map[string]gatewayTokenTest{
+		"test creation": {
+			partitionsEnabled: true,
+		},
+	})
+}
+
+func TestUpsertMeshGatewayTokenPolicyAndRole(t *testing.T) {
+	testUpsertMeshGatewayPolicyAndRole(t, map[string]gatewayTokenTest{
 		"test creation": {
 			partitionsEnabled: true,
 		},

--- a/subcommand/controller/command_ent_test.go
+++ b/subcommand/controller/command_ent_test.go
@@ -52,5 +52,9 @@ func TestUpsertMeshGatewayTokenPolicyAndRole(t *testing.T) {
 		"test creation": {
 			partitionsEnabled: true,
 		},
+		"test creation with non default partition": {
+			partitionsEnabled:      true,
+			useNonDefaultPartition: true,
+		},
 	})
 }

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -881,6 +881,10 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 				cmd.config.Controller.Partition = "default"
 				if c.useNonDefaultPartition {
 					cmd.config.Controller.Partition = testPartitionName
+
+					partition := &api.Partition{Name: testPartitionName, Description: "Test partition"}
+					_, _, err := consulClient.Partitions().Create(context.Background(), partition, nil)
+					require.NoError(t, err)
 				}
 			}
 

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -837,22 +837,6 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 			consulClient, err := api.NewClient(cfg)
 			require.NoError(t, err)
 
-			t.Cleanup(func() {
-				role, _, err := consulClient.ACL().RoleReadByName(meshGatewayRoleName, nil)
-				require.NoError(t, err)
-				require.NotNil(t, role)
-
-				_, err = consulClient.ACL().RoleDelete(role.ID, nil)
-				require.NoError(t, err)
-
-				policy, _, err := consulClient.ACL().PolicyReadByName(meshGatewayPolicyName, nil)
-				require.NoError(t, err)
-				require.NotNil(t, policy)
-
-				_, err = consulClient.ACL().PolicyDelete(policy.ID, nil)
-				require.NoError(t, err)
-			})
-
 			serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
 			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
 
@@ -908,6 +892,22 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 			opts := &api.QueryOptions{
 				Partition: cmd.config.Controller.Partition,
 			}
+
+			t.Cleanup(func() {
+				role, _, err := consulClient.ACL().RoleReadByName(meshGatewayRoleName, opts)
+				require.NoError(t, err)
+				require.NotNil(t, role)
+
+				_, err = consulClient.ACL().RoleDelete(role.ID, &api.WriteOptions{Partition: opts.Partition})
+				require.NoError(t, err)
+
+				policy, _, err := consulClient.ACL().PolicyReadByName(meshGatewayPolicyName, opts)
+				require.NoError(t, err)
+				require.NotNil(t, policy)
+
+				_, err = consulClient.ACL().PolicyDelete(policy.ID, &api.WriteOptions{Partition: opts.Partition})
+				require.NoError(t, err)
+			})
 
 			roles, _, err := consulClient.ACL().RoleList(opts)
 			require.NoError(t, err)

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -861,7 +861,6 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 				config: &config.Config{
 					Controller: config.Controller{
 						PartitionsEnabled: c.partitionsEnabled,
-						Partition:         "default",
 					},
 					ConsulServers: config.ConsulServers{
 						Hosts: serverHost,
@@ -878,8 +877,11 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 				},
 			}
 
-			if c.partitionsEnabled && c.useNonDefaultPartition {
-				cmd.config.Controller.Partition = testPartitionName
+			if c.partitionsEnabled {
+				cmd.config.Controller.Partition = "default"
+				if c.useNonDefaultPartition {
+					cmd.config.Controller.Partition = testPartitionName
+				}
 			}
 
 			if c.policyExists {

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -698,10 +698,11 @@ func testUpsertAnonymousTokenPolicy(t *testing.T, cases map[string]anonTokenTest
 }
 
 type gatewayTokenTest struct {
-	partitionsEnabled bool
-	policyExists      bool
-	roleExists        bool
-	wantErr           bool
+	partitionsEnabled      bool
+	useNonDefaultPartition bool
+	policyExists           bool
+	roleExists             bool
+	wantErr                bool
 }
 
 func TestUpsertAPIGatewayPolicyAndRole(t *testing.T) {
@@ -859,6 +860,7 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 				config: &config.Config{
 					Controller: config.Controller{
 						PartitionsEnabled: c.partitionsEnabled,
+						Partition:         "default",
 					},
 					ConsulServers: config.ConsulServers{
 						Hosts: serverHost,
@@ -873,6 +875,10 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 						SkipServerWatch: true,
 					},
 				},
+			}
+
+			if c.partitionsEnabled && c.useNonDefaultPartition {
+				cmd.config.Controller.Partition = testPartitionName
 			}
 
 			if c.policyExists {
@@ -904,7 +910,7 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 			require.NotNil(t, policy)
 
 			expPolicy := expOSSMeshGatewayPolicy
-			if c.partitionsEnabled {
+			if c.partitionsEnabled && !c.useNonDefaultPartition {
 				expPolicy = expEntMeshGatewayPolicy
 			}
 

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -772,7 +772,7 @@ func testUpsertAPIGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTok
 			}
 
 			if c.policyExists {
-				err = cmd.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription)
+				err = cmd.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription, cmd.writeOptions())
 				require.NoError(t, err)
 			}
 
@@ -876,7 +876,7 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 			}
 
 			if c.policyExists {
-				err = cmd.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription)
+				err = cmd.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription, cmd.writeOptions())
 				require.NoError(t, err)
 			}
 

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -905,14 +905,18 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 			err = cmd.upsertMeshGatewayPolicyAndRole(consulClient)
 			require.NoError(t, err)
 
-			roles, _, err := consulClient.ACL().RoleList(nil)
+			opts := &api.QueryOptions{
+				Partition: cmd.config.Controller.Partition,
+			}
+
+			roles, _, err := consulClient.ACL().RoleList(opts)
 			require.NoError(t, err)
 			require.Len(t, roles, 1)
 
 			require.Equal(t, meshGatewayRoleName, roles[0].Name)
 			require.NotNil(t, roles[0].Policies)
 
-			policy, _, err := consulClient.ACL().PolicyReadByName(meshGatewayPolicyName, nil)
+			policy, _, err := consulClient.ACL().PolicyReadByName(meshGatewayPolicyName, opts)
 			require.NoError(t, err)
 			require.NotNil(t, policy)
 

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -61,6 +61,13 @@ namespace_prefix "" {
 		policy = "read"
 	}
 }`
+
+	expOSSMeshGatewayPolicy = `mesh = "write"
+	peering = "read"`
+	expEntMeshGatewayPolicy = `mesh = "write"
+partition_prefix "" {
+	peering = "read"
+}`
 )
 
 var (
@@ -295,11 +302,12 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnab
 	}
 
 	require.Contains(t, policyNames, apiGatewayPolicyName)
+	require.Contains(t, policyNames, meshGatewayPolicyName)
 
 	// Check for the presence of API gateway and terminating gateway roles
 	roles, _, err := consulClient.ACL().RoleList(nil)
 	require.NoError(t, err)
-	require.Len(t, roles, 2)
+	require.Len(t, roles, 3)
 
 	roleNames := make([]string, 0)
 	for _, role := range roles {
@@ -307,6 +315,7 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnab
 	}
 	require.Contains(t, roleNames, apiGatewayRoleName)
 	require.Contains(t, roleNames, terminatingGatewayRoleName)
+	require.Contains(t, roleNames, meshGatewayRoleName)
 
 	// Check the auth methods are created
 	methods, _, err := consulClient.ACL().AuthMethodList(nil)
@@ -344,7 +353,7 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnab
 		// Check the binding rule is created.
 		rules, _, err := consulClient.ACL().BindingRuleList(method.Name, nil)
 		require.NoError(t, err)
-		require.Len(t, rules, 3)
+		require.Len(t, rules, 4)
 
 		var serviceBindingRule *api.ACLBindingRule
 		gatewayBindingRules := make([]*api.ACLBindingRule, 0)
@@ -359,7 +368,7 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnab
 		require.NotNil(t, serviceBindingRule)
 		require.Equal(t, serviceBindingRule.BindName, fmt.Sprintf(`${entity_tags.%s}`, authMethodServiceNameTag))
 
-		require.Len(t, gatewayBindingRules, 2)
+		require.Len(t, gatewayBindingRules, 3)
 
 		bindRuleNames := make([]string, 0)
 		for _, bindingRule := range gatewayBindingRules {
@@ -367,6 +376,7 @@ func checkConsulResources(t *testing.T, consulClient *api.Client, partitionsEnab
 		}
 		require.Contains(t, bindRuleNames, apiGatewayRoleName)
 		require.Contains(t, bindRuleNames, terminatingGatewayRoleName)
+		require.Contains(t, bindRuleNames, meshGatewayRoleName)
 	}
 }
 
@@ -687,7 +697,7 @@ func testUpsertAnonymousTokenPolicy(t *testing.T, cases map[string]anonTokenTest
 	}
 }
 
-type apiGatewayTokenTest struct {
+type gatewayTokenTest struct {
 	partitionsEnabled bool
 	policyExists      bool
 	roleExists        bool
@@ -695,7 +705,7 @@ type apiGatewayTokenTest struct {
 }
 
 func TestUpsertAPIGatewayPolicyAndRole(t *testing.T) {
-	testUpsertAPIGatewayPolicyAndRole(t, map[string]apiGatewayTokenTest{
+	testUpsertAPIGatewayPolicyAndRole(t, map[string]gatewayTokenTest{
 		"both policy and role doesn't exist": {},
 		"policy already exists": {
 			policyExists: true,
@@ -711,7 +721,7 @@ func TestUpsertAPIGatewayPolicyAndRole(t *testing.T) {
 	})
 }
 
-func testUpsertAPIGatewayPolicyAndRole(t *testing.T, cases map[string]apiGatewayTokenTest) {
+func testUpsertAPIGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTokenTest) {
 	t.Parallel()
 	t.Helper()
 	for name, c := range cases {
@@ -762,7 +772,7 @@ func testUpsertAPIGatewayPolicyAndRole(t *testing.T, cases map[string]apiGateway
 			}
 
 			if c.policyExists {
-				err = cmd.upsertAPIGatewayPolicy(consulClient, apiGatewayPolicyName)
+				err = cmd.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription)
 				require.NoError(t, err)
 			}
 
@@ -791,6 +801,111 @@ func testUpsertAPIGatewayPolicyAndRole(t *testing.T, cases map[string]apiGateway
 			expPolicy := expOSSAPIGatewayPolicy
 			if c.partitionsEnabled {
 				expPolicy = expEntAPIGatewayPolicy
+			}
+
+			require.Equal(t, expPolicy, policy.Rules)
+		})
+	}
+}
+
+func TestUpsertMeshGatewayPolicyAndRole(t *testing.T) {
+	testUpsertMeshGatewayPolicyAndRole(t, map[string]gatewayTokenTest{
+		"both policy and role doesn't exist": {},
+		"policy already exists": {
+			policyExists: true,
+		},
+		"role already exists": {
+			roleExists: true,
+			wantErr:    true,
+		},
+		"role already exists and policy also exists": {
+			roleExists:   true,
+			policyExists: true,
+		},
+	})
+}
+
+func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTokenTest) {
+	t.Parallel()
+	t.Helper()
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			server, cfg := testutil.ConsulServer(t, testutil.ConsulACLConfigFn)
+			consulClient, err := api.NewClient(cfg)
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				role, _, err := consulClient.ACL().RoleReadByName(meshGatewayRoleName, nil)
+				require.NoError(t, err)
+				require.NotNil(t, role)
+
+				_, err = consulClient.ACL().RoleDelete(role.ID, nil)
+				require.NoError(t, err)
+
+				policy, _, err := consulClient.ACL().PolicyReadByName(meshGatewayPolicyName, nil)
+				require.NoError(t, err)
+				require.NotNil(t, policy)
+
+				_, err = consulClient.ACL().PolicyDelete(policy.ID, nil)
+				require.NoError(t, err)
+			})
+
+			serverHost, serverGRPCPort := testutil.GetHostAndPortFromAddress(server.GRPCAddr)
+			_, serverHTTPPort := testutil.GetHostAndPortFromAddress(server.HTTPAddr)
+
+			cmd := Command{
+				log: hclog.Default().Named("controller"),
+				config: &config.Config{
+					Controller: config.Controller{
+						PartitionsEnabled: c.partitionsEnabled,
+					},
+					ConsulServers: config.ConsulServers{
+						Hosts: serverHost,
+						GRPC: config.GRPCSettings{
+							Port:      serverGRPCPort,
+							EnableTLS: testutil.BoolPtr(false),
+						},
+						HTTP: config.HTTPSettings{
+							Port:      serverHTTPPort,
+							EnableTLS: testutil.BoolPtr(false),
+						},
+						SkipServerWatch: true,
+					},
+				},
+			}
+
+			if c.policyExists {
+				err = cmd.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription)
+				require.NoError(t, err)
+			}
+
+			if c.roleExists {
+				err = cmd.upsertRole(consulClient, meshGatewayRoleName, meshGatewayPolicyName, meshGatewayRoleDescription)
+				if c.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			err = cmd.upsertMeshGatewayPolicyAndRole(consulClient)
+			require.NoError(t, err)
+
+			roles, _, err := consulClient.ACL().RoleList(nil)
+			require.NoError(t, err)
+			require.Len(t, roles, 1)
+
+			require.Equal(t, meshGatewayRoleName, roles[0].Name)
+			require.NotNil(t, roles[0].Policies)
+
+			policy, _, err := consulClient.ACL().PolicyReadByName(meshGatewayPolicyName, nil)
+			require.NoError(t, err)
+			require.NotNil(t, policy)
+
+			expPolicy := expOSSMeshGatewayPolicy
+			if c.partitionsEnabled {
+				expPolicy = expEntMeshGatewayPolicy
 			}
 
 			require.Equal(t, expPolicy, policy.Rules)

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -772,7 +772,7 @@ func testUpsertAPIGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTok
 			}
 
 			if c.policyExists {
-				err = cmd.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription, cmd.writeOptions())
+				err = cmd.upsertConsulPolicy(consulClient, apiGatewayPolicyName, apiGatewayPolicyDescription)
 				require.NoError(t, err)
 			}
 
@@ -876,7 +876,7 @@ func testUpsertMeshGatewayPolicyAndRole(t *testing.T, cases map[string]gatewayTo
 			}
 
 			if c.policyExists {
-				err = cmd.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription, cmd.writeOptions())
+				err = cmd.upsertConsulPolicy(consulClient, meshGatewayPolicyName, meshGatewayPolicyDescription)
 				require.NoError(t, err)
 			}
 

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -65,6 +65,7 @@ namespace_prefix "" {
 	expOSSMeshGatewayPolicy = `mesh = "write"
 peering = "read"`
 	expEntMeshGatewayPolicy = `mesh = "write"
+peering = "read"
 partition_prefix "" {
 	peering = "read"
 }`

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -63,7 +63,7 @@ namespace_prefix "" {
 }`
 
 	expOSSMeshGatewayPolicy = `mesh = "write"
-	peering = "read"`
+peering = "read"`
 	expEntMeshGatewayPolicy = `mesh = "write"
 partition_prefix "" {
 	peering = "read"


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds the missing `mesh:write` and `peering:read` permissions for mesh gateway based ECS tasks according to https://developer.hashicorp.com/consul/docs/security/acl/tokens/create/create-a-mesh-gateway-token#consul-enterprise-in-default-partition.
- Following are the changes made in the PR to support the same
   - Create a role named `consul-ecs-mesh-gateway-role` by default.
   - Create a policy named `consul-ecs-mesh-gateway-policy` with the relevant rules and link it to the role.
   - Create a binding rule to the auth method for mesh-gateway based service kind iam entity tags. Whenever a login is performed from a mesh gtw based ECS task, the binding rule makes sure to link the token to the existing mesh gateway role.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
