### PR TITLE
Removing 1.22.x version for 0.9.4 release(not required)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,6 @@ jobs:
         consul-version:
           - 1.21.5
           - 1.21.9+ent
-          - 1.22.3
-          - 1.22.3+ent
     env:
       TEST_RESULTS_DIR: /tmp/test-results
       GOTESTSUM_VERSION: 1.8.2


### PR DESCRIPTION
## Changes proposed in this PR:
- Removing 1.22.x version for 0.9.4 release(not required)
