### PR TITLE
fix: add shuttingDown flag to prevent syncChecks after SIGTERM 

### DIFF
--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -714,9 +714,13 @@ func TestRunGateways(t *testing.T) {
 			assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
 
 			if !c.missingDataplaneContainer {
-				// wait X seconds and assert if the status is still critical
-				time.Sleep(5 * time.Second)
-				assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
+				// Assert that the proxy check remains in the expected state for the full 5 seconds
+				end := time.Now().Add(5 * time.Second)
+				for time.Now().Before(end) {
+					// This will retry for up to 5 seconds, but we want to fail immediately if the status changes
+					assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
+					time.Sleep(100 * time.Millisecond)
+				}
 			}
 
 			// Stop dataplane container manually because

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -713,6 +713,13 @@ func TestRunGateways(t *testing.T) {
 
 			assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
 
+			if !c.missingDataplaneContainer {
+                // wait X seconds and assert if the status is still critical
+                time.Sleep(5 * time.Second)
+
+                assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
+            }
+
 			// Stop dataplane container manually because
 			// health-sync waits for it before deregistering
 			// the service and the proxy.

--- a/subcommand/health-sync/command_test.go
+++ b/subcommand/health-sync/command_test.go
@@ -714,11 +714,10 @@ func TestRunGateways(t *testing.T) {
 			assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
 
 			if !c.missingDataplaneContainer {
-                // wait X seconds and assert if the status is still critical
-                time.Sleep(5 * time.Second)
-
-                assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
-            }
+				// wait X seconds and assert if the status is still critical
+				time.Sleep(5 * time.Second)
+				assertHealthChecks(t, consulClient, nil, expectedProxyCheck)
+			}
 
 			// Stop dataplane container manually because
 			// health-sync waits for it before deregistering


### PR DESCRIPTION
The original changes are taken from the [PR](https://github.com/hashicorp/consul-ecs/pull/285) . Since some of the checks require secrets which are not accessible for PRs from external contributors, raising another PR

---------------------------------------------------------------------------

## Changes proposed in this PR:
- Introduces a `shuttingDown` boolean flag within the `realRun` method of the `healthsync` command. This flag is initialized to `false`.
- When a `SIGTERM` signal is received, the `shuttingDown` flag is set to `true` before `setChecksCritical` is called.
- The main reconciliation loop's `select` case for `time.After(syncChecksInterval)` (which triggers `c.syncChecks`) is now conditional:
    - It will only execute `c.syncChecks` if the `shuttingDown` flag is `false`.
    - This prevents `syncChecks` from running and potentially overriding the "critical" status after a `SIGTERM` has been processed.

## How I've tested this PR:
This change is a direct logical fix for the race condition described in issue #284 . The `shuttingDown` flag explicitly prevents the `syncChecks` routine from executing after `SIGTERM` handling has begun.
Also modified the `TestRunGateways` test to validate the changes; without the patch, it is noticeable that the container health status becomes healthy again after X seconds post-setting the critical state.

Manual verification steps would involve:
1. Setting up the environment as described in the "Reproduction Steps" of the issue.
2. Triggering a new deployment of the upstream service.
3. Monitoring `health-sync` debug logs.
4. Confirming that after the `SIGTERM` is received and logs like `[INFO] set Consul health status to critical: container=consul-dataplane` appear, no further `[DEBUG] updating Consul check from ECS container health: name=consul-dataplane status=HEALTHY...` logs for the `consul-dataplane` are emitted. The status should remain critical.

## How I expect reviewers to test this PR:
Reviewers should:
1.  Carefully review the logic of the `shuttingDown` flag and its placement within the `select` statement in `realRun`.
2.  Execute the "Reproduction Steps" from the original issue description.
3.  Verify that after a `SIGTERM` is received by a task, the `consul-dataplane` health check in Consul is set to `critical` by `health-sync` and *remains* `critical` until the task fully terminates.
4.  Specifically, check the `health-sync` logs to ensure that once the `setChecksCritical` function has run for the `consul-dataplane`, subsequent calls to `syncChecks` (identified by "updating Consul check from ECS container health" log lines) do not occur for the `consul-dataplane` or do not change its status away from critical.
5.  Confirm that the service instance stops receiving new requests promptly after the `SIGTERM` and the checks are marked critical.

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added
