### PR TITLE
ci: add Go test coverage reporting

### DIFF
--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -10,9 +10,6 @@ name: reusable-coverage-report
 on:
   workflow_call:
     inputs:
-      go-version:
-        required: true
-        type: string
       pr-number:
         required: false
         type: string
@@ -29,7 +26,9 @@ jobs:
 
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: ${{ inputs.go-version }}
+          # Use go-version-file to install the version declared in go.mod (go 1.26),
+          # avoiding a toolchain mismatch when .go-version and go.mod differ.
+          go-version-file: go.mod
 
       - name: Download coverage profiles
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -1,0 +1,203 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Reusable workflow: merges per-module coverage profiles, computes the total,
+# posts/edits a PR comment, uploads an HTML artifact, uploads to Codecov, and
+# (on main) pushes a coverage badge SVG to the `badges` branch for the README.
+
+name: reusable-coverage-report
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+      pr-number:
+        required: false
+        type: string
+
+jobs:
+  report:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # required for OIDC tokenless Codecov upload
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Download coverage profiles
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: '*-coverage'
+          path: coverage-artifacts
+
+      - name: Compute coverage
+        id: coverage
+        run: |
+          PROFILES=$(find coverage-artifacts -name 'coverage.txt' 2>/dev/null | sort)
+          COUNT=$(echo "$PROFILES" | grep -c . || true)
+          echo "Found $COUNT coverage profile(s)"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No coverage profiles found"
+            echo "total=N/A" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$COUNT" -eq 1 ]; then
+            cp "$(echo "$PROFILES")" merged-coverage.out
+          else
+            go install github.com/wadey/gocovmerge@b5bfa59ec0ad
+            echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
+          fi
+
+          # Exclude mocks, hack, and test-helper paths.
+          TOTAL=$(awk '
+            /^mode:/ { next }
+            /\/mocks\/|\/mock_|\/hack\/|\/testutil\// { next }
+            { stmts += $2; if ($3 > 0) covered += $2 }
+            END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
+          ' merged-coverage.out)
+          echo "Total coverage: $TOTAL"
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+
+          # Strip excluded lines from profile before generating HTML and per-package summary.
+          grep -v -e '/mocks/' -e '/mock_' -e '/hack/' -e '/testutil/' merged-coverage.out > filtered-coverage.out || true
+          mv filtered-coverage.out merged-coverage.out
+
+          # Package-level summary.
+          go tool cover -func merged-coverage.out | grep -v '^total:' | \
+            awk '{
+              sub(/^github\.com\/hashicorp\/consul-ecs\//, "", $1)
+              split($1, parts, "/")
+              pkg = parts[1]
+              gsub(/:.*/, "", pkg)
+              pct = $NF; gsub(/%/, "", pct)
+              sum[pkg] += pct; n[pkg]++
+            }
+            END {
+              for (pkg in sum) printf "%-40s %.1f%%\n", pkg, sum[pkg]/n[pkg]
+            }' | sort > pkg-summary.txt
+
+          {
+            echo "## Go Test Coverage"
+            echo ""
+            echo "**Total coverage: $TOTAL**"
+            echo ""
+            echo "| Package | Avg Coverage |"
+            echo "|---------|-------------|"
+            while IFS= read -r line; do
+              pkg=$(echo "$line" | awk '{print $1}')
+              pct=$(echo "$line" | awk '{print $2}')
+              echo "| \`$pkg\` | $pct |"
+            done < pkg-summary.txt
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          go tool cover -html=merged-coverage.out -o coverage.html
+
+      - name: Post PR comment
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ steps.coverage.outputs.total }}
+        run: |
+          MARKER="<!-- coverage-report-comment -->"
+          BODY=$(cat <<EOF
+          ${MARKER}
+
+          ### Go Test Coverage: **${TOTAL}**
+
+          See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report.
+          EOF
+          )
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- coverage-report-comment -->"))) | .id' \
+            | tail -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -f body="$BODY"
+          else
+            gh pr comment ${{ inputs.pr-number }} \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          fi
+
+      - name: Upload HTML coverage report
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: coverage-report-html
+          path: |
+            merged-coverage.out
+            coverage.html
+
+      - name: Upload to Codecov
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          files: merged-coverage.out
+          use_oidc: true
+          fail_ci_if_error: false
+          verbose: false
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'
+        env:
+          TOTAL: ${{ steps.coverage.outputs.total }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PCT="${TOTAL%%%}"
+          if (( $(echo "$PCT >= 80" | bc -l) )); then COLOR="brightgreen"
+          elif (( $(echo "$PCT >= 60" | bc -l) )); then COLOR="yellow"
+          else COLOR="red"
+          fi
+
+          cat > coverage.svg <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="120" height="20">
+            <linearGradient id="s" x2="0" y2="100%">
+              <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+              <stop offset="1" stop-opacity=".1"/>
+            </linearGradient>
+            <rect rx="3" width="120" height="20" fill="#555"/>
+            <rect rx="3" x="62" width="58" height="20" fill="${COLOR}"/>
+            <rect x="62" width="4" height="20" fill="${COLOR}"/>
+            <rect rx="3" width="120" height="20" fill="url(#s)"/>
+            <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+              <text x="32" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+              <text x="32" y="14">coverage</text>
+              <text x="90" y="15" fill="#010101" fill-opacity=".3">${TOTAL}</text>
+              <text x="90" y="14">${TOTAL}</text>
+            </g>
+          </svg>
+          SVGEOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin badges 2>/dev/null || true
+          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
+            git checkout -B badges origin/badges
+          else
+            git checkout --orphan badges
+            git rm -rf . --quiet || true
+          fi
+
+          mv coverage.svg coverage.svg.tmp
+          git rm -rf . --quiet || true
+          mv coverage.svg.tmp coverage.svg
+
+          git add coverage.svg
+          git commit -m "ci: update coverage badge to ${TOTAL}" || echo "No changes to badge"
+          git push origin badges

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -56,10 +56,11 @@ jobs:
             echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
           fi
 
-          # Exclude mocks, hack, and test-helper paths.
+          # Exclude mocks, hack, test-helper, and version-only paths.
+          # Must match the ignore list in codecov.yml.
           TOTAL=$(awk '
             /^mode:/ { next }
-            /\/mocks\/|\/mock_|\/hack\/|\/testutil\// { next }
+            /\/mocks\/|\/mock_|\/hack\/|\/testutil\/|\/version\// { next }
             { stmts += $2; if ($3 > 0) covered += $2 }
             END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
           ' merged-coverage.out)
@@ -67,7 +68,7 @@ jobs:
           echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
 
           # Strip excluded lines from profile before generating HTML and per-package summary.
-          grep -v -e '/mocks/' -e '/mock_' -e '/hack/' -e '/testutil/' merged-coverage.out > filtered-coverage.out || true
+          grep -v -e '/mocks/' -e '/mock_' -e '/hack/' -e '/testutil/' -e '/version/' merged-coverage.out > filtered-coverage.out || true
           mv filtered-coverage.out merged-coverage.out
 
           # Package-level summary.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,10 @@ concurrency:
 
 env:
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
-  # Latest CE version used in the test matrix — also used by unit-tests-coverage.
+  # CE version used in the test matrix — also used by unit-tests-coverage.
+  # Must match the first CE entry in the matrix below (consul-version list).
   # ENT variants need CONSUL_LICENSE and cannot be used in the coverage job.
-  CONSUL_CE_VERSION: "1.22.3"
+  CONSUL_CE_VERSION: "1.22.7"
 
 jobs:
   get-go-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,18 +66,6 @@ jobs:
     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
-    - name: Activate required Go toolchain
-      # setup-go adds go1.25.8 to PATH but a transitive dep (consul/api v1.34.3)
-      # requires go1.26. GOTOOLCHAIN=auto downloads go1.26.0 during setup-go's
-      # module-cache phase but does NOT update the shell PATH. Running `go env GOROOT`
-      # here re-triggers the toolchain switch; we then export the resulting GOROOT/PATH
-      # so every subsequent step starts with go1.26.0 directly, preventing
-      # "compile: version go1.26.0 does not match go tool version go1.25.8" errors.
-      # TODO: remove once .go-version is upgraded to 1.26 in a separate PR.
-      run: |
-        GOROOT=$(go env GOROOT)
-        echo "$GOROOT/bin" >> "$GITHUB_PATH"
-        echo "GOROOT=$GOROOT" >> "$GITHUB_ENV"
     - name: Install Consul
       shell: bash
       run: |
@@ -124,19 +112,9 @@ jobs:
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
-        go-version: ${{ needs.get-go-version.outputs.go-version }}
-    - name: Activate required Go toolchain
-      # setup-go adds go1.25.8 to PATH but a transitive dep (consul/api v1.34.3)
-      # requires go1.26. GOTOOLCHAIN=auto downloads go1.26.0 during setup-go's
-      # module-cache phase but does NOT update the shell PATH. Running `go env GOROOT`
-      # here re-triggers the toolchain switch; we then export the resulting GOROOT/PATH
-      # so every subsequent step starts with go1.26.0 directly, preventing
-      # "compile: version go1.26.0 does not match go tool version go1.25.8" errors.
-      # TODO: remove once .go-version is upgraded to 1.26 in a separate PR.
-      run: |
-        GOROOT=$(go env GOROOT)
-        echo "$GOROOT/bin" >> "$GITHUB_PATH"
-        echo "GOROOT=$GOROOT" >> "$GITHUB_ENV"
+        # Use go-version-file to install the version declared in go.mod (go 1.26),
+        # avoiding a toolchain mismatch when .go-version and go.mod differ.
+        go-version-file: go.mod
     - name: Install Consul
       shell: bash
       run: |
@@ -167,7 +145,6 @@ jobs:
       pull-requests: write
       id-token: write
     with:
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
       pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
 
   # This is job is required for branch protection as a required GitHub check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ concurrency:
 
 env:
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
+  # Latest CE version used in the test matrix — also used by unit-tests-coverage.
+  # ENT variants need CONSUL_LICENSE and cannot be used in the coverage job.
+  CONSUL_CE_VERSION: "1.22.3"
 
 jobs:
   get-go-version:
@@ -63,6 +66,18 @@ jobs:
     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
+    - name: Activate required Go toolchain
+      # setup-go adds go1.25.8 to PATH but a transitive dep (consul/api v1.34.3)
+      # requires go1.26. GOTOOLCHAIN=auto downloads go1.26.0 during setup-go's
+      # module-cache phase but does NOT update the shell PATH. Running `go env GOROOT`
+      # here re-triggers the toolchain switch; we then export the resulting GOROOT/PATH
+      # so every subsequent step starts with go1.26.0 directly, preventing
+      # "compile: version go1.26.0 does not match go tool version go1.25.8" errors.
+      # TODO: remove once .go-version is upgraded to 1.26 in a separate PR.
+      run: |
+        GOROOT=$(go env GOROOT)
+        echo "$GOROOT/bin" >> "$GITHUB_PATH"
+        echo "GOROOT=$GOROOT" >> "$GITHUB_ENV"
     - name: Install Consul
       shell: bash
       run: |
@@ -99,6 +114,62 @@ jobs:
         name: ${{ matrix.consul-version }}-test-results
         path: ${{ env.TEST_RESULTS_DIR }}/${{ matrix.consul-version }}
 
+  unit-tests-coverage:
+    needs:
+      - get-go-version
+    name: unit-tests-coverage
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      with:
+        go-version: ${{ needs.get-go-version.outputs.go-version }}
+    - name: Activate required Go toolchain
+      # setup-go adds go1.25.8 to PATH but a transitive dep (consul/api v1.34.3)
+      # requires go1.26. GOTOOLCHAIN=auto downloads go1.26.0 during setup-go's
+      # module-cache phase but does NOT update the shell PATH. Running `go env GOROOT`
+      # here re-triggers the toolchain switch; we then export the resulting GOROOT/PATH
+      # so every subsequent step starts with go1.26.0 directly, preventing
+      # "compile: version go1.26.0 does not match go tool version go1.25.8" errors.
+      # TODO: remove once .go-version is upgraded to 1.26 in a separate PR.
+      run: |
+        GOROOT=$(go env GOROOT)
+        echo "$GOROOT/bin" >> "$GITHUB_PATH"
+        echo "GOROOT=$GOROOT" >> "$GITHUB_ENV"
+    - name: Install Consul
+      shell: bash
+      run: |
+        CONSUL_VERSION="${{ env.CONSUL_CE_VERSION }}"
+        curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
+        unzip -o "consul_${CONSUL_VERSION}_linux_amd64.zip" consul -d /usr/local/bin
+        rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
+        consul version
+    - name: Run unit tests with coverage
+      run: |
+        PACKAGE_NAMES=$(go list ./... | grep -v 'mocks\|hack\|testing' | tr '\n' ' ')
+        go test -p 1 -coverprofile=coverage.txt -covermode=set $PACKAGE_NAMES
+    - name: Upload coverage profile
+      if: always()
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: ecs-coverage
+        path: coverage.txt
+        if-no-files-found: ignore
+
+  coverage-report:
+    needs:
+      - get-go-version
+      - unit-tests-coverage
+    uses: ./.github/workflows/reusable-coverage-report.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
+
   # This is job is required for branch protection as a required GitHub check
   # because GitHub actions show up as checks at the job level and not the
   # workflow level.  This is currently a feature request:
@@ -115,6 +186,8 @@ jobs:
     needs:
       - lint
       - test
+      - unit-tests-coverage
+      - coverage-report
     runs-on: ubuntu-22.04
     if: always()
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,9 @@ concurrency:
 
 env:
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
-  # CE version used in the test matrix — also used by unit-tests-coverage.
-  # Must match the first CE entry in the matrix below (consul-version list).
+  # Latest CE version, also present in the test matrix below — used by unit-tests-coverage.
   # ENT variants need CONSUL_LICENSE and cannot be used in the coverage job.
-  CONSUL_CE_VERSION: "1.22.7"
+  CONSUL_CE_VERSION: "2.0.0"
 
 jobs:
   get-go-version:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Codecov configuration for consul-ecs.
+# https://docs.codecov.com/docs/codecovyml-reference
+#
+# Note on displayed percentages:
+#   "project" = overall coverage across all files (matches the PR comment %)
+#   "patch"   = coverage of only the lines changed in this PR — a CI-only PR
+#               will show 0% patch coverage since it adds no new Go code.
+# Both are informational-only and will never block merges.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# Must match the exclusions in reusable-coverage-report.yml's awk/grep filters.
+ignore:
+  - "**/*_test.go"
+  - "**/mocks/**"
+  - "**/mock_*"
+  - "**/hack/**"
+  - "**/testutil/**"
+  - "version/**"


### PR DESCRIPTION
## Summary

Adds Go test coverage reporting to consul-ecs, modeled after the same feature in [consul-dataplane #1083](https://github.com/hashicorp/consul-dataplane/pull/1083).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/test.yml` | Modified — adds `unit-tests-coverage` job + `coverage-report` job; updates `test-success` fan-in |
| `.github/workflows/reusable-coverage-report.yml` | New — merges profiles, posts sticky PR comment, uploads HTML artifact, uploads to Codecov, pushes SVG badge to `badges` branch on main |
| `codecov.yml` | New — informational-only Codecov config (never blocks PRs) |
| `README.md` | Modified — adds coverage badge |

## How it works

1. New `unit-tests-coverage` job runs `go test -coverprofile` against CE consul `1.22.3` (same package exclusions as the existing test job: `mocks|hack|testing`)
2. New `coverage-report` job downloads the artifact, computes total %, posts a sticky comment on the PR, uploads HTML report, and uploads to Codecov
3. On merges to `main`, an SVG badge is pushed to the `badges` branch which the README badge points to

## Notes

- The existing matrix test jobs (CE + ENT, 4 variants) are **unchanged**
- Coverage is run once against CE only — ENT tests need `CONSUL_LICENSE` and would fail without it in the coverage job
- Coverage checks are informational-only and will never block merges
- PR comment is fork-safe (guarded against read-only token on fork PRs)
- `unzip -o consul` extracts only the binary, avoiding interactive prompts from LICENSE.txt in newer consul zips