### PR TITLE
fix: security scanner gh token

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -43,8 +43,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: hashicorp/security-scanner
-          # TODO: replace w/ org-level secret once available
-          token: ${{ secrets.PRODSEC_SCANNER_READ_ONLY_CONSUL_ECS_COPY }}
+          token: ${{ secrets.PRODSEC_SCANNER_READ_ONLY }}
           path: security-scanner
           ref: main
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Moving to use the org level GitHub token which get rotated and maintained regularly.

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
