### PR TITLE
Add 0.9.x to main

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -16,7 +16,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.8.0"
+	Version = "0.9.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
## Changes proposed in this PR:
- Now that `0.8.x` has been cut off from main we can bump the version in main to `0.9.0`

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
