### PR TITLE
Updating dockerfile to use latest go-discover version and suppressing the alpine CVE's

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -18,9 +18,15 @@ container {
       // known CVEs, they are patched at the OS level through apk upgrade.
       // This suppression targets the Alpine package database to avoid false
       // positives from the scanner.
-      paths = [
-        "/lib/apk/db/*",
-        "/etc/apk/*",
+      vulnerabilities = [
+        "CVE-2025-30258",
+        "CVE-2025-14017",
+        "CVE-2026-1965",
+        "CVE-2026-3783",
+        "CVE-2026-3784",
+        "CVE-2026-3805",
+        "CVE-2025-14819",
+        "CVE-2025-14524",
       ]
     }
   }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,9 @@
 
 # go-discover builds the discover binary
 FROM golang:1.25.8-alpine as go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@latest
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@f3e097417ebe7089c1999fd32983e0d0b1a3e220
 
 FROM docker.mirror.hashicorp.services/alpine:3.23 AS release-default
-RUN apk update && apk upgrade --no-cache
 
 ARG BIN_NAME=consul-ecs
 ARG PRODUCT_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@
 
 # go-discover builds the discover binary
 FROM golang:1.25.8-alpine as go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@f2efba8b24cb9a442238b106b6d7b526c0ca1ff6
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@latest
 
 FROM docker.mirror.hashicorp.services/alpine:3.23 AS release-default
-RUN apk upgrade --no-cache
+RUN apk update && apk upgrade --no-cache
 
 ARG BIN_NAME=consul-ecs
 ARG PRODUCT_VERSION


### PR DESCRIPTION
## Changes proposed in this PR:
- Resolving the go discover CVE's by using latest go-discover version.
- Suppressing the alpine CVE's as no fix is available for them. 

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
