### PR TITLE
mesh-init: add consul-dataplane and consul-ecs binaries version into ServiceMeta during service registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+IMPROVEMENTS
+* mesh-init: Add `ecs-service-version` and `dataplane-version` to Consul `ServiceMeta` during service registration. Populating `dataplane-version` requires the `ecs:DescribeTasks` permission on the task role. [[GH-353](https://github.com/hashicorp/consul-ecs/pull/353)]
+
+
 ## 0.10.0 (July 9, 2026)
 SECURITY
 * Upgrade `golang.org/x/crypto`, `golang.org/x/net`, and `golang.org/x/sys` to address CVEs in transitive dependencies. [[GH-345](https://github.com/hashicorp/consul-ecs/pull/345)]

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -41,15 +41,13 @@ type ECSTaskMeta struct {
 	Cluster          string                 `json:"Cluster"`
 	TaskARN          string                 `json:"TaskARN"`
 	Family           string                 `json:"Family"`
-	Revision         string                 `json:"Revision"`
 	Containers       []ECSTaskMetaContainer `json:"Containers"`
 	AvailabilityZone string                 `json:"AvailabilityZone"`
 }
 
-// ECSTaskDefinitionAPI is the subset of the ECS API used to read a task
-// definition. It is satisfied by *ecs.Client.
-type ECSTaskDefinitionAPI interface {
-	DescribeTaskDefinition(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error)
+// ECSTaskAPI is the subset of the ECS API needed by mesh-init.
+type ECSTaskAPI interface {
+	DescribeTasks(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error)
 }
 
 type ECSTaskMetaContainer struct {
@@ -74,16 +72,6 @@ type ECSTaskMetaNetwork struct {
 
 func (e ECSTaskMeta) TaskID() string {
 	return ParseTaskID(e.TaskARN)
-}
-
-// TaskDefinitionID returns the task definition identifier ("family:revision")
-// for use with the ECS DescribeTaskDefinition API. It falls back to just the
-// family when the revision is unavailable.
-func (e ECSTaskMeta) TaskDefinitionID() string {
-	if e.Revision != "" {
-		return fmt.Sprintf("%s:%s", e.Family, e.Revision)
-	}
-	return e.Family
 }
 
 // ImageVersion returns a version identifier derived from a container image
@@ -115,27 +103,23 @@ func ImageVersion(image string) string {
 	return image
 }
 
-// ContainerImage returns the image reference declared for the named container
-// in the given task definition (accepts "family", "family:revision", or a full
-// task definition ARN).
-// It reads from the task definition rather than the task
-// metadata endpoint because the task definition always contains the complete,
-// static container list, regardless of container startup ordering at runtime
-// (the metadata endpoint can omit containers that have not started yet).
-// It returns "" (with no error) when the container is not present.
-func ContainerImage(ctx context.Context, client ECSTaskDefinitionAPI, taskDefinition, containerName string) (string, error) {
-	out, err := client.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
-		TaskDefinition: aws.String(taskDefinition),
+// ContainerImage returns the image reference for the named container from
+// ECS DescribeTasks runtime state. It returns "" (with no error) when the
+// container is not present in the task response.
+func ContainerImage(ctx context.Context, client ECSTaskAPI, cluster, taskARN, containerName string) (string, error) {
+	out, err := client.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+		Cluster: aws.String(cluster),
+		Tasks:   []string{taskARN},
 	})
 	if err != nil {
-		return "", fmt.Errorf("describing task definition %q: %w", taskDefinition, err)
+		return "", fmt.Errorf("describing task %q: %w", taskARN, err)
 	}
-	if out == nil || out.TaskDefinition == nil {
-		return "", fmt.Errorf("task definition %q not found", taskDefinition)
+	if out == nil || len(out.Tasks) == 0 {
+		return "", fmt.Errorf("task %q not found", taskARN)
 	}
-	for _, cd := range out.TaskDefinition.ContainerDefinitions {
-		if aws.ToString(cd.Name) == containerName {
-			return aws.ToString(cd.Image), nil
+	for _, container := range out.Tasks[0].Containers {
+		if aws.ToString(container.Name) == containerName {
+			return aws.ToString(container.Image), nil
 		}
 	}
 	return "", nil

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -40,13 +41,19 @@ type ECSTaskMeta struct {
 	Cluster          string                 `json:"Cluster"`
 	TaskARN          string                 `json:"TaskARN"`
 	Family           string                 `json:"Family"`
+	Revision         string                 `json:"Revision"`
 	Containers       []ECSTaskMetaContainer `json:"Containers"`
 	AvailabilityZone string                 `json:"AvailabilityZone"`
 }
 
+// ECSTaskDefinitionAPI is the subset of the ECS API used to read a task
+// definition. It is satisfied by *ecs.Client.
+type ECSTaskDefinitionAPI interface {
+	DescribeTaskDefinition(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error)
+}
+
 type ECSTaskMetaContainer struct {
 	Name          string               `json:"Name"`
-	Image         string               `json:"Image"`
 	Health        ECSTaskMetaHealth    `json:"Health"`
 	DesiredStatus string               `json:"DesiredStatus"`
 	KnownStatus   string               `json:"KnownStatus"`
@@ -69,16 +76,25 @@ func (e ECSTaskMeta) TaskID() string {
 	return ParseTaskID(e.TaskARN)
 }
 
-// ImageVersion returns a version identifier derived from the
-// container's image reference. It prefers the image tag (e.g. "1.3.0").
-// When the image has no tag (it is pinned only by digest, or references a bare
-// repository), it returns the raw image reference unchanged, so the value is
-// still meaningful and can be used to pull the exact image.
-// It returns "" only when no image reference is available.
-func (c ECSTaskMetaContainer) ImageVersion() string {
-	imageRef := c.Image      // full reference, e.g. "localhost:5000/repo:1.3.0@sha256:..."
-	imageWithTag := imageRef // reference reduced to its final "repo:tag" segment
-	tag := ""                // the tag portion, if the image has one
+// TaskDefinitionID returns the task definition identifier ("family:revision")
+// for use with the ECS DescribeTaskDefinition API. It falls back to just the
+// family when the revision is unavailable.
+func (e ECSTaskMeta) TaskDefinitionID() string {
+	if e.Revision != "" {
+		return fmt.Sprintf("%s:%s", e.Family, e.Revision)
+	}
+	return e.Family
+}
+
+// ImageVersion returns a version identifier derived from a container image
+// reference. It prefers the image tag (e.g. "1.3.0"). When the image has no tag
+// (it is pinned only by digest, or references a bare repository), it returns
+// the raw image reference unchanged, so the value is still meaningful and can
+// be used to pull the exact image.
+// It returns "" only when image is empty.
+func ImageVersion(image string) string {
+	imageWithTag := image // reference reduced to its final "repo:tag" segment
+	tag := ""             // the tag portion, if the image has one
 
 	// Drop any digest ("@sha256:...") so it isn't mistaken for a tag.
 	if idx := strings.Index(imageWithTag, "@"); idx != -1 {
@@ -96,7 +112,33 @@ func (c ECSTaskMetaContainer) ImageVersion() string {
 		return tag
 	}
 	// No tag: return the raw reference (bare repo or digest-pinned) as-is.
-	return imageRef
+	return image
+}
+
+// ContainerImage returns the image reference declared for the named container
+// in the given task definition (accepts "family", "family:revision", or a full
+// task definition ARN).
+// It reads from the task definition rather than the task
+// metadata endpoint because the task definition always contains the complete,
+// static container list, regardless of container startup ordering at runtime
+// (the metadata endpoint can omit containers that have not started yet).
+// It returns "" (with no error) when the container is not present.
+func ContainerImage(ctx context.Context, client ECSTaskDefinitionAPI, taskDefinition, containerName string) (string, error) {
+	out, err := client.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(taskDefinition),
+	})
+	if err != nil {
+		return "", fmt.Errorf("describing task definition %q: %w", taskDefinition, err)
+	}
+	if out == nil || out.TaskDefinition == nil {
+		return "", fmt.Errorf("task definition %q not found", taskDefinition)
+	}
+	for _, cd := range out.TaskDefinition.ContainerDefinitions {
+		if aws.ToString(cd.Name) == containerName {
+			return aws.ToString(cd.Image), nil
+		}
+	}
+	return "", nil
 }
 
 func (e ECSTaskMeta) ClusterARN() (string, error) {

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -112,7 +112,7 @@ func ContainerImage(ctx context.Context, client ECSTaskAPI, cluster, taskARN, co
 		Tasks:   []string{taskARN},
 	})
 	if err != nil {
-		return "", fmt.Errorf("describing task %q: %w", taskARN, err)
+		return "", fmt.Errorf("describing ECS task %q: %w", taskARN, err)
 	}
 	if out == nil || len(out.Tasks) == 0 {
 		return "", fmt.Errorf("task %q not found", taskARN)

--- a/awsutil/awsutil.go
+++ b/awsutil/awsutil.go
@@ -46,6 +46,7 @@ type ECSTaskMeta struct {
 
 type ECSTaskMetaContainer struct {
 	Name          string               `json:"Name"`
+	Image         string               `json:"Image"`
 	Health        ECSTaskMetaHealth    `json:"Health"`
 	DesiredStatus string               `json:"DesiredStatus"`
 	KnownStatus   string               `json:"KnownStatus"`
@@ -66,6 +67,36 @@ type ECSTaskMetaNetwork struct {
 
 func (e ECSTaskMeta) TaskID() string {
 	return ParseTaskID(e.TaskARN)
+}
+
+// ImageVersion returns a version identifier derived from the
+// container's image reference. It prefers the image tag (e.g. "1.3.0").
+// When the image has no tag (it is pinned only by digest, or references a bare
+// repository), it returns the raw image reference unchanged, so the value is
+// still meaningful and can be used to pull the exact image.
+// It returns "" only when no image reference is available.
+func (c ECSTaskMetaContainer) ImageVersion() string {
+	imageRef := c.Image      // full reference, e.g. "localhost:5000/repo:1.3.0@sha256:..."
+	imageWithTag := imageRef // reference reduced to its final "repo:tag" segment
+	tag := ""                // the tag portion, if the image has one
+
+	// Drop any digest ("@sha256:...") so it isn't mistaken for a tag.
+	if idx := strings.Index(imageWithTag, "@"); idx != -1 {
+		imageWithTag = imageWithTag[:idx]
+	}
+	// Reduce to the final path segment so a registry "host:port" isn't mistaken for a tag.
+	if idx := strings.LastIndex(imageWithTag, "/"); idx != -1 {
+		imageWithTag = imageWithTag[idx+1:]
+	}
+	if idx := strings.Index(imageWithTag, ":"); idx != -1 {
+		tag = imageWithTag[idx+1:]
+	}
+
+	if tag != "" {
+		return tag
+	}
+	// No tag: return the raw reference (bare repo or digest-pinned) as-is.
+	return imageRef
 }
 
 func (e ECSTaskMeta) ClusterARN() (string, error) {

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -93,6 +93,31 @@ func TestECSTaskMeta(t *testing.T) {
 	require.Equal(t, "arn:aws:ecs:us-east-1:123456789:cluster/test", clusterArn)
 }
 
+func TestECSTaskMetaContainerImageVersion(t *testing.T) {
+	cases := map[string]struct {
+		image    string
+		expected string
+	}{
+		"tagged image":                  {"hashicorp/consul-dataplane:1.3.0", "1.3.0"},
+		"registry path with tag":        {"public.ecr.aws/hashicorp/consul-dataplane:1.3.0", "1.3.0"},
+		"latest tag":                    {"consul-dataplane:latest", "latest"},
+		"registry with port and tag":    {"localhost:5000/consul-dataplane:1.3.0", "1.3.0"},
+		"tag and digest":                {"hashicorp/consul-dataplane:1.3.0@sha256:9b2cabcdef0123456789", "1.3.0"},
+		"no tag":                        {"consul-dataplane", "consul-dataplane"},
+		"registry path no tag":          {"public.ecr.aws/hashicorp/consul-dataplane", "public.ecr.aws/hashicorp/consul-dataplane"},
+		"registry with port and no tag": {"localhost:5000/consul-dataplane", "localhost:5000/consul-dataplane"},
+		"digest only":                   {"public.ecr.aws/hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789", "public.ecr.aws/hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789"},
+		"empty image":                   {"", ""},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			container := ECSTaskMetaContainer{Image: c.image}
+			require.Equal(t, c.expected, container.ImageVersion())
+		})
+	}
+}
+
 func TestHasContainerStopped(t *testing.T) {
 	taskMeta := ECSTaskMeta{
 		Containers: []ECSTaskMetaContainer{

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -93,7 +93,7 @@ func TestECSTaskMeta(t *testing.T) {
 	require.Equal(t, "arn:aws:ecs:us-east-1:123456789:cluster/test", clusterArn)
 }
 
-func TestECSTaskMetaContainerImageVersion(t *testing.T) {
+func TestImageVersion(t *testing.T) {
 	cases := map[string]struct {
 		image    string
 		expected string
@@ -112,8 +112,7 @@ func TestECSTaskMetaContainerImageVersion(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			container := ECSTaskMetaContainer{Image: c.image}
-			require.Equal(t, c.expected, container.ImageVersion())
+			require.Equal(t, c.expected, ImageVersion(c.image))
 		})
 	}
 }

--- a/awsutil/awsutil_test.go
+++ b/awsutil/awsutil_test.go
@@ -4,9 +4,12 @@
 package awsutil
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/stretchr/testify/require"
 )
@@ -113,6 +116,117 @@ func TestImageVersion(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			require.Equal(t, c.expected, ImageVersion(c.image))
+		})
+	}
+}
+
+// fakeECSTaskAPI is a test double for ECSTaskAPI that returns a fixed
+// DescribeTasks output/error and records the input it was called with.
+type fakeECSTaskAPI struct {
+	out *ecs.DescribeTasksOutput
+	err error
+
+	// gotInput records the input from the most recent DescribeTasks call.
+	gotInput *ecs.DescribeTasksInput
+}
+
+func (f *fakeECSTaskAPI) DescribeTasks(_ context.Context, in *ecs.DescribeTasksInput, _ ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
+	f.gotInput = in
+	return f.out, f.err
+}
+
+// taskWithContainers builds a DescribeTasks output for a single task whose
+// containers have the given name->image pairs (in order).
+func taskWithContainers(containers ...types.Container) *ecs.DescribeTasksOutput {
+	return &ecs.DescribeTasksOutput{Tasks: []types.Task{{Containers: containers}}}
+}
+
+func container(name, image string) types.Container {
+	c := types.Container{Name: aws.String(name)}
+	if image != "" {
+		c.Image = aws.String(image)
+	}
+	return c
+}
+
+// TestContainerImage exercises ContainerImage, which extracts a named
+// container's image reference from an ECS DescribeTasks response. Using a fake
+// ECSTaskAPI, it covers: the happy path, the container-matching loop when the
+// requested container is not first, a present-but-empty image, an absent
+// container, and the nil/empty-tasks and client-error paths. The requested
+// container here is consul-dataplane (the real caller), but the function itself
+// is generic over any container name.
+func TestContainerImage(t *testing.T) {
+	const containerName = "consul-dataplane"
+	const containerImage = "hashicorp/consul-dataplane:1.3.0"
+	const cluster = "test-cluster"
+	const taskARN = "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+
+	cases := map[string]struct {
+		out         *ecs.DescribeTasksOutput
+		clientErr   error
+		expectImage string
+		expectErr   []string
+	}{
+		"requested container is the only container": {
+			out:         taskWithContainers(container(containerName, containerImage)),
+			expectImage: containerImage,
+		},
+		"requested container is not first; skips non-matching containers": {
+			out: taskWithContainers(
+				container("app", "myapp:1.0.0"),
+				container("consul-ecs", "hashicorp/consul-ecs:0.9.0"),
+				container(containerName, containerImage),
+			),
+			expectImage: containerImage,
+		},
+		"requested container present with empty image returns empty string": {
+			out:         taskWithContainers(container(containerName, "")),
+			expectImage: "",
+		},
+		"requested container absent returns empty string": {
+			out: taskWithContainers(
+				container("app", "myapp:1.0.0"),
+				container("consul-ecs", "hashicorp/consul-ecs:0.9.0"),
+			),
+			expectImage: "",
+		},
+		"nil output returns not found error": {
+			out:       nil,
+			expectErr: []string{"not found"},
+		},
+		"no tasks returns not found error": {
+			out:       &ecs.DescribeTasksOutput{Tasks: []types.Task{}},
+			expectErr: []string{"not found"},
+		},
+		"client error is wrapped": {
+			clientErr: fmt.Errorf("some client error"),
+			expectErr: []string{"describing ECS task", "some client error"},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := &fakeECSTaskAPI{out: c.out, err: c.clientErr}
+			image, err := ContainerImage(context.Background(), client, cluster, taskARN, containerName)
+
+			// The cluster and task ARN must be forwarded to DescribeTasks.
+			require.NotNil(t, client.gotInput)
+			require.Equal(t, cluster, aws.ToString(client.gotInput.Cluster))
+			require.Equal(t, []string{taskARN}, client.gotInput.Tasks)
+
+			if len(c.expectErr) > 0 {
+				require.Error(t, err)
+				// Errors must identify the task by its ARN.
+				require.Contains(t, err.Error(), taskARN)
+				for _, want := range c.expectErr {
+					require.Contains(t, err.Error(), want)
+				}
+				require.Empty(t, image)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectImage, image)
 		})
 	}
 }

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -62,6 +62,11 @@ const (
 	// retry, hanging).
 	// Refer: https://github.com/hashicorp/consul/blob/9a38fac228fae7960f12f5b2a45c7548c90e8224/agent/structs/structs.go#L191
 	maxMetaValueLength = 512
+
+	// describeTasksTimeout bounds the best-effort ECS DescribeTasks call used to
+	// derive dataplane-version, so a slow or retrying AWS API cannot stall
+	// service registration.
+	describeTasksTimeout = 5 * time.Second
 )
 
 func (c *Command) Run(args []string) int {
@@ -102,12 +107,16 @@ func (c *Command) realRun() error {
 	}
 
 	// Set up the ECS client used to read container image data from DescribeTasks.
+	// This only powers the best-effort dataplane-version ServiceMeta field, so a
+	// failure here must not block service registration: on error we log and leave
+	// ecsClient nil, and getDataplaneVersion handles a nil client gracefully.
 	if c.ecsClient == nil {
 		awsCfg, err := awsutil.NewAWSConfig(taskMeta, "mesh-init")
 		if err != nil {
-			return fmt.Errorf("constructing aws config: %w", err)
+			c.log.Warn("omitting dataplane-version from ServiceMeta: unable to construct AWS config for ECS DescribeTasks", "error", err)
+		} else {
+			c.ecsClient = ecs.NewFromConfig(awsCfg)
 		}
-		c.ecsClient = ecs.NewFromConfig(awsCfg)
 	}
 
 	serverConnMgrCfg, err := c.config.ConsulServerConnMgrConfig(taskMeta)
@@ -583,7 +592,9 @@ func getNodeMeta() map[string]string {
 // internal use and Consul rejects such keys during service registration.
 // Refer: https://github.com/hashicorp/consul/blob/9a38fac228fae7960f12f5b2a45c7548c90e8224/agent/structs/structs.go#L182
 func (c *Command) setVersionMeta(meta map[string]string, taskMeta awsutil.ECSTaskMeta) {
-	meta["ecs-service-version"] = version.GetHumanVersion()
+	if ecsVersion := version.GetHumanVersion(); len(ecsVersion) <= maxMetaValueLength {
+		meta["ecs-service-version"] = ecsVersion
+	}
 	if dp := c.getDataplaneVersion(taskMeta); dp != "" {
 		meta["dataplane-version"] = dp
 	}
@@ -593,18 +604,34 @@ func (c *Command) setVersionMeta(meta map[string]string, taskMeta awsutil.ECSTas
 // derived from its image reference in ECS DescribeTasks runtime state.
 //
 // This is best-effort and never blocks registration.
-// It returns "" when the container is absent or the derived value exceeds
-// Consul's meta value limit, and additionally logs a warning when the task
-// lookup itself fails.
+// It returns "" when the ECS client is unavailable, the container is absent, or
+// the derived value exceeds Consul's meta value limit, and additionally logs a
+// warning when the task lookup itself fails.
 func (c *Command) getDataplaneVersion(taskMeta awsutil.ECSTaskMeta) string {
-	dpImage, err := awsutil.ContainerImage(context.Background(), c.ecsClient, taskMeta.Cluster, taskMeta.TaskARN, config.ConsulDataplaneContainerName)
+	// The ECS client may be nil if AWS config construction failed earlier; skip
+	// rather than panic, keeping dataplane-version strictly best-effort.
+	if c.ecsClient == nil {
+		return ""
+	}
+
+	// Bound the call so a slow or retrying DescribeTasks cannot stall registration.
+	ctx, cancel := context.WithTimeout(context.Background(), describeTasksTimeout)
+	defer cancel()
+
+	dpImage, err := awsutil.ContainerImage(ctx, c.ecsClient, taskMeta.Cluster, taskMeta.TaskARN, config.ConsulDataplaneContainerName)
 	if err != nil {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
 			c.log.Warn("omitting dataplane-version from ServiceMeta: ECS task role lacks ecs:DescribeTasks; grant it to populate dataplane-version", "phase", "service-registration", "error", err)
 		} else {
-			c.log.Warn("unable to determine consul-dataplane version from ECS DescribeTasks", "error", err)
+			c.log.Debug("unable to determine consul-dataplane version from ECS DescribeTasks", "error", err)
 		}
+		return ""
+	}
+	if dpImage == "" {
+		// The container was not found in the task (e.g. a custom task definition
+		// that names the dataplane container differently). Omit best-effort.
+		c.log.Debug("omitting dataplane-version from ServiceMeta: consul-dataplane container not found in ECS task", "container", config.ConsulDataplaneContainerName)
 		return ""
 	}
 	dpVersion := awsutil.ImageVersion(dpImage)

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -43,9 +43,10 @@ type Command struct {
 	// Provider to be used for applying redirection rules in unit tests
 	trafficRedirectionProvider redirecttraffic.TrafficRedirectionProvider
 
-	// ecsClient looks up the task definition to determine the consul-dataplane
-	// image version. Injectable for unit tests; constructed at runtime when nil.
-	ecsClient awsutil.ECSTaskDefinitionAPI
+	// ecsClient looks up ECS task runtime state to determine the
+	// consul-dataplane image version. Injectable for unit tests; constructed at
+	// runtime when nil.
+	ecsClient awsutil.ECSTaskAPI
 
 	// etcResolvConfFile used to configure DNS via unit tests
 	etcResolvConfFile string
@@ -100,8 +101,7 @@ func (c *Command) realRun() error {
 		return err
 	}
 
-	// Set up the ECS client
-	// Used to look up the consul-dataplane image version from the task definition.
+	// Set up the ECS client used to read container image data from DescribeTasks.
 	if c.ecsClient == nil {
 		awsCfg, err := awsutil.NewAWSConfig(taskMeta, "mesh-init")
 		if err != nil {
@@ -590,25 +590,20 @@ func (c *Command) setVersionMeta(meta map[string]string, taskMeta awsutil.ECSTas
 }
 
 // getDataplaneVersion returns the version of the consul-dataplane container,
-// derived from its image reference in the task definition.
-//
-// The image is read from the task definition (not the ECS task metadata
-// endpoint) because consul-dataplane starts only after mesh-init exits.
-// At mesh-init time the consul-dataplane container is therefore absent
-// from the runtime metadata snapshot, whereas the task definition
-// always carries the complete, static container list.
+// derived from its image reference in ECS DescribeTasks runtime state.
 //
 // This is best-effort and never blocks registration.
-// It returns "" when the container is absent or the derived value exceeds Consul's meta value limit,
-// and additionally logs a warning when the task definition lookup itself fails.
+// It returns "" when the container is absent or the derived value exceeds
+// Consul's meta value limit, and additionally logs a warning when the task
+// lookup itself fails.
 func (c *Command) getDataplaneVersion(taskMeta awsutil.ECSTaskMeta) string {
-	dpImage, err := awsutil.ContainerImage(context.Background(), c.ecsClient, taskMeta.TaskDefinitionID(), config.ConsulDataplaneContainerName)
+	dpImage, err := awsutil.ContainerImage(context.Background(), c.ecsClient, taskMeta.Cluster, taskMeta.TaskARN, config.ConsulDataplaneContainerName)
 	if err != nil {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
-			c.log.Warn("dataplane-version will be omitted: the ECS task role is missing the ecs:DescribeTaskDefinition permission; grant it (Resource: \"*\") to populate dataplane-version", "error", err)
+			c.log.Warn("dataplane-version will be omitted: the ECS task role is missing the ecs:DescribeTasks permission; grant it to populate dataplane-version", "error", err)
 		} else {
-			c.log.Warn("unable to determine consul-dataplane version from task definition", "error", err)
+			c.log.Warn("unable to determine consul-dataplane version from ECS DescribeTasks", "error", err)
 		}
 		return ""
 	}

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -592,11 +592,17 @@ func getNodeMeta() map[string]string {
 // internal use and Consul rejects such keys during service registration.
 // Refer: https://github.com/hashicorp/consul/blob/9a38fac228fae7960f12f5b2a45c7548c90e8224/agent/structs/structs.go#L182
 func (c *Command) setVersionMeta(meta map[string]string, taskMeta awsutil.ECSTaskMeta) {
+	// consul-ecs owns these keys. Clear any user-supplied values first so they
+	// cannot be spoofed via service.meta/gateway.meta when we omit our own value
+	// (e.g. dataplane-version could not be determined).
+	delete(meta, "ecs-service-version")
+	delete(meta, "dataplane-version")
+
 	if ecsVersion := version.GetHumanVersion(); len(ecsVersion) <= maxMetaValueLength {
 		meta["ecs-service-version"] = ecsVersion
 	}
-	if dp := c.getDataplaneVersion(taskMeta); dp != "" {
-		meta["dataplane-version"] = dp
+	if dpVersion := c.getDataplaneVersion(taskMeta); dpVersion != "" {
+		meta["dataplane-version"] = dpVersion
 	}
 }
 

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/consul-ecs/internal/dns"
 	"github.com/hashicorp/consul-ecs/internal/redirecttraffic"
 	"github.com/hashicorp/consul-ecs/logging"
+	"github.com/hashicorp/consul-ecs/version"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
@@ -46,6 +47,13 @@ type Command struct {
 const (
 	dataplaneConfigFileName = "consul-dataplane.json"
 	caCertFileName          = "consul-grpc-ca-cert.pem"
+
+	// maxMetaValueLength is Consul's limit for a service meta value. Consul
+	// rejects registrations with a longer value, so we omit any value that
+	// exceeds it to avoid failing (and, given mesh-init's infinite registration
+	// retry, hanging).
+	// Refer: https://github.com/hashicorp/consul/blob/9a38fac228fae7960f12f5b2a45c7548c90e8224/agent/structs/structs.go#L191
+	maxMetaValueLength = 512
 )
 
 func (c *Command) Run(args []string) int {
@@ -260,6 +268,10 @@ func (c *Command) constructServiceRegistration(taskMeta awsutil.ECSTaskMeta, clu
 		"source":   "consul-ecs",
 	}, c.config.Service.Meta)
 
+	// Version metadata is owned by consul-ecs and applied after the user meta so
+	// it cannot be overridden.
+	setVersionMeta(fullMeta, taskMeta)
+
 	service := c.config.Service.ToConsulType()
 	service.ID = serviceID
 	service.Service = serviceName
@@ -326,6 +338,10 @@ func (c *Command) constructGatewayProxyRegistration(taskMeta awsutil.ECSTaskMeta
 		"task-arn": taskMeta.TaskARN,
 		"source":   "consul-ecs",
 	}, c.config.Gateway.Meta)
+
+	// Version metadata is owned by consul-ecs and applied after the user meta so
+	// it cannot be overridden.
+	setVersionMeta(gatewaySvc.Meta, taskMeta)
 
 	switch c.config.Gateway.Kind {
 	case api.ServiceKindMeshGateway:
@@ -537,6 +553,42 @@ func getNodeMeta() map[string]string {
 	return map[string]string{
 		config.SyntheticNode: "true",
 	}
+}
+
+// setVersionMeta writes the consul-ecs and consul-dataplane versions into meta.
+// These reflect the actual running binaries, so they are applied after the
+// user-provided meta and cannot be overridden: the purpose of these fields is
+// to report the exact versions in use (e.g. for LTS upgrade audits).
+// The dataplane-version key is omitted when the version cannot be determined,
+// so we never advertise a misleading empty value.
+//
+// Meta keys must not start with "consul-": that prefix is reserved for Consul's
+// internal use and Consul rejects such keys during service registration.
+// Refer: https://github.com/hashicorp/consul/blob/9a38fac228fae7960f12f5b2a45c7548c90e8224/agent/structs/structs.go#L182
+func setVersionMeta(meta map[string]string, taskMeta awsutil.ECSTaskMeta) {
+	meta["ecs-service-version"] = version.GetHumanVersion()
+	if dp := getDataplaneVersion(taskMeta); dp != "" {
+		meta["dataplane-version"] = dp
+	}
+}
+
+// getDataplaneVersion returns the version of the consul-dataplane container,
+// derived from its image reference in the ECS task metadata.
+// This is the image tag when present, otherwise the raw image reference
+// (a bare repository or a digest-pinned image).
+// It returns "" when the container is absent from the task metadata, has no
+// image reference, or the derived value exceeds Consul's meta value limit.
+func getDataplaneVersion(taskMeta awsutil.ECSTaskMeta) string {
+	for _, container := range taskMeta.Containers {
+		if container.Name == config.ConsulDataplaneContainerName {
+			dpVersion := container.ImageVersion()
+			if len(dpVersion) > maxMetaValueLength {
+				return ""
+			}
+			return dpVersion
+		}
+	}
+	return ""
 }
 
 func makeServiceID(serviceName, taskID string) string {

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -5,6 +5,7 @@ package meshinit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -16,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/smithy-go"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/consul-ecs/awsutil"
 	"github.com/hashicorp/consul-ecs/config"
@@ -39,6 +42,10 @@ type Command struct {
 
 	// Provider to be used for applying redirection rules in unit tests
 	trafficRedirectionProvider redirecttraffic.TrafficRedirectionProvider
+
+	// ecsClient looks up the task definition to determine the consul-dataplane
+	// image version. Injectable for unit tests; constructed at runtime when nil.
+	ecsClient awsutil.ECSTaskDefinitionAPI
 
 	// etcResolvConfFile used to configure DNS via unit tests
 	etcResolvConfFile string
@@ -91,6 +98,16 @@ func (c *Command) realRun() error {
 	clusterARN, err := taskMeta.ClusterARN()
 	if err != nil {
 		return err
+	}
+
+	// Set up the ECS client
+	// Used to look up the consul-dataplane image version from the task definition.
+	if c.ecsClient == nil {
+		awsCfg, err := awsutil.NewAWSConfig(taskMeta, "mesh-init")
+		if err != nil {
+			return fmt.Errorf("constructing aws config: %w", err)
+		}
+		c.ecsClient = ecs.NewFromConfig(awsCfg)
 	}
 
 	serverConnMgrCfg, err := c.config.ConsulServerConnMgrConfig(taskMeta)
@@ -270,7 +287,7 @@ func (c *Command) constructServiceRegistration(taskMeta awsutil.ECSTaskMeta, clu
 
 	// Version metadata is owned by consul-ecs and applied after the user meta so
 	// it cannot be overridden.
-	setVersionMeta(fullMeta, taskMeta)
+	c.setVersionMeta(fullMeta, taskMeta)
 
 	service := c.config.Service.ToConsulType()
 	service.ID = serviceID
@@ -341,7 +358,7 @@ func (c *Command) constructGatewayProxyRegistration(taskMeta awsutil.ECSTaskMeta
 
 	// Version metadata is owned by consul-ecs and applied after the user meta so
 	// it cannot be overridden.
-	setVersionMeta(gatewaySvc.Meta, taskMeta)
+	c.setVersionMeta(gatewaySvc.Meta, taskMeta)
 
 	switch c.config.Gateway.Kind {
 	case api.ServiceKindMeshGateway:
@@ -565,30 +582,41 @@ func getNodeMeta() map[string]string {
 // Meta keys must not start with "consul-": that prefix is reserved for Consul's
 // internal use and Consul rejects such keys during service registration.
 // Refer: https://github.com/hashicorp/consul/blob/9a38fac228fae7960f12f5b2a45c7548c90e8224/agent/structs/structs.go#L182
-func setVersionMeta(meta map[string]string, taskMeta awsutil.ECSTaskMeta) {
+func (c *Command) setVersionMeta(meta map[string]string, taskMeta awsutil.ECSTaskMeta) {
 	meta["ecs-service-version"] = version.GetHumanVersion()
-	if dp := getDataplaneVersion(taskMeta); dp != "" {
+	if dp := c.getDataplaneVersion(taskMeta); dp != "" {
 		meta["dataplane-version"] = dp
 	}
 }
 
 // getDataplaneVersion returns the version of the consul-dataplane container,
-// derived from its image reference in the ECS task metadata.
-// This is the image tag when present, otherwise the raw image reference
-// (a bare repository or a digest-pinned image).
-// It returns "" when the container is absent from the task metadata, has no
-// image reference, or the derived value exceeds Consul's meta value limit.
-func getDataplaneVersion(taskMeta awsutil.ECSTaskMeta) string {
-	for _, container := range taskMeta.Containers {
-		if container.Name == config.ConsulDataplaneContainerName {
-			dpVersion := container.ImageVersion()
-			if len(dpVersion) > maxMetaValueLength {
-				return ""
-			}
-			return dpVersion
+// derived from its image reference in the task definition.
+//
+// The image is read from the task definition (not the ECS task metadata
+// endpoint) because consul-dataplane starts only after mesh-init exits.
+// At mesh-init time the consul-dataplane container is therefore absent
+// from the runtime metadata snapshot, whereas the task definition
+// always carries the complete, static container list.
+//
+// This is best-effort and never blocks registration.
+// It returns "" when the container is absent or the derived value exceeds Consul's meta value limit,
+// and additionally logs a warning when the task definition lookup itself fails.
+func (c *Command) getDataplaneVersion(taskMeta awsutil.ECSTaskMeta) string {
+	dpImage, err := awsutil.ContainerImage(context.Background(), c.ecsClient, taskMeta.TaskDefinitionID(), config.ConsulDataplaneContainerName)
+	if err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
+			c.log.Warn("dataplane-version will be omitted: the ECS task role is missing the ecs:DescribeTaskDefinition permission; grant it (Resource: \"*\") to populate dataplane-version", "error", err)
+		} else {
+			c.log.Warn("unable to determine consul-dataplane version from task definition", "error", err)
 		}
+		return ""
 	}
-	return ""
+	dpVersion := awsutil.ImageVersion(dpImage)
+	if len(dpVersion) > maxMetaValueLength {
+		return ""
+	}
+	return dpVersion
 }
 
 func makeServiceID(serviceName, taskID string) string {

--- a/subcommand/mesh-init/command.go
+++ b/subcommand/mesh-init/command.go
@@ -601,7 +601,7 @@ func (c *Command) getDataplaneVersion(taskMeta awsutil.ECSTaskMeta) string {
 	if err != nil {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
-			c.log.Warn("dataplane-version will be omitted: the ECS task role is missing the ecs:DescribeTasks permission; grant it to populate dataplane-version", "error", err)
+			c.log.Warn("omitting dataplane-version from ServiceMeta: ECS task role lacks ecs:DescribeTasks; grant it to populate dataplane-version", "phase", "service-registration", "error", err)
 		} else {
 			c.log.Warn("unable to determine consul-dataplane version from ECS DescribeTasks", "error", err)
 		}

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -4,6 +4,7 @@
 package meshinit
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,6 +14,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-ecs/awsutil"
@@ -32,6 +36,27 @@ type fileMeta struct {
 	name string
 	path string
 	mode int
+}
+
+// fakeECSClient is a test double for awsutil.ECSTaskDefinitionAPI. It returns a
+// task definition containing a single consul-dataplane container with the given
+// image (omitted when image is empty), or err when set.
+type fakeECSClient struct {
+	image string
+	err   error
+}
+
+func (f *fakeECSClient) DescribeTaskDefinition(_ context.Context, _ *ecs.DescribeTaskDefinitionInput, _ ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	td := &types.TaskDefinition{}
+	if f.image != "" {
+		td.ContainerDefinitions = []types.ContainerDefinition{
+			{Name: aws.String(config.ConsulDataplaneContainerName), Image: aws.String(f.image)},
+		}
+	}
+	return &ecs.DescribeTaskDefinitionOutput{TaskDefinition: td}, nil
 }
 
 func TestNoCLIFlagsSupported(t *testing.T) {
@@ -235,12 +260,6 @@ func TestRun(t *testing.T) {
 				TaskARN:          taskARN,
 				Family:           family,
 				AvailabilityZone: testZone,
-				Containers: []awsutil.ECSTaskMetaContainer{
-					{
-						Name:  config.ConsulDataplaneContainerName,
-						Image: "hashicorp/consul-dataplane:1.3.0",
-					},
-				},
 			}
 			taskMetaRespStr, err := constructTaskMetaResponseString(taskMetadataResponse)
 			require.NoError(t, err)
@@ -264,6 +283,7 @@ func TestRun(t *testing.T) {
 
 			ui := cli.NewMockUi()
 			cmd := Command{UI: ui}
+			cmd.ecsClient = &fakeECSClient{image: "hashicorp/consul-dataplane:1.3.0"}
 
 			envoyBootstrapDir := testutil.TempDir(t)
 			dataplaneConfigJSONFile := filepath.Join(envoyBootstrapDir, dataplaneConfigFileName)
@@ -659,10 +679,6 @@ func TestGateway(t *testing.T) {
 							},
 						},
 					},
-					{
-						Name:  config.ConsulDataplaneContainerName,
-						Image: "hashicorp/consul-dataplane:1.3.0",
-					},
 				},
 			}
 
@@ -727,6 +743,7 @@ func TestGateway(t *testing.T) {
 
 			ui := cli.NewMockUi()
 			cmd := Command{UI: ui}
+			cmd.ecsClient = &fakeECSClient{image: "hashicorp/consul-dataplane:1.3.0"}
 
 			code := cmd.Run(nil)
 			require.Equal(t, code, 0, ui.ErrorWriter.String())
@@ -843,55 +860,51 @@ func TestMakeProxyServiceIDAndName(t *testing.T) {
 
 func TestGetDataplaneVersion(t *testing.T) {
 	cases := map[string]struct {
-		containers []awsutil.ECSTaskMetaContainer
-		expected   string
+		// image is the consul-dataplane image in the task definition; empty means
+		// the container is absent from the task definition.
+		image     string
+		clientErr error
+		expected  string
 	}{
 		"dataplane present with tag": {
-			containers: []awsutil.ECSTaskMetaContainer{
-				{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane:1.3.0"},
-			},
+			image:    "hashicorp/consul-dataplane:1.3.0",
 			expected: "1.3.0",
 		},
 		"dataplane pinned by digest": {
-			containers: []awsutil.ECSTaskMetaContainer{
-				{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789"},
-			},
+			image:    "hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789",
 			expected: "hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789",
 		},
-		"dataplane absent": {
-			containers: []awsutil.ECSTaskMetaContainer{
-				{Name: "app", Image: "my-app:1.0.0"},
-			},
+		"dataplane absent from task definition": {
+			image:    "",
 			expected: "",
 		},
-		"dataplane image reference exceeds meta value limit": {
+		"image reference exceeds meta value limit": {
 			// A digest-only reference longer than Consul's 512-char meta value
 			// limit is omitted rather than stored (which would fail registration).
-			containers: []awsutil.ECSTaskMetaContainer{
-				{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane@sha256:" + strings.Repeat("a", 600)},
-			},
+			image:    "hashicorp/consul-dataplane@sha256:" + strings.Repeat("a", 600),
 			expected: "",
 		},
-		"no containers": {
-			containers: nil,
-			expected:   "",
+		"task definition lookup fails": {
+			clientErr: fmt.Errorf("boom"),
+			expected:  "",
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			taskMeta := awsutil.ECSTaskMeta{Containers: c.containers}
-			require.Equal(t, c.expected, getDataplaneVersion(taskMeta))
+			cmd := &Command{
+				log:       hclog.NewNullLogger(),
+				ecsClient: &fakeECSClient{image: c.image, err: c.clientErr},
+			}
+			require.Equal(t, c.expected, cmd.getDataplaneVersion(awsutil.ECSTaskMeta{}))
 		})
 	}
 }
 
 func TestSetVersionMetaOverridesUserMeta(t *testing.T) {
-	taskMeta := awsutil.ECSTaskMeta{
-		TaskARN: "arn:aws:ecs:us-east-1:123456789:task/test/abcdef",
-		Containers: []awsutil.ECSTaskMetaContainer{
-			{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane:1.3.0"},
-		},
+	cmd := &Command{
+		log:       hclog.NewNullLogger(),
+		ecsClient: &fakeECSClient{image: "hashicorp/consul-dataplane:1.3.0"},
 	}
 
 	// User-supplied meta attempts to spoof the version fields and keep a custom one.
@@ -901,7 +914,7 @@ func TestSetVersionMetaOverridesUserMeta(t *testing.T) {
 		"custom":              "keep-me",
 	}
 
-	setVersionMeta(meta, taskMeta)
+	cmd.setVersionMeta(meta, awsutil.ECSTaskMeta{})
 
 	// consul-ecs owns the version keys, so its values win over the user's.
 	require.Equal(t, version.GetHumanVersion(), meta["ecs-service-version"])

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -933,16 +933,24 @@ func TestGetDataplaneVersionNilClient(t *testing.T) {
 
 // TestSetVersionMetaNilClient ensures registration meta is still populated with
 // ecs-service-version and simply omits dataplane-version when the ECS client is
-// unavailable, keeping the version reporting strictly best-effort.
+// unavailable, keeping the version reporting strictly best-effort. It also
+// asserts that a user-supplied dataplane-version cannot be spoofed when ours is
+// omitted.
 func TestSetVersionMetaNilClient(t *testing.T) {
 	cmd := &Command{log: hclog.NewNullLogger()} // ecsClient intentionally nil
 
-	meta := map[string]string{}
+	meta := map[string]string{
+		"ecs-service-version": "spoofed",
+		"dataplane-version":   "spoofed",
+		"custom":              "keep-me",
+	}
 	cmd.setVersionMeta(meta, awsutil.ECSTaskMeta{})
 
 	require.Equal(t, version.GetHumanVersion(), meta["ecs-service-version"])
+	require.NotEqual(t, "spoofed", meta["ecs-service-version"], "ecs-service-version must not be spoofable via user meta")
 	_, ok := meta["dataplane-version"]
-	require.False(t, ok, "dataplane-version should be omitted when the ECS client is nil")
+	require.False(t, ok, "dataplane-version should be omitted (not spoofable) when the ECS client is nil")
+	require.Equal(t, "keep-me", meta["custom"])
 }
 
 func TestWriteCACertToVolume(t *testing.T) {

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -923,6 +923,28 @@ func TestSetVersionMetaOverridesUserMeta(t *testing.T) {
 	require.Equal(t, "keep-me", meta["custom"])
 }
 
+// TestGetDataplaneVersionNilClient ensures that when the ECS client could not be
+// constructed (e.g. AWS config resolution failed), the best-effort lookup is
+// skipped rather than panicking on a nil client.
+func TestGetDataplaneVersionNilClient(t *testing.T) {
+	cmd := &Command{log: hclog.NewNullLogger()} // ecsClient intentionally nil
+	require.Equal(t, "", cmd.getDataplaneVersion(awsutil.ECSTaskMeta{}))
+}
+
+// TestSetVersionMetaNilClient ensures registration meta is still populated with
+// ecs-service-version and simply omits dataplane-version when the ECS client is
+// unavailable, keeping the version reporting strictly best-effort.
+func TestSetVersionMetaNilClient(t *testing.T) {
+	cmd := &Command{log: hclog.NewNullLogger()} // ecsClient intentionally nil
+
+	meta := map[string]string{}
+	cmd.setVersionMeta(meta, awsutil.ECSTaskMeta{})
+
+	require.Equal(t, version.GetHumanVersion(), meta["ecs-service-version"])
+	_, ok := meta["dataplane-version"]
+	require.False(t, ok, "dataplane-version should be omitted when the ECS client is nil")
+}
+
 func TestWriteCACertToVolume(t *testing.T) {
 	cases := map[string]struct {
 		serverConfig               config.ConsulServers

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/consul-ecs/config"
 	"github.com/hashicorp/consul-ecs/internal/dataplane"
 	"github.com/hashicorp/consul-ecs/testutil"
+	"github.com/hashicorp/consul-ecs/version"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/iptables"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -174,9 +175,11 @@ func TestRun(t *testing.T) {
 			var (
 				taskARN          = "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
 				expectedTaskMeta = map[string]string{
-					"task-id":  "abcdef",
-					"task-arn": taskARN,
-					"source":   "consul-ecs",
+					"task-id":             "abcdef",
+					"task-arn":            taskARN,
+					"source":              "consul-ecs",
+					"ecs-service-version": version.GetHumanVersion(),
+					"dataplane-version":   "1.3.0",
 				}
 				expectedServiceName = strings.ToLower(family)
 				expectedPartition   = ""
@@ -232,6 +235,12 @@ func TestRun(t *testing.T) {
 				TaskARN:          taskARN,
 				Family:           family,
 				AvailabilityZone: testZone,
+				Containers: []awsutil.ECSTaskMetaContainer{
+					{
+						Name:  config.ConsulDataplaneContainerName,
+						Image: "hashicorp/consul-dataplane:1.3.0",
+					},
+				},
 			}
 			taskMetaRespStr, err := constructTaskMetaResponseString(taskMetadataResponse)
 			require.NoError(t, err)
@@ -458,9 +467,11 @@ func TestGateway(t *testing.T) {
 		publicIP         = "255.1.2.3"
 		taskDNSName      = "test-dns-name"
 		expectedTaskMeta = map[string]string{
-			"task-id":  "abcdef",
-			"task-arn": taskARN,
-			"source":   "consul-ecs",
+			"task-id":             "abcdef",
+			"task-arn":            taskARN,
+			"source":              "consul-ecs",
+			"ecs-service-version": version.GetHumanVersion(),
+			"dataplane-version":   "1.3.0",
 		}
 	)
 	// Simulate mesh gateway registration:
@@ -648,6 +659,10 @@ func TestGateway(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name:  config.ConsulDataplaneContainerName,
+						Image: "hashicorp/consul-dataplane:1.3.0",
+					},
 				},
 			}
 
@@ -824,6 +839,75 @@ func TestMakeProxyServiceIDAndName(t *testing.T) {
 	actualID, actualName := makeProxySvcIDAndName("test-service-12345", "test-service")
 	require.Equal(t, expectedID, actualID)
 	require.Equal(t, expectedName, actualName)
+}
+
+func TestGetDataplaneVersion(t *testing.T) {
+	cases := map[string]struct {
+		containers []awsutil.ECSTaskMetaContainer
+		expected   string
+	}{
+		"dataplane present with tag": {
+			containers: []awsutil.ECSTaskMetaContainer{
+				{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane:1.3.0"},
+			},
+			expected: "1.3.0",
+		},
+		"dataplane pinned by digest": {
+			containers: []awsutil.ECSTaskMetaContainer{
+				{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789"},
+			},
+			expected: "hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789",
+		},
+		"dataplane absent": {
+			containers: []awsutil.ECSTaskMetaContainer{
+				{Name: "app", Image: "my-app:1.0.0"},
+			},
+			expected: "",
+		},
+		"dataplane image reference exceeds meta value limit": {
+			// A digest-only reference longer than Consul's 512-char meta value
+			// limit is omitted rather than stored (which would fail registration).
+			containers: []awsutil.ECSTaskMetaContainer{
+				{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane@sha256:" + strings.Repeat("a", 600)},
+			},
+			expected: "",
+		},
+		"no containers": {
+			containers: nil,
+			expected:   "",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			taskMeta := awsutil.ECSTaskMeta{Containers: c.containers}
+			require.Equal(t, c.expected, getDataplaneVersion(taskMeta))
+		})
+	}
+}
+
+func TestSetVersionMetaOverridesUserMeta(t *testing.T) {
+	taskMeta := awsutil.ECSTaskMeta{
+		TaskARN: "arn:aws:ecs:us-east-1:123456789:task/test/abcdef",
+		Containers: []awsutil.ECSTaskMetaContainer{
+			{Name: config.ConsulDataplaneContainerName, Image: "hashicorp/consul-dataplane:1.3.0"},
+		},
+	}
+
+	// User-supplied meta attempts to spoof the version fields and keep a custom one.
+	meta := map[string]string{
+		"ecs-service-version": "spoofed",
+		"dataplane-version":   "spoofed",
+		"custom":              "keep-me",
+	}
+
+	setVersionMeta(meta, taskMeta)
+
+	// consul-ecs owns the version keys, so its values win over the user's.
+	require.Equal(t, version.GetHumanVersion(), meta["ecs-service-version"])
+	require.Equal(t, "1.3.0", meta["dataplane-version"])
+	// Non-version user keys are left untouched.
+	require.Equal(t, "keep-me", meta["custom"])
 }
 
 func TestWriteCACertToVolume(t *testing.T) {

--- a/subcommand/mesh-init/command_test.go
+++ b/subcommand/mesh-init/command_test.go
@@ -38,25 +38,25 @@ type fileMeta struct {
 	mode int
 }
 
-// fakeECSClient is a test double for awsutil.ECSTaskDefinitionAPI. It returns a
-// task definition containing a single consul-dataplane container with the given
-// image (omitted when image is empty), or err when set.
+// fakeECSClient is a test double for awsutil.ECSTaskAPI. It returns a
+// DescribeTasks response containing a single task with a consul-dataplane
+// container image (omitted when image is empty), or err when set.
 type fakeECSClient struct {
 	image string
 	err   error
 }
 
-func (f *fakeECSClient) DescribeTaskDefinition(_ context.Context, _ *ecs.DescribeTaskDefinitionInput, _ ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error) {
+func (f *fakeECSClient) DescribeTasks(_ context.Context, _ *ecs.DescribeTasksInput, _ ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
-	td := &types.TaskDefinition{}
+	task := types.Task{}
 	if f.image != "" {
-		td.ContainerDefinitions = []types.ContainerDefinition{
+		task.Containers = []types.Container{
 			{Name: aws.String(config.ConsulDataplaneContainerName), Image: aws.String(f.image)},
 		}
 	}
-	return &ecs.DescribeTaskDefinitionOutput{TaskDefinition: td}, nil
+	return &ecs.DescribeTasksOutput{Tasks: []types.Task{task}}, nil
 }
 
 func TestNoCLIFlagsSupported(t *testing.T) {
@@ -860,8 +860,8 @@ func TestMakeProxyServiceIDAndName(t *testing.T) {
 
 func TestGetDataplaneVersion(t *testing.T) {
 	cases := map[string]struct {
-		// image is the consul-dataplane image in the task definition; empty means
-		// the container is absent from the task definition.
+		// image is the consul-dataplane image in DescribeTasks output; empty means
+		// the container is absent from the task.
 		image     string
 		clientErr error
 		expected  string
@@ -874,7 +874,7 @@ func TestGetDataplaneVersion(t *testing.T) {
 			image:    "hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789",
 			expected: "hashicorp/consul-dataplane@sha256:9b2cabcdef0123456789",
 		},
-		"dataplane absent from task definition": {
+		"dataplane absent from task": {
 			image:    "",
 			expected: "",
 		},
@@ -884,7 +884,7 @@ func TestGetDataplaneVersion(t *testing.T) {
 			image:    "hashicorp/consul-dataplane@sha256:" + strings.Repeat("a", 600),
 			expected: "",
 		},
-		"task definition lookup fails": {
+		"describe tasks lookup fails": {
 			clientErr: fmt.Errorf("boom"),
 			expected:  "",
 		},


### PR DESCRIPTION
## Inject `consul-ecs` and `consul-dataplane` versions into ServiceMeta
Fixes #339

### 1. What is changed/added in this PR

This PR extends the Consul `ServiceMeta` that `mesh-init` sets during service, sidecar-proxy, and gateway registration with two new fields, so operators can query the exact binary versions running in a task (e.g. to verify dataplane versions before an LTS upgrade):

- `ecs-service-version` — the running `consul-ecs` binary version (`version.GetHumanVersion()`).
- `dataplane-version` — the `consul-dataplane` version, derived from its container image in the ECS Task. 

**Note on consul dataplane version:** 
1. Consul `dataplane-version` can be raw container image reference in case if image lacks tags as fallback and `dataplane-version` field will be skipped if there is no container image reference in ECS Task.
2. Consul dataplane image is read via **ECS DescribeTasks**, since the dataplane container is not yet present in the local task metadata endpoint when mesh-init registers the service. This requires the `ecs:DescribeTasks` permission on the ECS task role; when it is missing, the version is omitted (with a log) and service registration is never blocked.
3. Customer is OK to provide extra IAM permissions ([ref](https://github.com/hashicorp/consul-ecs/issues/339#issuecomment-4954369535)) and want real-time container `dataplane-version` instead of terraform-module propagated values. 

Before:
```json
"ServiceMeta": {
  "source": "consul-ecs",
  "task-arn": "arn:aws:ecs:...:task/<cluster>/<task-id>",
  "task-id": "<task-id>"
}
```
After:
```json
"ServiceMeta": {
  "source": "consul-ecs",
  "task-arn": "arn:aws:ecs:...:task/<cluster>/<task-id>",
  "task-id": "<task-id>",
  "ecs-service-version": "v0.9.4-dev (<sha>)",
  "dataplane-version": "1.3.0"
}
```

Implementation notes (no existing behavior changed):
- **No change to the existing base meta flow.** `task-id` / `task-arn` / `source` are built and merged with user config meta exactly as on `main`. **The version fields are simply applied *after* that merge via a new `setVersionMeta` helper.**
- **awsutil**: added an `Image` field to `ECSTaskContainer` and an `ImageVersion()` helper that returns the image **tag** when present, and otherwise the raw image reference (bare repo or digest-pinned), so the value is always meaningful.
- **Safety guards** (both protect against `mesh-init`'s infinite registration retry silently hanging):
  - Version meta keys deliberately avoid the `consul-` prefix, which Consul reserves for internal use and rejects during registration.
  - A value longer than Consul's 512-char meta-value limit is omitted rather than truncated (a truncated image ref would be misleading, and a full one would fail registration).

### 2. How I've tested this PR

- **Unit tests** for the new logic:
  - `TestECSTaskMetaContainerImageVersion` — covers tags, `latest`, digest-only, `host:port` registries, tag+digest, and empty image.
  - `TestGetDataplaneVersion` — including the `>512` char omission case.
  - `TestSetVersionMetaOverridesUserMeta` — verifies the version keys are not user-overridable.
- **Integration tests against a real Consul agent:** `TestRun` and `TestGateway` spin up an actual `consul` server (via `hashicorp/consul/sdk/testutil`), run the full `mesh-init` flow, register the service/proxy/gateway through the real Consul catalog, then read the records back and assert `ServiceMeta` contains the new `ecs-service-version` / `dataplane-version` values. This exercises Consul's own server-side meta validation end-to-end.
- Consul-ecs deployment test:
Adding couple of test setups scripts and logs - All race test (25 continuous deployments) passed.
[test_serviceMetadata_race.sh](https://github.com/user-attachments/files/30125496/test_serviceMetadata_race.sh)
[test_serviceMetadata_race.log](https://github.com/user-attachments/files/30125498/test_serviceMetadata_race.log)
[test_serviceMetadata.sh](https://github.com/user-attachments/files/30125497/test_serviceMetadata.sh)
[test_serviceMetadata3.log](https://github.com/user-attachments/files/30125500/test_serviceMetadata3.log)

### 3. How I expect reviewers to test this PR
- **Version fields are intentionally not user-overridable.** The `ecs-service-version` and `dataplane-version` values are owned by `consul-ecs` and applied *after* the user-provided `service.meta` / `gateway.meta`, so a user cannot override them via config. **This is deliberate: the whole purpose of these fields is to report the version **actually in use** (e.g. for upgrade audits), so allowing an override would let the reported value drift from reality.** _That said, this is a design choice — if we'd prefer to let users override them, it's a trivial change (apply the version meta *before* the user meta instead of after). Please let me know if we need to go this path._
- **Dataplane version can be raw container image reference in case if image lacks tags as fallback:** Please let me know if this needs to be changed as well. Should we only return image tags?
---

AWS ECS Ref:
https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security_iam_id-based-policy-examples.html#IAM_run_policies
