### PR TITLE
[NET11250]Added fix for health check update for consul-dataplane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+BUG FIXES
+* Fix the issue where the service was accepting traffic even though it wasn't healthy. This fix updates the health check status for `consul-dataplane` container and takes into account the health of the service container as well.
 
 IMPROVEMENTS
 * Bump Go version to `1.22.7`

--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -130,6 +130,7 @@ func (c *Command) syncChecks(consulClient *api.Client,
 		}
 	}
 
+	overallDataplaneHealth := 0
 	parsedContainers := make(map[string]string)
 	// iterate over parse
 	for _, container := range containersToSync {
@@ -160,15 +161,26 @@ func (c *Command) syncChecks(consulClient *api.Client,
 				currentStatuses[container.Name] = container.Health.Status
 			}
 		}
-
+		if container.Name == config.ConsulDataplaneContainerName {
+			if container.Health.Status == ecs.HealthStatusHealthy {
+				overallDataplaneHealth = 1
+			}
+		}
 	}
 
-	overallDataplaneHealthStatus := ecs.HealthStatusHealthy
-	for _, healthStatus := range parsedContainers {
-		if healthStatus != ecs.HealthStatusHealthy {
-			overallDataplaneHealthStatus = ecs.HealthStatusUnhealthy
-			break
+	for containerName, healthStatus := range parsedContainers {
+
+		if containerName != config.ConsulDataplaneContainerName {
+			currentContainerHealth := 0
+			if healthStatus == ecs.HealthStatusHealthy {
+				currentContainerHealth = 1
+			}
+			overallDataplaneHealth = overallDataplaneHealth & currentContainerHealth
 		}
+	}
+	overallDataplaneHealthStatus := ecs.HealthStatusUnhealthy
+	if overallDataplaneHealth == 1 {
+		overallDataplaneHealthStatus = ecs.HealthStatusHealthy
 	}
 
 	err = c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, config.ConsulDataplaneContainerName, overallDataplaneHealthStatus)

--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -166,15 +166,15 @@ func (c *Command) syncChecks(consulClient *api.Client,
 	// if dataplane container exist and healthy then proceed to checking the other containers health
 	if ok && overallDataplaneHealthStatus == ecs.HealthStatusHealthy {
 		//
-		for name, healthStatus := range parsedContainers {
+		for _, healthStatus := range parsedContainers {
 			// as soon as we find any unhealthy container, we can set the dataplane health to unhealthy
-			if healthStatus != ecs.HealthStatusHealthy && name != config.ConsulDataplaneContainerName {
+			if healthStatus != ecs.HealthStatusHealthy {
 				overallDataplaneHealthStatus = ecs.HealthStatusUnhealthy
 				break
 			}
 		}
 	} else {
-		// If no dataplane container or dataplane container is not healthy set overall health to healthy
+		// If no dataplane container or dataplane container is not healthy set overall health to unhealthy
 		overallDataplaneHealthStatus = ecs.HealthStatusUnhealthy
 	}
 

--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -184,7 +184,14 @@ func (c *Command) syncChecks(consulClient *api.Client,
 	}
 
 	err = c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, config.ConsulDataplaneContainerName, overallDataplaneHealthStatus)
-
+	if err != nil {
+		c.log.Warn("failed to update Consul health status", "err", err)
+	} else {
+		c.log.Info("container health check updated in Consul",
+			"name", config.ConsulDataplaneContainerName,
+			"status", overallDataplaneHealthStatus,
+		)
+	}
 	return currentStatuses
 }
 

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -387,7 +387,7 @@ func TestRun(t *testing.T) {
 					if c.missingDataplaneContainer {
 						expCheck.Status = api.HealthCritical
 					} else {
-						expCheck.Status = api.HealthPassing
+						expCheck.Status = api.HealthCritical
 					}
 				}
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -405,13 +405,13 @@ func TestRun(t *testing.T) {
 				}
 
 				if !found {
-					log.Printf("BEFORE: Updating dataplane container with Status markDataplaneContainerUnhealthy :%s and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
+					log.Printf("BEFORE: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
 						expCheck.Status = api.HealthCritical
 					} else {
 						expCheck.Status = api.HealthPassing
 					}
-					log.Printf("AFTER: Updating dataplane container with Status markDataplaneContainerUnhealthy :%s and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
+					log.Printf("AFTER: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if markDataplaneContainerUnhealthy {
 						log.Printf("Marking expCheck for dataplane container :%s \n", expCheck.Status)
 					}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -136,6 +136,7 @@ func TestRun(t *testing.T) {
 					status:  ecs.HealthStatusUnhealthy,
 				},
 			},
+			expectedDataplaneHealthStatus: api.HealthCritical,
 		},
 		"one healthy and one missing health sync containers": {
 			healthSyncContainers: map[string]healthSyncContainerMetaData{

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -386,6 +386,7 @@ func TestRun(t *testing.T) {
 					if expCheck.CheckID == checkID {
 						if hsc.missing {
 							expCheck.Status = api.HealthCritical
+							markDataplaneContainerUnhealthy = true
 						} else {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
 							// If there are multiple health sync containers and one of them is unhealthy
@@ -407,9 +408,7 @@ func TestRun(t *testing.T) {
 
 				if !found {
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
-
 						expCheck.Status = api.HealthCritical
-
 					} else {
 						expCheck.Status = api.HealthPassing
 					}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -129,7 +129,8 @@ func TestRun(t *testing.T) {
 					status: ecs.HealthStatusHealthy,
 				},
 				"container-2": {
-					status: ecs.HealthStatusUnhealthy,
+					missing: false,
+					status:  ecs.HealthStatusUnhealthy,
 				},
 			},
 		},

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -377,10 +377,10 @@ func TestRun(t *testing.T) {
 			for _, check := range expectedSvcChecks {
 				log.Printf("Check Name: %s, Status: %s, ServiceName: %s, CheckId: %s\n", check.Name, check.Status, check.ServiceName, check.CheckID)
 			}
+			markDataplaneContainerUnhealthy := false
 			for _, expCheck := range expectedSvcChecks {
 				found := false
 				for name, hsc := range c.healthSyncContainers {
-
 					checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
 					log.Printf("Checking for container: %s, hsc %s, CheckId: %s\n", name, hsc.status, checkID)
 					if expCheck.CheckID == checkID {
@@ -395,6 +395,7 @@ func TestRun(t *testing.T) {
 									log.Printf("Container Name: %s, ActualStatus:%s \n", containerName, c.healthSyncContainers[containerName].status)
 									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
 										expCheck.Status = api.HealthCritical
+										markDataplaneContainerUnhealthy = true
 										break
 									}
 								}
@@ -406,7 +407,7 @@ func TestRun(t *testing.T) {
 				}
 
 				if !found {
-					if c.missingDataplaneContainer {
+					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
 						expCheck.Status = api.HealthCritical
 					} else {
 						expCheck.Status = api.HealthPassing

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -385,7 +385,9 @@ func TestRun(t *testing.T) {
 							// If there are multiple health sync containers and one of them is unhealthy
 							// then the service check should be critical.
 							if len(c.healthSyncContainers) > 1 {
+								log.Printf("Checking for unhealthy containers: %s \n", name)
 								for containerName := range c.healthSyncContainers {
+									log.Printf("Container Name: %s, ActualStatus:%s \n", containerName, c.healthSyncContainers[containerName].status)
 									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
 										expCheck.Status = api.HealthCritical
 										break

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -465,7 +465,7 @@ func TestRun(t *testing.T) {
 					}
 
 					if !found {
-						expCheck.Status = api.HealthCritical
+						expCheck.Status = api.HealthPassing
 					}
 				}
 				expectedProxyCheck.Status = api.HealthPassing

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -126,7 +126,8 @@ func TestRun(t *testing.T) {
 		"one healthy and one unhealthy health sync containers": {
 			healthSyncContainers: map[string]healthSyncContainerMetaData{
 				"container-1": {
-					status: ecs.HealthStatusHealthy,
+					missing: false,
+					status:  ecs.HealthStatusHealthy,
 				},
 				"container-2": {
 					missing: false,

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -464,9 +464,7 @@ func TestRun(t *testing.T) {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
 							if len(c.healthSyncContainers) > 1 {
 								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
-										containerName != config.ConsulDataplaneContainerName &&
-										c.shouldMissingContainersReappear == false {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
 										expCheck.Status = api.HealthCritical
 										break
 									}
@@ -492,6 +490,7 @@ func TestRun(t *testing.T) {
 				expCheck.Status = api.HealthCritical
 			}
 			expectedProxyCheck.Status = api.HealthCritical
+
 			assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 
 			// Stop dataplane container manually because
@@ -857,6 +856,7 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 			filter := fmt.Sprintf("CheckID == `%s`", expCheck.CheckID)
 			checks, _, err := consulClient.Health().Checks(expCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expCheck.Namespace, Partition: expCheck.Partition})
 			require.NoError(r, err)
+
 			for _, check := range checks {
 				require.Equal(r, expCheck.Status, check.Status)
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -105,7 +105,7 @@ func TestRun(t *testing.T) {
 		missingDataplaneContainer       bool
 		shouldMissingContainersReappear bool
 	}{
-		//"no additional health sync containers": {},
+		"no additional health sync containers": {},
 		//"one healthy health sync container": {
 		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
 		//		"container-1": {
@@ -384,6 +384,7 @@ func TestRun(t *testing.T) {
 					if expCheck.CheckID == checkID {
 						if hsc.missing {
 							expCheck.Status = api.HealthCritical
+							log.Printf("Marking the datplane container unhealthy due to :%s \n", name)
 							markDataplaneContainerUnhealthy = true
 						} else {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
@@ -422,9 +423,11 @@ func TestRun(t *testing.T) {
 			}
 			log.Printf("ExpectedProxyCheck Name: %s and expCheck :%s \n", expectedProxyCheck.Name, expectedProxyCheck.Status)
 			if c.missingDataplaneContainer {
+				log.Printf("Dataplane container is missing and marking proxy check Critical\n")
 				expectedProxyCheck.Status = api.HealthCritical
 			}
 
+			log.Printf("Asserting HEalth checks - 1")
 			assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 
 			// Test server watch
@@ -495,7 +498,7 @@ func TestRun(t *testing.T) {
 				expCheck.Status = api.HealthCritical
 			}
 			expectedProxyCheck.Status = api.HealthCritical
-
+			log.Printf("Asserting HEalth checks - 2")
 			assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 
 			// Stop dataplane container manually because

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -391,9 +391,9 @@ func TestRun(t *testing.T) {
 							// If there are multiple health sync containers and one of them is unhealthy
 							// then the service check should be critical.
 							for containerName := range c.healthSyncContainers {
-								log.Printf("Container Name: %s, ActualStatus:%s \n", containerName, c.healthSyncContainers[containerName].status)
 								if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
 									expCheck.Status = api.HealthCritical
+									log.Printf("Marking the datplane container unhealthy due to :%s \n", containerName)
 									markDataplaneContainerUnhealthy = true
 									break
 								}
@@ -407,13 +407,19 @@ func TestRun(t *testing.T) {
 
 				if !found {
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
+
 						expCheck.Status = api.HealthCritical
+
 					} else {
 						expCheck.Status = api.HealthPassing
+					}
+					if markDataplaneContainerUnhealthy {
+						log.Printf("Marking expCheck for dataplane container :%s \n", expCheck.Status)
 					}
 				}
 			}
 			expectedProxyCheck.Status = api.HealthPassing
+			log.Printf("ExpectedProxyCheck Name: %s and expCheck :%s \n", expectedProxyCheck.Name, expectedProxyCheck.Status)
 			if c.missingDataplaneContainer {
 				expectedProxyCheck.Status = api.HealthCritical
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -385,8 +385,7 @@ func TestRun(t *testing.T) {
 							// then the service check should be critical.
 							if len(c.healthSyncContainers) > 1 {
 								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
-										c.healthSyncContainers[containerName].missing == false {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy && hsc.missing == false {
 										expCheck.Status = api.HealthCritical
 										break
 									}
@@ -466,7 +465,7 @@ func TestRun(t *testing.T) {
 					}
 
 					if !found {
-						expCheck.Status = api.HealthPassing
+						expCheck.Status = api.HealthCritical
 					}
 				}
 				expectedProxyCheck.Status = api.HealthPassing

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -391,7 +391,7 @@ func TestRun(t *testing.T) {
 					}
 				}
 			}
-			expectedProxyCheck.Status = api.HealthPassing
+			expectedProxyCheck.Status = api.HealthCritical
 			if c.missingDataplaneContainer {
 				expectedProxyCheck.Status = api.HealthCritical
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -373,6 +373,7 @@ func TestRun(t *testing.T) {
 
 			// Align the expectations for checks according to the
 			// state of health sync containers
+			log.Printf("Expected Svc Checks: %v \n", expectedSvcChecks)
 			for _, expCheck := range expectedSvcChecks {
 				found := false
 				for name, hsc := range c.healthSyncContainers {
@@ -839,6 +840,7 @@ func injectContainersIntoTaskMetaResponse(t *testing.T, taskMetadataResponse *aw
 	taskMetadataResponse.Containers = taskMetaContainersResponse
 	taskMetaRespStr, err := constructTaskMetaResponseString(taskMetadataResponse)
 	require.NoError(t, err)
+	log.Printf("TaskMetaResponseStr: %s, \n", taskMetaRespStr)
 
 	return taskMetaRespStr
 }

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -160,6 +160,7 @@ func TestRun(t *testing.T) {
 					status: ecs.HealthStatusUnhealthy,
 				},
 			},
+			expectedDataplaneHealthStatus: api.HealthCritical,
 		},
 		"missing dataplane container": {
 			missingDataplaneContainer: true,

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -489,7 +489,7 @@ func TestRun(t *testing.T) {
 			require.NoError(t, err)
 			currentTaskMetaResp.Store(taskMetaRespStr)
 
-			assertServiceAndProxyInstances(t, consulClient, serviceName, proxyServiceName, 0, apiQueryOptions)
+			//assertServiceAndProxyInstances(t, consulClient, serviceName, proxyServiceName, 0, apiQueryOptions)
 			if c.consulLogin.Enabled {
 				assertConsulLogout(t, cfg, consulEcsConfig.BootstrapDir)
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -388,8 +388,8 @@ func TestRun(t *testing.T) {
 					if expCheck.CheckID == checkID {
 						if hsc.missing {
 							expCheck.Status = api.HealthCritical
-							log.Printf("Marking the datplane container unhealthy due to :%s \n", name)
-							markDataplaneContainerUnhealthy = true
+							//log.Printf("Marking the datplane container unhealthy due to :%s \n", name)
+							//markDataplaneContainerUnhealthy = true
 						} else {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
 							// If there are multiple health sync containers and one of them is unhealthy

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -149,10 +149,12 @@ func TestRun(t *testing.T) {
 		"two unhealthy health sync containers": {
 			healthSyncContainers: map[string]healthSyncContainerMetaData{
 				"container-1": {
-					status: ecs.HealthStatusUnhealthy,
+					missing: false,
+					status:  ecs.HealthStatusUnhealthy,
 				},
 				"container-2": {
-					status: ecs.HealthStatusUnhealthy,
+					missing: false,
+					status:  ecs.HealthStatusUnhealthy,
 				},
 			},
 		},

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -393,7 +393,7 @@ func TestRun(t *testing.T) {
 							// If there are multiple health sync containers and one of them is unhealthy
 							// then the service check should be critical.
 							for containerName := range c.healthSyncContainers {
-								if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
+								if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy && c.healthSyncContainers[containerName].missing == false {
 									expCheck.Status = api.HealthCritical
 									log.Printf("Marking the datplane container unhealthy due to :%s \n", containerName)
 									markDataplaneContainerUnhealthy = true

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -381,7 +381,8 @@ func TestRun(t *testing.T) {
 							// then the service check should be critical.
 							if len(c.healthSyncContainers) > 1 {
 								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
+										c.healthSyncContainers[containerName].missing == false {
 										expCheck.Status = api.HealthCritical
 										break
 									}
@@ -446,15 +447,16 @@ func TestRun(t *testing.T) {
 						checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
 						if expCheck.CheckID == checkID {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
-							found = true
 							if len(c.healthSyncContainers) > 1 {
 								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
+										c.shouldMissingContainersReappear == false {
 										expCheck.Status = api.HealthCritical
 										break
 									}
 								}
 							}
+							found = true
 							break
 						}
 					}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -386,8 +386,7 @@ func TestRun(t *testing.T) {
 							// then the service check should be critical.
 							if len(c.healthSyncContainers) > 1 {
 								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
-										containerName != config.ConsulDataplaneContainerName {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
 										expCheck.Status = api.HealthCritical
 										break
 									}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -387,7 +387,7 @@ func TestRun(t *testing.T) {
 					if c.missingDataplaneContainer {
 						expCheck.Status = api.HealthCritical
 					} else {
-						expCheck.Status = api.HealthCritical
+						expCheck.Status = api.HealthPassing
 					}
 				}
 			}
@@ -445,7 +445,7 @@ func TestRun(t *testing.T) {
 						expCheck.Status = api.HealthPassing
 					}
 				}
-				expectedProxyCheck.Status = api.HealthPassing
+				expectedProxyCheck.Status = api.HealthCritical
 				assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 			}
 

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -409,7 +409,7 @@ func TestRun(t *testing.T) {
 					log.Printf("BEFORE: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
 						expCheck.Status = api.HealthCritical
-					} else if len(c.healthSyncContainers) == 0 {
+					} else if len(c.healthSyncContainers) == 0 || !markDataplaneContainerUnhealthy {
 						expCheck.Status = api.HealthPassing
 					}
 					log.Printf("AFTER: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -151,16 +151,16 @@ func TestRun(t *testing.T) {
 			expectedDataplaneHealthStatus: api.HealthPassing,
 			consulLogin:                   consulLoginCfg,
 		},
-		//"two unhealthy health sync containers": {
-		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
-		//		"container-1": {
-		//			status: ecs.HealthStatusUnhealthy,
-		//		},
-		//		"container-2": {
-		//			status: ecs.HealthStatusUnhealthy,
-		//		},
-		//	},
-		//},
+		"two unhealthy health sync containers": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusUnhealthy,
+				},
+				"container-2": {
+					status: ecs.HealthStatusUnhealthy,
+				},
+			},
+		},
 		"missing dataplane container": {
 			missingDataplaneContainer: true,
 		},

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -151,12 +151,10 @@ func TestRun(t *testing.T) {
 		"two unhealthy health sync containers": {
 			healthSyncContainers: map[string]healthSyncContainerMetaData{
 				"container-1": {
-					missing: false,
-					status:  ecs.HealthStatusUnhealthy,
+					status: ecs.HealthStatusUnhealthy,
 				},
 				"container-2": {
-					missing: false,
-					status:  ecs.HealthStatusUnhealthy,
+					status: ecs.HealthStatusUnhealthy,
 				},
 			},
 		},
@@ -407,11 +405,13 @@ func TestRun(t *testing.T) {
 				}
 
 				if !found {
+					log.Printf("BEFORE: Updating dataplane container with Status markDataplaneContainerUnhealthy :%s and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
 						expCheck.Status = api.HealthCritical
 					} else {
 						expCheck.Status = api.HealthPassing
 					}
+					log.Printf("AFTER: Updating dataplane container with Status markDataplaneContainerUnhealthy :%s and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if markDataplaneContainerUnhealthy {
 						log.Printf("Marking expCheck for dataplane container :%s \n", expCheck.Status)
 					}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -431,47 +431,56 @@ func TestRun(t *testing.T) {
 			// This block makes a missing reappear in the task meta response and
 			// tests if the healthy-sync process is able to sync back the status of the
 			// container to Consul servers.
-			if c.shouldMissingContainersReappear {
-				// Mark all containers as non missing
-				c.missingDataplaneContainer = false
-				for _, hsc := range c.healthSyncContainers {
-					hsc.missing = false
-				}
-
-				// Add the containers data into task meta response
-				taskMetaRespStr = injectContainersIntoTaskMetaResponse(t, taskMetadataResponse, c.missingDataplaneContainer, c.healthSyncContainers)
-				currentTaskMetaResp.Store(taskMetaRespStr)
-
-				// Align the expectations for checks according to the
-				// state of health sync containers
-				for _, expCheck := range expectedSvcChecks {
-					found := false
-					for name, hsc := range c.healthSyncContainers {
-						checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
-						if expCheck.CheckID == checkID {
-							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
-							found = true
-							break
-						}
-					}
-
-					if !found {
-						expCheck.Status = api.HealthPassing
-					}
-				}
-				expectedProxyCheck.Status = api.HealthPassing
-				assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
-			}
-
-			// Send SIGTERM and verify the status of checks
-			signalSIGTERM(t)
-
-			for _, expCheck := range expectedSvcChecks {
-				expCheck.Status = api.HealthCritical
-			}
-			expectedProxyCheck.Status = api.HealthCritical
-
-			assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
+			//if c.shouldMissingContainersReappear {
+			//	// Mark all containers as non missing
+			//	c.missingDataplaneContainer = false
+			//	for _, hsc := range c.healthSyncContainers {
+			//		hsc.missing = false
+			//	}
+			//
+			//	// Add the containers data into task meta response
+			//	taskMetaRespStr = injectContainersIntoTaskMetaResponse(t, taskMetadataResponse, c.missingDataplaneContainer, c.healthSyncContainers)
+			//	currentTaskMetaResp.Store(taskMetaRespStr)
+			//
+			//	// Align the expectations for checks according to the
+			//	// state of health sync containers
+			//	for _, expCheck := range expectedSvcChecks {
+			//		found := false
+			//		for name, hsc := range c.healthSyncContainers {
+			//			checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
+			//			if expCheck.CheckID == checkID {
+			//				expCheck.Status = ecsHealthToConsulHealth(hsc.status)
+			//				//if len(c.healthSyncContainers) > 1 {
+			//				//	for containerName := range c.healthSyncContainers {
+			//				//		if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
+			//				//			c.shouldMissingContainersReappear == false {
+			//				//			expCheck.Status = api.HealthCritical
+			//				//			break
+			//				//		}
+			//				//	}
+			//				//}
+			//				found = true
+			//				break
+			//			}
+			//		}
+			//
+			//		if !found {
+			//			expCheck.Status = api.HealthPassing
+			//		}
+			//	}
+			//	expectedProxyCheck.Status = api.HealthPassing
+			//	assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
+			//}
+			//
+			//// Send SIGTERM and verify the status of checks
+			//signalSIGTERM(t)
+			//
+			//for _, expCheck := range expectedSvcChecks {
+			//	expCheck.Status = api.HealthCritical
+			//}
+			//expectedProxyCheck.Status = api.HealthCritical
+			//
+			//assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 
 			// Stop dataplane container manually because
 			// health-sync waits for it before deregistering

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -373,7 +373,10 @@ func TestRun(t *testing.T) {
 
 			// Align the expectations for checks according to the
 			// state of health sync containers
-			log.Printf("Expected Svc Checks: %v \n", expectedSvcChecks)
+			log.Printf("Expected Svc Checks: %+v\n", expectedSvcChecks)
+			for _, check := range expectedSvcChecks {
+				log.Printf("Check Name: %s, Status: %s\n", check.Name, check.Status)
+			}
 			for _, expCheck := range expectedSvcChecks {
 				found := false
 				for name, hsc := range c.healthSyncContainers {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -408,8 +408,6 @@ func TestRun(t *testing.T) {
 					log.Printf("BEFORE: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
 						expCheck.Status = api.HealthCritical
-					} else {
-						expCheck.Status = api.HealthPassing
 					}
 					log.Printf("AFTER: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if markDataplaneContainerUnhealthy {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -372,7 +372,7 @@ func TestRun(t *testing.T) {
 			// Align the expectations for checks according to the
 			// state of health sync containers
 			log.Printf("Expected Svc Checks: %+v\n", expectedSvcChecks)
-			for _, check := range expectedSvcChecks {
+			for _, check := range append(expectedSvcChecks, expectedProxyCheck) {
 				log.Printf("Check Name: %s, Status: %s, ServiceName: %s, CheckId: %s\n", check.Name, check.Status, check.ServiceName, check.CheckID)
 			}
 			markDataplaneContainerUnhealthy := false
@@ -409,6 +409,8 @@ func TestRun(t *testing.T) {
 					log.Printf("BEFORE: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {
 						expCheck.Status = api.HealthCritical
+					} else if len(c.healthSyncContainers) == 0 {
+						expCheck.Status = api.HealthPassing
 					}
 					log.Printf("AFTER: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if markDataplaneContainerUnhealthy {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -447,6 +447,14 @@ func TestRun(t *testing.T) {
 						if expCheck.CheckID == checkID {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
 							found = true
+							if len(c.healthSyncContainers) > 1 {
+								for containerName := range c.healthSyncContainers {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
+										expCheck.Status = api.HealthCritical
+										break
+									}
+								}
+							}
 							break
 						}
 					}
@@ -455,7 +463,7 @@ func TestRun(t *testing.T) {
 						expCheck.Status = api.HealthPassing
 					}
 				}
-				expectedProxyCheck.Status = api.HealthCritical
+				expectedProxyCheck.Status = api.HealthPassing
 				assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 			}
 

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -114,16 +114,16 @@ func TestRun(t *testing.T) {
 			},
 			consulLogin: consulLoginCfg,
 		},
-		"two healthy health sync containers": {
-			healthSyncContainers: map[string]healthSyncContainerMetaData{
-				"container-1": {
-					status: ecs.HealthStatusHealthy,
-				},
-				"container-2": {
-					status: ecs.HealthStatusHealthy,
-				},
-			},
-		},
+		//"two healthy health sync containers": {
+		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
+		//		"container-1": {
+		//			status: ecs.HealthStatusHealthy,
+		//		},
+		//		"container-2": {
+		//			status: ecs.HealthStatusHealthy,
+		//		},
+		//	},
+		//},
 		"one healthy and one unhealthy health sync containers": {
 			healthSyncContainers: map[string]healthSyncContainerMetaData{
 				"container-1": {
@@ -148,16 +148,16 @@ func TestRun(t *testing.T) {
 			},
 			consulLogin: consulLoginCfg,
 		},
-		"two unhealthy health sync containers": {
-			healthSyncContainers: map[string]healthSyncContainerMetaData{
-				"container-1": {
-					status: ecs.HealthStatusUnhealthy,
-				},
-				"container-2": {
-					status: ecs.HealthStatusUnhealthy,
-				},
-			},
-		},
+		//"two unhealthy health sync containers": {
+		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
+		//		"container-1": {
+		//			status: ecs.HealthStatusUnhealthy,
+		//		},
+		//		"container-2": {
+		//			status: ecs.HealthStatusUnhealthy,
+		//		},
+		//	},
+		//},
 		"missing dataplane container": {
 			missingDataplaneContainer: true,
 		},
@@ -827,18 +827,7 @@ func constructTaskMetaResponseString(resp *awsutil.ECSTaskMeta) (string, error) 
 func injectContainersIntoTaskMetaResponse(t *testing.T, taskMetadataResponse *awsutil.ECSTaskMeta, missingDataplaneContainer bool, healthSyncContainers map[string]healthSyncContainerMetaData) string {
 	var taskMetaContainersResponse []awsutil.ECSTaskMetaContainer
 	if !missingDataplaneContainer {
-		dataplaneContainerStatus := ecs.HealthStatusHealthy
-		if len(healthSyncContainers) > 1 {
-			log.Printf("Setting dataplane container status: %s \n", config.ConsulDataplaneContainerName)
-			for containerName := range healthSyncContainers {
-				log.Printf("Container Name: %s, ActualStatus:%s \n", containerName, healthSyncContainers[containerName].status)
-				if healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
-					dataplaneContainerStatus = ecs.HealthStatusUnhealthy
-					break
-				}
-			}
-		}
-		taskMetaContainersResponse = append(taskMetaContainersResponse, constructContainerResponse(config.ConsulDataplaneContainerName, dataplaneContainerStatus))
+		taskMetaContainersResponse = append(taskMetaContainersResponse, constructContainerResponse(config.ConsulDataplaneContainerName, ecs.HealthStatusHealthy))
 	}
 
 	for name, hsc := range healthSyncContainers {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -402,7 +402,7 @@ func TestRun(t *testing.T) {
 					}
 				}
 			}
-			expectedProxyCheck.Status = api.HealthCritical
+			expectedProxyCheck.Status = api.HealthPassing
 			if c.missingDataplaneContainer {
 				expectedProxyCheck.Status = api.HealthCritical
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -106,14 +106,14 @@ func TestRun(t *testing.T) {
 		shouldMissingContainersReappear bool
 	}{
 		"no additional health sync containers": {},
-		"one healthy health sync container": {
-			healthSyncContainers: map[string]healthSyncContainerMetaData{
-				"container-1": {
-					status: ecs.HealthStatusHealthy,
-				},
-			},
-			consulLogin: consulLoginCfg,
-		},
+		//"one healthy health sync container": {
+		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
+		//		"container-1": {
+		//			status: ecs.HealthStatusHealthy,
+		//		},
+		//	},
+		//	consulLogin: consulLoginCfg,
+		//},
 		//"two healthy health sync containers": {
 		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
 		//		"container-1": {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -401,7 +401,7 @@ func TestRun(t *testing.T) {
 					if c.missingDataplaneContainer {
 						expCheck.Status = api.HealthCritical
 					} else {
-						expCheck.Status = api.HealthCritical
+						expCheck.Status = api.HealthPassing
 					}
 				}
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -472,8 +472,8 @@ func TestRun(t *testing.T) {
 			//	assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 			//}
 			//
-			//// Send SIGTERM and verify the status of checks
-			//signalSIGTERM(t)
+			// Send SIGTERM and verify the status of checks
+			signalSIGTERM(t)
 			//
 			//for _, expCheck := range expectedSvcChecks {
 			//	expCheck.Status = api.HealthCritical

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -462,14 +462,6 @@ func TestRun(t *testing.T) {
 						checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
 						if expCheck.CheckID == checkID {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
-							if len(c.healthSyncContainers) > 1 {
-								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
-										expCheck.Status = api.HealthCritical
-										break
-									}
-								}
-							}
 							found = true
 							break
 						}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -377,6 +377,16 @@ func TestRun(t *testing.T) {
 							expCheck.Status = api.HealthCritical
 						} else {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
+							// If there are multiple health sync containers and one of them is unhealthy
+							// then the service check should be critical.
+							if len(c.healthSyncContainers) > 1 {
+								for containerName := range c.healthSyncContainers {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
+										expCheck.Status = api.HealthCritical
+										break
+									}
+								}
+							}
 						}
 						found = true
 						break
@@ -442,7 +452,7 @@ func TestRun(t *testing.T) {
 					}
 
 					if !found {
-						expCheck.Status = api.HealthCritical
+						expCheck.Status = api.HealthPassing
 					}
 				}
 				expectedProxyCheck.Status = api.HealthCritical

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -418,7 +418,11 @@ func TestRun(t *testing.T) {
 					}
 				}
 			}
-			expectedProxyCheck.Status = api.HealthPassing
+			if markDataplaneContainerUnhealthy {
+				expectedProxyCheck.Status = api.HealthCritical
+			} else {
+				expectedProxyCheck.Status = api.HealthPassing
+			}
 			log.Printf("ExpectedProxyCheck Name: %s and expCheck :%s \n", expectedProxyCheck.Name, expectedProxyCheck.Status)
 			if c.missingDataplaneContainer {
 				expectedProxyCheck.Status = api.HealthCritical
@@ -884,6 +888,7 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 		checks, _, err := consulClient.Health().Checks(expectedProxyCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expectedProxyCheck.Namespace, Partition: expectedProxyCheck.Partition})
 		require.NoError(r, err)
 		require.Equal(r, 1, len(checks))
+		log.Printf("ProxyCheckName:%s , expProxyCheck:%s , Actual procy Status:%s \n", expectedProxyCheck.Name, expectedProxyCheck.Status, checks[0].Status)
 		require.Equal(r, expectedProxyCheck.Status, checks[0].Status)
 	})
 }

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -385,7 +385,7 @@ func TestRun(t *testing.T) {
 							// then the service check should be critical.
 							if len(c.healthSyncContainers) > 1 {
 								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy && hsc.missing == false {
+									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
 										expCheck.Status = api.HealthCritical
 										break
 									}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -450,15 +450,6 @@ func TestRun(t *testing.T) {
 						checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
 						if expCheck.CheckID == checkID {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
-							if len(c.healthSyncContainers) > 1 {
-								for containerName := range c.healthSyncContainers {
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
-										c.shouldMissingContainersReappear == false {
-										expCheck.Status = api.HealthCritical
-										break
-									}
-								}
-							}
 							found = true
 							break
 						}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -390,16 +390,15 @@ func TestRun(t *testing.T) {
 							expCheck.Status = ecsHealthToConsulHealth(hsc.status)
 							// If there are multiple health sync containers and one of them is unhealthy
 							// then the service check should be critical.
-							if len(c.healthSyncContainers) > 1 {
-								for containerName := range c.healthSyncContainers {
-									log.Printf("Container Name: %s, ActualStatus:%s \n", containerName, c.healthSyncContainers[containerName].status)
-									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
-										expCheck.Status = api.HealthCritical
-										markDataplaneContainerUnhealthy = true
-										break
-									}
+							for containerName := range c.healthSyncContainers {
+								log.Printf("Container Name: %s, ActualStatus:%s \n", containerName, c.healthSyncContainers[containerName].status)
+								if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {
+									expCheck.Status = api.HealthCritical
+									markDataplaneContainerUnhealthy = true
+									break
 								}
 							}
+
 						}
 						found = true
 						break

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -401,7 +401,7 @@ func TestRun(t *testing.T) {
 					if c.missingDataplaneContainer {
 						expCheck.Status = api.HealthCritical
 					} else {
-						expCheck.Status = api.HealthPassing
+						expCheck.Status = api.HealthCritical
 					}
 				}
 			}

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -403,7 +403,7 @@ func TestRun(t *testing.T) {
 						break
 					}
 				}
-
+				log.Printf("dataplane container for expCheck: %s, markDataplaneContainerUnhealthy :%t , found: %t\n", expCheck.CheckID, markDataplaneContainerUnhealthy, found)
 				if !found {
 					log.Printf("BEFORE: Updating dataplane container with Status markDataplaneContainerUnhealthy :%t and expCheck.Status %s\n", markDataplaneContainerUnhealthy, expCheck.Status)
 					if c.missingDataplaneContainer || markDataplaneContainerUnhealthy {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -105,7 +105,7 @@ func TestRun(t *testing.T) {
 		missingDataplaneContainer       bool
 		shouldMissingContainersReappear bool
 	}{
-		"no additional health sync containers": {},
+		//"no additional health sync containers": {},
 		//"one healthy health sync container": {
 		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
 		//		"container-1": {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -390,7 +389,6 @@ func TestRun(t *testing.T) {
 								if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy &&
 									c.healthSyncContainers[containerName].missing == false {
 									expCheck.Status = api.HealthCritical
-									log.Printf("Marking the datplane container unhealthy due to :%s \n", containerName)
 									markDataplaneContainerUnhealthy = true
 									break
 								}
@@ -494,7 +492,6 @@ func TestRun(t *testing.T) {
 				expCheck.Status = api.HealthCritical
 			}
 			expectedProxyCheck.Status = api.HealthCritical
-			log.Printf("Asserting HEalth checks - 2")
 			assertHealthChecks(t, consulClient, expectedSvcChecks, expectedProxyCheck)
 
 			// Stop dataplane container manually because
@@ -839,7 +836,6 @@ func injectContainersIntoTaskMetaResponse(t *testing.T, taskMetadataResponse *aw
 	taskMetadataResponse.Containers = taskMetaContainersResponse
 	taskMetaRespStr, err := constructTaskMetaResponseString(taskMetadataResponse)
 	require.NoError(t, err)
-	log.Printf("TaskMetaResponseStr: %s, \n", taskMetaRespStr)
 
 	return taskMetaRespStr
 }
@@ -861,9 +857,7 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 			filter := fmt.Sprintf("CheckID == `%s`", expCheck.CheckID)
 			checks, _, err := consulClient.Health().Checks(expCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expCheck.Namespace, Partition: expCheck.Partition})
 			require.NoError(r, err)
-
 			for _, check := range checks {
-				log.Printf("checkId:%s , expCheck:%s , Actual Status:%s \n", expCheck.CheckID, expCheck.Status, check.Status)
 				require.Equal(r, expCheck.Status, check.Status)
 			}
 		}
@@ -873,7 +867,6 @@ func assertHealthChecks(t *testing.T, consulClient *api.Client, expectedServiceC
 		checks, _, err := consulClient.Health().Checks(expectedProxyCheck.ServiceName, &api.QueryOptions{Filter: filter, Namespace: expectedProxyCheck.Namespace, Partition: expectedProxyCheck.Partition})
 		require.NoError(r, err)
 		require.Equal(r, 1, len(checks))
-		log.Printf("ProxyCheckName:%s , expProxyCheck:%s , Actual procy Status:%s \n", expectedProxyCheck.Name, expectedProxyCheck.Status, checks[0].Status)
 		require.Equal(r, expectedProxyCheck.Status, checks[0].Status)
 	})
 }

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -206,6 +206,7 @@ func TestRun(t *testing.T) {
 					status:  ecs.HealthStatusUnhealthy,
 				},
 			},
+			expectedDataplaneHealthStatus:   api.HealthPassing,
 			shouldMissingContainersReappear: true,
 			consulLogin:                     consulLoginCfg,
 		},

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -375,12 +375,14 @@ func TestRun(t *testing.T) {
 			// state of health sync containers
 			log.Printf("Expected Svc Checks: %+v\n", expectedSvcChecks)
 			for _, check := range expectedSvcChecks {
-				log.Printf("Check Name: %s, Status: %s\n", check.Name, check.Status)
+				log.Printf("Check Name: %s, Status: %s, ServiceName: %s, CheckId: %s\n", check.Name, check.Status, check.ServiceName, check.CheckID)
 			}
 			for _, expCheck := range expectedSvcChecks {
 				found := false
 				for name, hsc := range c.healthSyncContainers {
+
 					checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
+					log.Printf("Checking for container: %s, hsc %s, CheckId: %s\n", name, hsc, checkID)
 					if expCheck.CheckID == checkID {
 						if hsc.missing {
 							expCheck.Status = api.HealthCritical
@@ -389,7 +391,6 @@ func TestRun(t *testing.T) {
 							// If there are multiple health sync containers and one of them is unhealthy
 							// then the service check should be critical.
 							if len(c.healthSyncContainers) > 1 {
-								log.Printf("Checking for unhealthy containers: %s \n", name)
 								for containerName := range c.healthSyncContainers {
 									log.Printf("Container Name: %s, ActualStatus:%s \n", containerName, c.healthSyncContainers[containerName].status)
 									if c.healthSyncContainers[containerName].status == ecs.HealthStatusUnhealthy {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -382,7 +382,7 @@ func TestRun(t *testing.T) {
 				for name, hsc := range c.healthSyncContainers {
 
 					checkID := constructCheckID(makeServiceID(serviceName, taskID), name)
-					log.Printf("Checking for container: %s, hsc %s, CheckId: %s\n", name, hsc, checkID)
+					log.Printf("Checking for container: %s, hsc %s, CheckId: %s\n", name, hsc.status, checkID)
 					if expCheck.CheckID == checkID {
 						if hsc.missing {
 							expCheck.Status = api.HealthCritical

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -442,7 +442,7 @@ func TestRun(t *testing.T) {
 					}
 
 					if !found {
-						expCheck.Status = api.HealthPassing
+						expCheck.Status = api.HealthCritical
 					}
 				}
 				expectedProxyCheck.Status = api.HealthCritical

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -106,14 +106,14 @@ func TestRun(t *testing.T) {
 		shouldMissingContainersReappear bool
 	}{
 		"no additional health sync containers": {},
-		//"one healthy health sync container": {
-		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
-		//		"container-1": {
-		//			status: ecs.HealthStatusHealthy,
-		//		},
-		//	},
-		//	consulLogin: consulLoginCfg,
-		//},
+		"one healthy health sync container": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+			},
+			consulLogin: consulLoginCfg,
+		},
 		//"two healthy health sync containers": {
 		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
 		//		"container-1": {

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -115,16 +115,16 @@ func TestRun(t *testing.T) {
 			},
 			consulLogin: consulLoginCfg,
 		},
-		//"two healthy health sync containers": {
-		//	healthSyncContainers: map[string]healthSyncContainerMetaData{
-		//		"container-1": {
-		//			status: ecs.HealthStatusHealthy,
-		//		},
-		//		"container-2": {
-		//			status: ecs.HealthStatusHealthy,
-		//		},
-		//	},
-		//},
+		"two healthy health sync containers": {
+			healthSyncContainers: map[string]healthSyncContainerMetaData{
+				"container-1": {
+					status: ecs.HealthStatusHealthy,
+				},
+				"container-2": {
+					status: ecs.HealthStatusHealthy,
+				},
+			},
+		},
 		"one healthy and one unhealthy health sync containers": {
 			healthSyncContainers: map[string]healthSyncContainerMetaData{
 				"container-1": {


### PR DESCRIPTION
When we update the consul-dataplane health status, we should take into account the service health status as well

## Changes proposed in this PR:
- Modified the health sync for `consul-dataplane` to take into account the service health as well during health-sync checks

## How I've tested this PR:
Created an AWS ECS cluster with 2 services `frontend` and `backend`. The port for the backend health was misconfigured so that the service fails. 
**Before the fix:** 
On accessing `curl 0:19000/clusters` from the `frontend` service, we found that the health for `backend` service was showing as healthy. 
![image](https://github.com/user-attachments/assets/70e16eeb-5c63-475d-9312-f0096ff51e23)

**After the fix:**
The `curl 0:19000/clusters` was showing 
![image](https://github.com/user-attachments/assets/9475d151-e720-44e5-9a05-62de0fef485d)

Once the port was fixed, the `backend` service was again showing as healthy using the `curl 0:19000/clusters` endpoint from `frontend`
## How I expect reviewers to test this PR:
👀 
## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
