### PR TITLE
Prevent excessive logging on health checks sync

### DIFF
--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -181,11 +181,6 @@ func (c *Command) syncChecks(consulClient *api.Client,
 	err = c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, config.ConsulDataplaneContainerName, overallDataplaneHealthStatus)
 	if err != nil {
 		c.log.Warn("failed to update Consul health status", "err", err)
-	} else {
-		c.log.Info("container health check updated in Consul",
-			"name", config.ConsulDataplaneContainerName,
-			"status", overallDataplaneHealthStatus,
-		)
 	}
 	return currentStatuses
 }


### PR DESCRIPTION
## Changes proposed in this PR:

`syncChecks` pools the container health check endpoint [every 1 second](https://github.com/hashicorp/consul-ecs/blob/46744afa702765bd4beffb18a4ef79ff62712c8c/subcommand/health-sync/command.go#L32).

In version 0.9.0 it started to log every successful check:

```log
2025-02-12T21:59:19.795Z [INFO] container health check updated in Consul: name=consul-dataplane status=HEALTHY
2025-02-12T21:59:18.767Z [INFO] container health check updated in Consul: name=consul-dataplane status=HEALTHY
2025-02-12T21:59:17.760Z [INFO] container health check updated in Consul: name=consul-dataplane status=HEALTHY
...
```

This floods our log groups with redundant logs.

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
