### PR TITLE
health-sync: batch Consul health check updates into a single atomic Catalog.Register

### DIFF
--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -249,15 +249,14 @@ func (c *Command) stageContainerHealthChecks(taskMeta awsutil.ECSTaskMeta, conta
 		return nil, err
 	}
 
-	if containerName == config.ConsulDataplaneContainerName {
-		// A gateway has no sidecar proxy, so just the serviceCheck.
-		if c.config.IsGateway() {
-			return api.HealthChecks{serviceCheck}, nil
-		}
+	// Gateway service: dataplane container maps to a single service check
+	if containerName == config.ConsulDataplaneContainerName && c.config.IsGateway() {
+		return api.HealthChecks{serviceCheck}, nil
+	}
 
-		// A typical service has a sidecar proxy as well, so stage the proxyCheck too &
-		// return both serviceCheck and proxyCheck.
-		proxySvcID, _ := makeProxySvcIDAndName(serviceID, "")
+	// Typical service (non-gateway): dataplane container maps to serviceCheck and proxyCheck
+	if containerName == config.ConsulDataplaneContainerName && !c.config.IsGateway() {
+		proxySvcID, _ := makeProxySvcIDAndName(serviceID, serviceName)
 		proxyCheck, err := c.stageCheck(proxySvcID, containerName, ecsHealthStatus)
 		if err != nil {
 			return nil, err
@@ -265,6 +264,7 @@ func (c *Command) stageContainerHealthChecks(taskMeta awsutil.ECSTaskMeta, conta
 		return api.HealthChecks{serviceCheck, proxyCheck}, nil
 	}
 
+	// Non-gateway service, non-dataplane: app container maps to a single serviceCheck
 	return api.HealthChecks{serviceCheck}, nil
 }
 

--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -62,21 +62,34 @@ func (c *Command) fetchHealthChecks(consulClient *api.Client, taskMeta awsutil.E
 	return healthCheckMap, nil
 }
 
-// setChecksCritical sets checks for all of the containers to critical
+// setChecksCritical stages every container's check as critical and writes them
+// to Consul in a single Catalog.Register call.
 func (c *Command) setChecksCritical(consulClient *api.Client, taskMeta awsutil.ECSTaskMeta, clusterARN string, parsedContainerNames []string) error {
 	var result error
+	var healthCheckBatch api.HealthChecks
+	var stagedContainers []string
 
 	for _, containerName := range parsedContainerNames {
-		err := c.writeContainerHealth(consulClient, taskMeta, clusterARN, containerName, string(types.HealthStatusUnhealthy))
-		if err == nil {
-			c.log.Info("set Consul health status to critical",
-				"container", containerName)
-		} else {
+		checks, err := c.stageContainerHealthChecks(taskMeta, containerName, string(types.HealthStatusUnhealthy))
+		if err != nil {
 			c.log.Warn("failed to set Consul health status to critical",
-				"err", err,
-				"container", containerName)
+				"err", err, "container", containerName)
 			result = multierror.Append(result, err)
+			continue
 		}
+		healthCheckBatch = append(healthCheckBatch, checks...)
+		stagedContainers = append(stagedContainers, containerName)
+	}
+
+	if err := c.registerChecks(consulClient, clusterARN, healthCheckBatch); err != nil {
+		return multierror.Append(result, err)
+	}
+
+	// Log only after the write succeeds, so we never report a critical status
+	// that was not actually committed to Consul.
+	for _, containerName := range stagedContainers {
+		c.log.Info("set Consul health status to critical",
+			"container", containerName)
 	}
 
 	return result
@@ -86,7 +99,8 @@ func (c *Command) setChecksCritical(consulClient *api.Client, taskMeta awsutil.E
 // the containers in parsedContainerNames. Containers absent from task metadata
 // are treated as UNHEALTHY. The consul-dataplane check reports the aggregate
 // of every tracked container's status. Only checks whose status changed since
-// the last tick are written, to minimise Catalog.Register traffic.
+// the last tick are written, and all of a tick's changed checks are written in
+// a single atomic Catalog.Register call.
 func (c *Command) syncChecks(consulClient *api.Client,
 	currentStatuses map[string]string,
 	clusterARN string,
@@ -115,31 +129,65 @@ func (c *Command) syncChecks(consulClient *api.Client,
 
 	resolvedStatuses[config.ConsulDataplaneContainerName] = computeOverallDataplaneHealth(resolvedStatuses)
 
-	for _, name := range parsedContainerNames {
-		desired := resolvedStatuses[name]
-		if desired == currentStatuses[name] {
+	// Stage every changed container's health checks in memory, accumulate them into a
+	// single healthCheckBatch, then issue one Catalog.Register for the whole tick.
+	type statusChange struct {
+		containerName  string
+		desiredStatus  string
+		previousStatus string
+	}
+	var (
+		healthCheckBatch  api.HealthChecks // For writing (or registering) health checks (updates) to Consul
+		statusChangeBatch []statusChange   // For logging containers status change after a successful write
+	)
+	for _, containerName := range parsedContainerNames {
+		desiredStatus := resolvedStatuses[containerName]
+		if desiredStatus == currentStatuses[containerName] {
 			continue
 		}
 
-		if err := c.writeContainerHealth(consulClient, taskMeta, clusterARN, name, desired); err != nil {
-			c.log.Warn("failed to update Consul health status",
-				"err", err, "container", name)
+		checks, err := c.stageContainerHealthChecks(taskMeta, containerName, desiredStatus)
+		if err != nil {
+			c.log.Warn("failed to stage Consul health status",
+				"err", err, "container", containerName)
 			continue
 		}
 
+		healthCheckBatch = append(healthCheckBatch, checks...)
+		statusChangeBatch = append(statusChangeBatch, statusChange{
+			containerName:  containerName,
+			desiredStatus:  desiredStatus,
+			previousStatus: currentStatuses[containerName],
+		})
+	}
+
+	if len(healthCheckBatch) == 0 {
+		return currentStatuses
+	}
+
+	// Commit the whole tick's staged healthCheckBatch to Consul in one atomic Catalog.Register.
+	// On failure we leave currentStatuses untouched so the next tick retries.
+	if err := c.registerChecks(consulClient, clusterARN, healthCheckBatch); err != nil {
+		c.log.Warn("failed to update Consul health status", "err", err)
+		return currentStatuses
+	}
+
+	// A single Consul write happened this tick.
+	// Log one line per changed container so each transition is on its own line.
+	for _, change := range statusChangeBatch {
 		logFields := []any{
-			"container", name,
-			"status", desired,
-			"previous", currentStatuses[name],
+			"container", change.containerName,
+			"status", change.desiredStatus,
+			"previous", change.previousStatus,
 		}
-		if container, ok := foundContainers[name]; ok {
+		if container, ok := foundContainers[change.containerName]; ok {
 			logFields = append(logFields,
 				"statusSince", container.Health.StatusSince,
 				"exitCode", container.Health.ExitCode,
 			)
 		}
 		c.log.Info("container health check updated in Consul", logFields...)
-		currentStatuses[name] = desired
+		currentStatuses[change.containerName] = change.desiredStatus
 	}
 
 	return currentStatuses
@@ -166,57 +214,71 @@ func computeOverallDataplaneHealth(resolvedStatuses map[string]string) string {
 	return string(types.HealthStatusHealthy)
 }
 
-// writeContainerHealth dispatches a single container's status to the right
-// Consul check(s). consul-dataplane updates both the service check and the
-// sidecar proxy check; every other container updates one service check.
-func (c *Command) writeContainerHealth(consulClient *api.Client, taskMeta awsutil.ECSTaskMeta, clusterARN, name, status string) error {
+// stageContainerHealthChecks stages the Consul check(s) that a single container's
+// status maps to and returns them, without writing to Consul.
+//
+// Consul registrations differ by service type:
+//   - A typical service has two registrations: the service (kind "typical"),
+//     which holds one check per app container plus a consul-dataplane readiness
+//     check, and the sidecar proxy (kind "connect-proxy"), which holds one
+//     consul-dataplane readiness check.
+//   - A gateway has a single registration (no sidecar proxy) with one
+//     consul-dataplane readiness check.
+//
+// As a result, the consul-dataplane container updates both the service check and
+// the sidecar proxy check, while every other container (and any gateway
+// container) updates a single service check.
+func (c *Command) stageContainerHealthChecks(taskMeta awsutil.ECSTaskMeta, containerName, ecsHealthStatus string) (api.HealthChecks, error) {
 	serviceName := c.constructServiceName(taskMeta.Family)
-	if name == config.ConsulDataplaneContainerName {
-		return c.handleHealthForDataplaneContainer(consulClient, taskMeta.TaskID(), serviceName, clusterARN, name, status)
-	}
 	serviceID := makeServiceID(serviceName, taskMeta.TaskID())
-	return c.updateConsulHealthStatus(consulClient, constructCheckID(serviceID, name), clusterARN, status)
-}
 
-// handleHealthForDataplaneContainer takes care of the special handling needed for syncing
-// the health of consul-dataplane container. We register two checks (one for the service
-// and the other for proxy) when registering a typical service to the catalog. Updates
-// should also happen twice in such cases.
-func (c *Command) handleHealthForDataplaneContainer(consulClient *api.Client, taskID, serviceName, clusterARN, containerName, ecsHealthStatus string) error {
-	var checkID string
-	serviceID := makeServiceID(serviceName, taskID)
-	if c.config.IsGateway() {
-		checkID = constructCheckID(serviceID, containerName)
-		return c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
+	serviceCheck, err := c.stageCheck(serviceID, containerName, ecsHealthStatus)
+	if err != nil {
+		return nil, err
 	}
 
-	checkID = constructCheckID(serviceID, containerName)
-	err := c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
-	if err != nil {
-		return err
+	// Only the consul-dataplane container of a non-gateway service
+	// has a second (sidecar proxy) check to keep in sync.
+	if containerName != config.ConsulDataplaneContainerName || c.config.IsGateway() {
+		return api.HealthChecks{serviceCheck}, nil
 	}
 
 	proxySvcID, _ := makeProxySvcIDAndName(serviceID, "")
-	checkID = constructCheckID(proxySvcID, containerName)
-	return c.updateConsulHealthStatus(consulClient, checkID, clusterARN, ecsHealthStatus)
+	proxyCheck, err := c.stageCheck(proxySvcID, containerName, ecsHealthStatus)
+	if err != nil {
+		return nil, err
+	}
+	return api.HealthChecks{serviceCheck, proxyCheck}, nil
 }
 
-func (c *Command) updateConsulHealthStatus(consulClient *api.Client, checkID string, clusterARN string, ecsHealthStatus string) error {
-	consulHealthStatus := ecsHealthToConsulHealth(ecsHealthStatus)
-
+// stageCheck mutates the in-memory copy of the check for the given service and
+// container to reflect ecsHealthStatus and returns it. It performs no network
+// I/O; the caller registers the staged checks with Consul.
+func (c *Command) stageCheck(serviceID, containerName, ecsHealthStatus string) (*api.HealthCheck, error) {
+	checkID := constructCheckID(serviceID, containerName)
 	check, ok := c.checks[checkID]
 	if !ok {
-		return fmt.Errorf("unable to find check with ID %s", checkID)
+		return nil, fmt.Errorf("unable to find check with ID %s", checkID)
 	}
 
-	check.Status = consulHealthStatus
+	check.Status = ecsHealthToConsulHealth(ecsHealthStatus)
 	check.Output = fmt.Sprintf("ECS health status is %q for container %q", ecsHealthStatus, checkID)
-	c.checks[checkID] = check
+	return check, nil
+}
+
+// registerChecks writes the given health checks to the Consul catalog in a
+// single Catalog.Register call. Each check carries its own ServiceID, so checks
+// belonging to the service and the sidecar proxy can be registered together. It
+// is a no-op when checks is empty.
+func (c *Command) registerChecks(consulClient *api.Client, clusterARN string, checks api.HealthChecks) error {
+	if len(checks) == 0 {
+		return nil
+	}
 
 	updateCheckReq := &api.CatalogRegistration{
 		Node:           clusterARN,
 		SkipNodeUpdate: true,
-		Checks:         api.HealthChecks{check},
+		Checks:         checks,
 	}
 
 	_, err := consulClient.Catalog().Register(updateCheckReq, nil)

--- a/subcommand/health-sync/checks.go
+++ b/subcommand/health-sync/checks.go
@@ -77,6 +77,9 @@ func (c *Command) setChecksCritical(consulClient *api.Client, taskMeta awsutil.E
 			result = multierror.Append(result, err)
 			continue
 		}
+		if len(checks) == 0 {
+			continue
+		}
 		healthCheckBatch = append(healthCheckBatch, checks...)
 		stagedContainers = append(stagedContainers, containerName)
 	}
@@ -152,7 +155,9 @@ func (c *Command) syncChecks(consulClient *api.Client,
 				"err", err, "container", containerName)
 			continue
 		}
-
+		if len(checks) == 0 {
+			continue
+		}
 		healthCheckBatch = append(healthCheckBatch, checks...)
 		statusChangeBatch = append(statusChangeBatch, statusChange{
 			containerName:  containerName,
@@ -225,30 +230,42 @@ func computeOverallDataplaneHealth(resolvedStatuses map[string]string) string {
 //   - A gateway has a single registration (no sidecar proxy) with one
 //     consul-dataplane readiness check.
 //
-// As a result, the consul-dataplane container updates both the service check and
-// the sidecar proxy check, while every other container (and any gateway
-// container) updates a single service check.
+// As a result:
+//   - the consul-dataplane container of a typical service (non-gateway) maps to two checks:
+//     the service checks [serviceID-app + serviceID-consul-dataplane] and
+//     the sidecar proxy check [proxySvcID-consul-dataplane], kept in sync together;
+//   - the consul-dataplane container of a gateway service maps to a
+//     single service check [gwServiceID-consul-dataplane],
+//     because a gateway has no sidecar proxy registration; and
+//   - every other (application) container maps to a single service check [serviceID-app].
 func (c *Command) stageContainerHealthChecks(taskMeta awsutil.ECSTaskMeta, containerName, ecsHealthStatus string) (api.HealthChecks, error) {
 	serviceName := c.constructServiceName(taskMeta.Family)
 	serviceID := makeServiceID(serviceName, taskMeta.TaskID())
 
+	// Every container, regardless of type, has a check on the primary
+	// service (or gateway) registration.
 	serviceCheck, err := c.stageCheck(serviceID, containerName, ecsHealthStatus)
 	if err != nil {
 		return nil, err
 	}
 
-	// Only the consul-dataplane container of a non-gateway service
-	// has a second (sidecar proxy) check to keep in sync.
-	if containerName != config.ConsulDataplaneContainerName || c.config.IsGateway() {
-		return api.HealthChecks{serviceCheck}, nil
+	if containerName == config.ConsulDataplaneContainerName {
+		// A gateway has no sidecar proxy, so just the serviceCheck.
+		if c.config.IsGateway() {
+			return api.HealthChecks{serviceCheck}, nil
+		}
+
+		// A typical service has a sidecar proxy as well, so stage the proxyCheck too &
+		// return both serviceCheck and proxyCheck.
+		proxySvcID, _ := makeProxySvcIDAndName(serviceID, "")
+		proxyCheck, err := c.stageCheck(proxySvcID, containerName, ecsHealthStatus)
+		if err != nil {
+			return nil, err
+		}
+		return api.HealthChecks{serviceCheck, proxyCheck}, nil
 	}
 
-	proxySvcID, _ := makeProxySvcIDAndName(serviceID, "")
-	proxyCheck, err := c.stageCheck(proxySvcID, containerName, ecsHealthStatus)
-	if err != nil {
-		return nil, err
-	}
-	return api.HealthChecks{serviceCheck, proxyCheck}, nil
+	return api.HealthChecks{serviceCheck}, nil
 }
 
 // stageCheck mutates the in-memory copy of the check for the given service and
@@ -257,7 +274,7 @@ func (c *Command) stageContainerHealthChecks(taskMeta awsutil.ECSTaskMeta, conta
 func (c *Command) stageCheck(serviceID, containerName, ecsHealthStatus string) (*api.HealthCheck, error) {
 	checkID := constructCheckID(serviceID, containerName)
 	check, ok := c.checks[checkID]
-	if !ok {
+	if !ok || check == nil {
 		return nil, fmt.Errorf("unable to find check with ID %s", checkID)
 	}
 

--- a/subcommand/health-sync/checks_test.go
+++ b/subcommand/health-sync/checks_test.go
@@ -381,6 +381,210 @@ func TestSyncChecksAppBecomesUnhealthyMidOperation(t *testing.T) {
 	require.Equal(t, api.HealthPassing, proxyChecks[0].Status, "proxy check must recover to passing")
 }
 
+// TestSyncChecksBatchesRegisterInOneCall verifies that all of a tick's changed
+// checks are written by a single Catalog.Register. When the app and dataplane
+// containers both transition "" -> HEALTHY, the app service check, the dataplane
+// service check, and the dataplane proxy check must share one ModifyIndex,
+// proving they landed in a single atomic write.
+func TestSyncChecksBatchesRegisterInOneCall(t *testing.T) {
+	serviceName := "batch-register-svc"
+	proxyServiceName := serviceName + "-sidecar-proxy"
+	taskARN := "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+	appContainer := "app-container"
+
+	taskMeta := &awsutil.ECSTaskMeta{Cluster: "test", TaskARN: taskARN, Family: serviceName}
+
+	var currentTaskMetaResp atomic.Value
+	taskMeta.Containers = []awsutil.ECSTaskMetaContainer{
+		constructContainerResponse(config.ConsulDataplaneContainerName, string(types.HealthStatusHealthy)),
+		constructContainerResponse(appContainer, string(types.HealthStatusHealthy)),
+	}
+	s, err := constructTaskMetaResponseString(taskMeta)
+	require.NoError(t, err)
+	currentTaskMetaResp.Store(s)
+	testutil.TaskMetaServer(t, testutil.TaskMetaHandlerFn(t, func() string {
+		return currentTaskMetaResp.Load().(string)
+	}))
+
+	cmd, consulClient, clusterARN := setupSyncChecksCmd(t, serviceName, []string{appContainer}, taskMeta)
+	healthSyncContainers := []string{appContainer, config.ConsulDataplaneContainerName}
+	currentStatuses := make(map[string]string)
+
+	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer])
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[config.ConsulDataplaneContainerName])
+
+	serviceChecks, _, err := consulClient.Health().Checks(serviceName, nil)
+	require.NoError(t, err)
+	require.Len(t, serviceChecks, 2) // app service check + dataplane service check
+
+	proxyChecks, _, err := consulClient.Health().Checks(proxyServiceName, nil)
+	require.NoError(t, err)
+	require.Len(t, proxyChecks, 1) // dataplane proxy check
+
+	// A single atomic Catalog.Register commits at one Raft index, so every
+	// check it touched shares the same ModifyIndex.
+	idx := proxyChecks[0].ModifyIndex
+	require.Equal(t, api.HealthPassing, proxyChecks[0].Status)
+	for _, ch := range serviceChecks {
+		require.Equal(t, api.HealthPassing, ch.Status)
+		require.Equal(t, idx, ch.ModifyIndex,
+			"all of a tick's checks must be written in a single Catalog.Register (same ModifyIndex)")
+	}
+}
+
+// TestSyncChecksDataplaneFailsLeavesAppCheckUntouched verifies the asymmetry
+// between the two failure directions. When the consul-dataplane container
+// becomes UNHEALTHY while the app container stays HEALTHY, only the aggregate is
+// written: the dataplane service check and the dataplane proxy check go critical
+// (in a single atomic Catalog.Register), while the app's own check keeps its
+// PASSING status AND its ModifyIndex, proving it was skipped as unchanged.
+func TestSyncChecksDataplaneFailsLeavesAppCheckUntouched(t *testing.T) {
+	serviceName := "dp-fails-svc"
+	proxyServiceName := serviceName + "-sidecar-proxy"
+	taskARN := "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+	appContainer := "app-container"
+
+	taskMeta := &awsutil.ECSTaskMeta{Cluster: "test", TaskARN: taskARN, Family: serviceName}
+
+	var currentTaskMetaResp atomic.Value
+	// Start with everything healthy.
+	taskMeta.Containers = []awsutil.ECSTaskMetaContainer{
+		constructContainerResponse(config.ConsulDataplaneContainerName, string(types.HealthStatusHealthy)),
+		constructContainerResponse(appContainer, string(types.HealthStatusHealthy)),
+	}
+	s, err := constructTaskMetaResponseString(taskMeta)
+	require.NoError(t, err)
+	currentTaskMetaResp.Store(s)
+	testutil.TaskMetaServer(t, testutil.TaskMetaHandlerFn(t, func() string {
+		return currentTaskMetaResp.Load().(string)
+	}))
+
+	cmd, consulClient, clusterARN := setupSyncChecksCmd(t, serviceName, []string{appContainer}, taskMeta)
+	healthSyncContainers := []string{appContainer, config.ConsulDataplaneContainerName}
+	currentStatuses := make(map[string]string)
+
+	serviceID := makeServiceID(serviceName, taskMeta.TaskID())
+	appCheckID := constructCheckID(serviceID, appContainer)
+	dpCheckID := constructCheckID(serviceID, config.ConsulDataplaneContainerName)
+
+	serviceCheckByID := func(id string) *api.HealthCheck {
+		checks, _, err := consulClient.Health().Checks(serviceName, nil)
+		require.NoError(t, err)
+		for _, ch := range checks {
+			if ch.CheckID == id {
+				return ch
+			}
+		}
+		t.Fatalf("service check %s not found", id)
+		return nil
+	}
+	proxyCheck := func() *api.HealthCheck {
+		checks, _, err := consulClient.Health().Checks(proxyServiceName, nil)
+		require.NoError(t, err)
+		require.Len(t, checks, 1)
+		return checks[0]
+	}
+
+	// Tick 1: all healthy → app and dataplane checks passing.
+	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer])
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[config.ConsulDataplaneContainerName])
+
+	appAfterTick1 := serviceCheckByID(appCheckID)
+	require.Equal(t, api.HealthPassing, appAfterTick1.Status)
+	appIdxAfterTick1 := appAfterTick1.ModifyIndex
+
+	// Tick 2: only the consul-dataplane container becomes UNHEALTHY; app stays HEALTHY.
+	taskMeta.Containers = []awsutil.ECSTaskMetaContainer{
+		constructContainerResponse(config.ConsulDataplaneContainerName, string(types.HealthStatusUnhealthy)),
+		constructContainerResponse(appContainer, string(types.HealthStatusHealthy)),
+	}
+	s, err = constructTaskMetaResponseString(taskMeta)
+	require.NoError(t, err)
+	currentTaskMetaResp.Store(s)
+
+	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer],
+		"app's own status is unchanged")
+	require.Equal(t, string(types.HealthStatusUnhealthy), currentStatuses[config.ConsulDataplaneContainerName],
+		"aggregate goes critical because the dataplane container is unhealthy")
+
+	// The app check must be skipped: same status, same ModifyIndex.
+	appAfterTick2 := serviceCheckByID(appCheckID)
+	require.Equal(t, api.HealthPassing, appAfterTick2.Status,
+		"app check must remain passing when only the dataplane container fails")
+	require.Equal(t, appIdxAfterTick1, appAfterTick2.ModifyIndex,
+		"app check must NOT be rewritten when its status is unchanged")
+
+	// Only the two dataplane checks are written, and they share one ModifyIndex.
+	dpServiceCheck := serviceCheckByID(dpCheckID)
+	dpProxyCheck := proxyCheck()
+	require.Equal(t, api.HealthCritical, dpServiceCheck.Status)
+	require.Equal(t, api.HealthCritical, dpProxyCheck.Status)
+	require.Equal(t, dpServiceCheck.ModifyIndex, dpProxyCheck.ModifyIndex,
+		"the dataplane service and proxy checks must be written in a single atomic Catalog.Register")
+	require.Greater(t, dpServiceCheck.ModifyIndex, appIdxAfterTick1,
+		"the dataplane checks must advance while the app check stays put")
+}
+
+// TestSetChecksCriticalBatchesInOneCall covers the graceful-shutdown path:
+// setChecksCritical must mark every tracked container's check critical and write
+// them all in a single Catalog.Register. This is the method the SIGTERM handler
+// in realRun invokes; we call it directly (the signal wiring is not under test
+// here, only the logic it triggers).
+func TestSetChecksCriticalBatchesInOneCall(t *testing.T) {
+	serviceName := "set-critical-svc"
+	proxyServiceName := serviceName + "-sidecar-proxy"
+	taskARN := "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+	appContainer := "app-container"
+
+	taskMeta := &awsutil.ECSTaskMeta{Cluster: "test", TaskARN: taskARN, Family: serviceName}
+
+	var currentTaskMetaResp atomic.Value
+	taskMeta.Containers = []awsutil.ECSTaskMetaContainer{
+		constructContainerResponse(config.ConsulDataplaneContainerName, string(types.HealthStatusHealthy)),
+		constructContainerResponse(appContainer, string(types.HealthStatusHealthy)),
+	}
+	s, err := constructTaskMetaResponseString(taskMeta)
+	require.NoError(t, err)
+	currentTaskMetaResp.Store(s)
+	testutil.TaskMetaServer(t, testutil.TaskMetaHandlerFn(t, func() string {
+		return currentTaskMetaResp.Load().(string)
+	}))
+
+	cmd, consulClient, clusterARN := setupSyncChecksCmd(t, serviceName, []string{appContainer}, taskMeta)
+	healthSyncContainers := []string{appContainer, config.ConsulDataplaneContainerName}
+
+	// First drive everything to passing so the critical transition is observable.
+	currentStatuses := make(map[string]string)
+	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer])
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[config.ConsulDataplaneContainerName])
+
+	// Run the shutdown path directly (what the SIGTERM handler calls).
+	require.NoError(t, cmd.setChecksCritical(consulClient, *taskMeta, clusterARN, healthSyncContainers))
+
+	// Verify that all checks are critical and share one ModifyIndex.
+	serviceChecks, _, err := consulClient.Health().Checks(serviceName, nil)
+	require.NoError(t, err)
+	require.Len(t, serviceChecks, 2) // app service check + dataplane service check
+
+	proxyChecks, _, err := consulClient.Health().Checks(proxyServiceName, nil)
+	require.NoError(t, err)
+	require.Len(t, proxyChecks, 1) // dataplane proxy check
+
+	// Every check must be critical and share one ModifyIndex (single atomic write).
+	idx := proxyChecks[0].ModifyIndex
+	require.Equal(t, api.HealthCritical, proxyChecks[0].Status)
+	for _, ch := range serviceChecks {
+		require.Equal(t, api.HealthCritical, ch.Status,
+			"every container's check must be critical after setChecksCritical")
+		require.Equal(t, idx, ch.ModifyIndex,
+			"setChecksCritical must write all checks in a single Catalog.Register (same ModifyIndex)")
+	}
+}
+
 func TestComputeOverallDataplaneHealth(t *testing.T) {
 	healthy := string(types.HealthStatusHealthy)
 	unhealthy := string(types.HealthStatusUnhealthy)

--- a/subcommand/health-sync/checks_test.go
+++ b/subcommand/health-sync/checks_test.go
@@ -4,6 +4,7 @@
 package healthsync
 
 import (
+	"bytes"
 	"sync/atomic"
 	"testing"
 
@@ -116,6 +117,140 @@ func TestSyncChecksDataplaneDeltaCheck(t *testing.T) {
 	_, meta, err = consulClient.Health().Checks(proxyServiceName, nil)
 	require.NoError(t, err)
 	require.Equal(t, indexAfterTick1, meta.LastIndex, "no Consul write should occur when dataplane status is unchanged")
+}
+
+// TestSyncChecksRegisterFailureLeavesStatusesUnchanged verifies that when the
+// Catalog.Register write fails, syncChecks does not advance currentStatuses, so
+// the next tick is free to retry the same transition.
+func TestSyncChecksRegisterFailureLeavesStatusesUnchanged(t *testing.T) {
+	serviceName := "register-fail-svc"
+	proxyServiceName := serviceName + "-sidecar-proxy"
+	taskARN := "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+
+	taskMeta := &awsutil.ECSTaskMeta{Cluster: "test", TaskARN: taskARN, Family: serviceName}
+
+	var currentTaskMetaResp atomic.Value
+	taskMeta.Containers = []awsutil.ECSTaskMetaContainer{
+		constructContainerResponse(config.ConsulDataplaneContainerName, string(types.HealthStatusHealthy)),
+	}
+	s, err := constructTaskMetaResponseString(taskMeta)
+	require.NoError(t, err)
+	currentTaskMetaResp.Store(s)
+	testutil.TaskMetaServer(t, testutil.TaskMetaHandlerFn(t, func() string {
+		return currentTaskMetaResp.Load().(string)
+	}))
+
+	cmd, consulClient, clusterARN := setupSyncChecksCmd(t, serviceName, nil, taskMeta)
+	healthSyncContainers := []string{config.ConsulDataplaneContainerName}
+
+	// Two clients:
+	// consulClient is the reachable Consul used to set up and to
+	// observe what actually got committed;
+	// failingClient points at an address with nothing listening,
+	// so its Catalog.Register write fails.
+	failingClient, err := api.NewClient(&api.Config{Address: "127.0.0.1:1"})
+	require.NoError(t, err)
+
+	// Capture the catalog index before the failing tick so we can prove nothing
+	// was committed.
+	proxyChecksBefore, meta, err := consulClient.Health().Checks(proxyServiceName, nil)
+	require.NoError(t, err)
+	require.Len(t, proxyChecksBefore, 1)
+	idxBeforeFailingTick := meta.LastIndex
+	proxyModifyIdxBeforeFailingTick := proxyChecksBefore[0].ModifyIndex
+
+	// Failing tick: the write fails, so currentStatuses must not advance.
+	// Seed a stale prior status (UNHEALTHY) that differs from the desired
+	// HEALTHY, so the tick actually builds a non-empty healthCheckBatch and
+	// reaches the (failing) register step. Snapshot it so we can prove the map
+	// is byte-for-byte unchanged afterwards.
+	currentStatuses := map[string]string{
+		config.ConsulDataplaneContainerName: string(types.HealthStatusUnhealthy),
+	}
+	statusesBefore := make(map[string]string, len(currentStatuses))
+	for k, v := range currentStatuses {
+		statusesBefore[k] = v
+	}
+
+	updatedStatuses := cmd.syncChecks(failingClient, currentStatuses, clusterARN, healthSyncContainers)
+	require.Equal(t, statusesBefore, updatedStatuses,
+		"currentStatuses must be unchanged when the Consul write fails")
+
+	// Observable evidence: the reachable Consul confirms nothing was committed.
+	proxyChecksAfterFail, meta, err := consulClient.Health().Checks(proxyServiceName, nil)
+	require.NoError(t, err)
+	require.Len(t, proxyChecksAfterFail, 1)
+	require.Equal(t, idxBeforeFailingTick, meta.LastIndex,
+		"no Consul write should be committed when Catalog.Register fails")
+	require.Equal(t, proxyModifyIdxBeforeFailingTick, proxyChecksAfterFail[0].ModifyIndex,
+		"the dataplane check's ModifyIndex must not advance when the write fails")
+
+	// Recovery tick on the reachable client: the same UNHEALTHY -> HEALTHY
+	// transition now succeeds and is committed to Consul.
+	updatedStatuses = cmd.syncChecks(consulClient, updatedStatuses, clusterARN, healthSyncContainers)
+	require.Equal(t, string(types.HealthStatusHealthy), updatedStatuses[config.ConsulDataplaneContainerName])
+
+	proxyChecks, _, err := consulClient.Health().Checks(proxyServiceName, nil)
+	require.NoError(t, err)
+	require.Len(t, proxyChecks, 1)
+	require.Equal(t, api.HealthPassing, proxyChecks[0].Status,
+		"the retried tick must commit the dataplane check as passing")
+	require.Greater(t, proxyChecks[0].ModifyIndex, proxyModifyIdxBeforeFailingTick,
+		"the recovery write must advance the dataplane check's ModifyIndex")
+}
+
+// TestSyncChecksLogsOnlyOnCommittedWrite verifies the observable log evidence:
+// syncChecks emits one "container health check updated in Consul" line per
+// changed container ONLY after a write is committed to Consul, and logs nothing
+// on a delta-suppressed no-op tick.
+func TestSyncChecksLogsOnlyOnCommittedWrite(t *testing.T) {
+	serviceName := "log-evidence-svc"
+	taskARN := "arn:aws:ecs:us-east-1:123456789:task/test/abcdef"
+	appContainer := "app-container"
+
+	taskMeta := &awsutil.ECSTaskMeta{Cluster: "test", TaskARN: taskARN, Family: serviceName}
+
+	var currentTaskMetaResp atomic.Value
+	taskMeta.Containers = []awsutil.ECSTaskMetaContainer{
+		constructContainerResponse(config.ConsulDataplaneContainerName, string(types.HealthStatusHealthy)),
+		constructContainerResponse(appContainer, string(types.HealthStatusHealthy)),
+	}
+	s, err := constructTaskMetaResponseString(taskMeta)
+	require.NoError(t, err)
+	currentTaskMetaResp.Store(s)
+	testutil.TaskMetaServer(t, testutil.TaskMetaHandlerFn(t, func() string {
+		return currentTaskMetaResp.Load().(string)
+	}))
+
+	cmd, consulClient, clusterARN := setupSyncChecksCmd(t, serviceName, []string{appContainer}, taskMeta)
+	healthSyncContainers := []string{appContainer, config.ConsulDataplaneContainerName}
+
+	// Redirect the command's logger into a buffer so we can assert on the
+	// emitted log lines.
+	var logBuf bytes.Buffer
+	cmd.log = hclog.New(&hclog.LoggerOptions{Output: &logBuf, Level: hclog.Info})
+
+	currentStatuses := make(map[string]string)
+
+	// Tick 1: "" -> HEALTHY for both containers. The write is committed, so one
+	// log line per changed container must be emitted.
+	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	tick1Logs := logBuf.String()
+	require.Contains(t, tick1Logs, "container health check updated in Consul",
+		"a committed write must log the update")
+	require.Contains(t, tick1Logs, "container="+appContainer,
+		"the app container transition must be logged")
+	require.Contains(t, tick1Logs, "container="+config.ConsulDataplaneContainerName,
+		"the dataplane container transition must be logged")
+	require.Contains(t, tick1Logs, "status="+string(types.HealthStatusHealthy),
+		"the logged status must reflect the desired HEALTHY status")
+
+	// Tick 2: nothing changed, so the delta guard suppresses the write and no
+	// update line must be logged.
+	logBuf.Reset()
+	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	require.NotContains(t, logBuf.String(), "container health check updated in Consul",
+		"a delta-suppressed no-op tick must not log any update")
 }
 
 // TestSyncChecksDataplaneDoubleWriteWhenMissing verifies that when consul-dataplane
@@ -381,11 +516,14 @@ func TestSyncChecksAppBecomesUnhealthyMidOperation(t *testing.T) {
 	require.Equal(t, api.HealthPassing, proxyChecks[0].Status, "proxy check must recover to passing")
 }
 
-// TestSyncChecksBatchesRegisterInOneCall verifies that all of a tick's changed
-// checks are written by a single Catalog.Register. When the app and dataplane
-// containers both transition "" -> HEALTHY, the app service check, the dataplane
-// service check, and the dataplane proxy check must share one ModifyIndex,
-// proving they landed in a single atomic write.
+// TestSyncChecksBatchesRegisterInOneCall verifies three things:
+//  1. All of a tick's changed checks are written by a single Catalog.Register.
+//  2. When the app and dataplane containers both transition "" -> HEALTHY,
+//     the app service check, the dataplane service check, and
+//     the dataplane proxy check must share one ModifyIndex,
+//     proving they landed in a single atomic write.
+//  3. Fresh mesh-init catalog state before health-sync runs (all relevant checks
+//     exist and start CRITICAL),
 func TestSyncChecksBatchesRegisterInOneCall(t *testing.T) {
 	serviceName := "batch-register-svc"
 	proxyServiceName := serviceName + "-sidecar-proxy"
@@ -410,15 +548,51 @@ func TestSyncChecksBatchesRegisterInOneCall(t *testing.T) {
 	healthSyncContainers := []string{appContainer, config.ConsulDataplaneContainerName}
 	currentStatuses := make(map[string]string)
 
-	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
-	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer])
-	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[config.ConsulDataplaneContainerName])
+	// Fresh catalog state from mesh-init (before any health-sync tick):
+	// app + dataplane service checks plus dataplane proxy check are present
+	// and start as critical.
+	require.Len(t, cmd.checks, 3)
 
 	serviceChecks, _, err := consulClient.Health().Checks(serviceName, nil)
 	require.NoError(t, err)
 	require.Len(t, serviceChecks, 2) // app service check + dataplane service check
+	for _, ch := range serviceChecks {
+		require.Equal(t, api.HealthCritical, ch.Status,
+			"mesh-init should register service checks as critical before health-sync runs")
+	}
 
 	proxyChecks, _, err := consulClient.Health().Checks(proxyServiceName, nil)
+	require.NoError(t, err)
+	require.Len(t, proxyChecks, 1) // dataplane proxy check
+	require.Equal(t, api.HealthCritical, proxyChecks[0].Status,
+		"mesh-init should register the proxy check as critical before health-sync runs")
+
+	// Capture logs so we can confirm both changed containers are logged for the
+	// single committed write.
+	var logBuf bytes.Buffer
+	cmd.log = hclog.New(&hclog.LoggerOptions{Output: &logBuf, Level: hclog.Info})
+
+	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer])
+	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[config.ConsulDataplaneContainerName])
+
+	// Both containers transitioned "" -> HEALTHY in one tick, so each must be
+	// logged as updated once the write is committed.
+	logs := logBuf.String()
+	require.Contains(t, logs, "container health check updated in Consul",
+		"the committed write must log the update")
+	require.Contains(t, logs, "container="+appContainer,
+		"the app container transition must be logged")
+	require.Contains(t, logs, "container="+config.ConsulDataplaneContainerName,
+		"the dataplane container transition must be logged")
+	require.Contains(t, logs, "status="+string(types.HealthStatusHealthy),
+		"the logged status must reflect the desired HEALTHY status")
+
+	serviceChecks, _, err = consulClient.Health().Checks(serviceName, nil)
+	require.NoError(t, err)
+	require.Len(t, serviceChecks, 2) // app service check + dataplane service check
+
+	proxyChecks, _, err = consulClient.Health().Checks(proxyServiceName, nil)
 	require.NoError(t, err)
 	require.Len(t, proxyChecks, 1) // dataplane proxy check
 
@@ -464,6 +638,12 @@ func TestSyncChecksDataplaneFailsLeavesAppCheckUntouched(t *testing.T) {
 	healthSyncContainers := []string{appContainer, config.ConsulDataplaneContainerName}
 	currentStatuses := make(map[string]string)
 
+	// Capture logs so we can corroborate the ModifyIndex-based asymmetry with a
+	// second, independent signal: only the dataplane transition should be logged
+	// on tick 2, never the delta-skipped app container.
+	var logBuf bytes.Buffer
+	cmd.log = hclog.New(&hclog.LoggerOptions{Output: &logBuf, Level: hclog.Info})
+
 	serviceID := makeServiceID(serviceName, taskMeta.TaskID())
 	appCheckID := constructCheckID(serviceID, appContainer)
 	dpCheckID := constructCheckID(serviceID, config.ConsulDataplaneContainerName)
@@ -504,11 +684,25 @@ func TestSyncChecksDataplaneFailsLeavesAppCheckUntouched(t *testing.T) {
 	require.NoError(t, err)
 	currentTaskMetaResp.Store(s)
 
+	// Drop tick 1's log output so the assertions below only see tick 2.
+	logBuf.Reset()
 	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
 	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer],
 		"app's own status is unchanged")
 	require.Equal(t, string(types.HealthStatusUnhealthy), currentStatuses[config.ConsulDataplaneContainerName],
 		"aggregate goes critical because the dataplane container is unhealthy")
+
+	// Log evidence for the asymmetry: only the dataplane container's transition
+	// is logged; the delta-skipped app container is never mentioned.
+	tick2Logs := logBuf.String()
+	require.Contains(t, tick2Logs, "container health check updated in Consul",
+		"the dataplane transition must be logged")
+	require.Contains(t, tick2Logs, "container="+config.ConsulDataplaneContainerName,
+		"the dataplane container transition must be logged")
+	require.Contains(t, tick2Logs, "status="+string(types.HealthStatusUnhealthy),
+		"the logged status must reflect the dataplane going UNHEALTHY")
+	require.NotContains(t, tick2Logs, "container="+appContainer,
+		"the delta-skipped app container must NOT be logged")
 
 	// The app check must be skipped: same status, same ModifyIndex.
 	appAfterTick2 := serviceCheckByID(appCheckID)
@@ -562,8 +756,23 @@ func TestSetChecksCriticalBatchesInOneCall(t *testing.T) {
 	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[appContainer])
 	require.Equal(t, string(types.HealthStatusHealthy), currentStatuses[config.ConsulDataplaneContainerName])
 
+	// Capture only the shutdown-path logs (swap in a buffer logger after the
+	// initial sync so we don't pick up the sync's own log lines).
+	var logBuf bytes.Buffer
+	cmd.log = hclog.New(&hclog.LoggerOptions{Output: &logBuf, Level: hclog.Info})
+
 	// Run the shutdown path directly (what the SIGTERM handler calls).
 	require.NoError(t, cmd.setChecksCritical(consulClient, *taskMeta, clusterARN, healthSyncContainers))
+
+	// Log evidence: setChecksCritical logs one "set Consul health status to
+	// critical" line per tracked container, after the write succeeds.
+	criticalLogs := logBuf.String()
+	require.Contains(t, criticalLogs, "set Consul health status to critical",
+		"the shutdown path must log the critical transition")
+	require.Contains(t, criticalLogs, "container="+appContainer,
+		"the app container must be logged as set critical")
+	require.Contains(t, criticalLogs, "container="+config.ConsulDataplaneContainerName,
+		"the dataplane container must be logged as set critical")
 
 	// Verify that all checks are critical and share one ModifyIndex.
 	serviceChecks, _, err := consulClient.Health().Checks(serviceName, nil)
@@ -582,6 +791,43 @@ func TestSetChecksCriticalBatchesInOneCall(t *testing.T) {
 			"every container's check must be critical after setChecksCritical")
 		require.Equal(t, idx, ch.ModifyIndex,
 			"setChecksCritical must write all checks in a single Catalog.Register (same ModifyIndex)")
+	}
+}
+
+// TestStageCheckReturnsErrorWhenCheckMissingOrNil verifies both halves of
+// stageCheck's lookup guard:
+// 1) check ID exists but maps to nil, and
+// 2) check ID is missing from cmd.checks.
+func TestStageCheckReturnsErrorWhenCheckMissingOrNil(t *testing.T) {
+	serviceID := "test-service-id"
+	containerName := "app-container"
+	checkID := constructCheckID(serviceID, containerName)
+
+	tests := []struct {
+		name   string
+		checks map[string]*api.HealthCheck
+	}{
+		{
+			name: "check entry is nil",
+			checks: map[string]*api.HealthCheck{
+				checkID: nil,
+			},
+		},
+		{
+			name:   "check is missing",
+			checks: map[string]*api.HealthCheck{},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &Command{checks: tc.checks}
+
+			staged, err := cmd.stageCheck(serviceID, containerName, string(types.HealthStatusHealthy))
+			require.Nil(t, staged)
+			require.EqualError(t, err, "unable to find check with ID "+checkID)
+		})
 	}
 }
 

--- a/subcommand/health-sync/checks_test.go
+++ b/subcommand/health-sync/checks_test.go
@@ -246,9 +246,10 @@ func TestSyncChecksLogsOnlyOnCommittedWrite(t *testing.T) {
 		"the logged status must reflect the desired HEALTHY status")
 
 	// Tick 2: nothing changed, so the delta guard suppresses the write and no
-	// update line must be logged.
+	// update line must be logged. Reuse tick 1's currentStatuses (both HEALTHY)
+	// so this is a genuine delta-suppressed no-op; the return value is unused.
 	logBuf.Reset()
-	currentStatuses = cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
+	cmd.syncChecks(consulClient, currentStatuses, clusterARN, healthSyncContainers)
 	require.NotContains(t, logBuf.String(), "container health check updated in Consul",
 		"a delta-suppressed no-op tick must not log any update")
 }


### PR DESCRIPTION
## Changes proposed in this PR:
**health-sync: batch Consul check updates into a single atomic Catalog.Register**
_Extension of PR: [Fix health-sync logic](https://github.com/hashicorp/consul-ecs/pull/320)_

During consul-ecs to consul healthSync, previously each tick issued up to three separate `Catalog.Register` calls (the service check, the dataplane service check, and the dataplane proxy check), which could partially fail and leave the **service-side and proxy-side dataplane checks diverged**.  
Also, updating consul for each health check is an inefficient way.

**Refactored healthSync to write healthStatusUpdate delta atomically per tick:**
1. `syncChecks` and `setChecksCritical` to stage every changed check in memory and commit the whole tick in one `Catalog.Register`, so all of a tick's updates land at a single Raft index atomically.
2. `syncChecks` now truly follows **Gather state → Compute checks (Stage) → Update Consul (Register/Commit)** flow.

**Atomic failure handling:** on a failed CatalogRegistration (write to consul), the entire batch is dropped (atomic — nothing is committed) and `currentStatuses` is left untouched, so the next tick recomputes and retries the full set. There is never a partial commit to reconcile.

**The delta guard is preserved:** only checks whose status changed since the last tick are written, and a tick with no changes performs no write. `currentStatuses` is committed only after a successful register so a failed write is retried on the next tick. For example, when only the dataplane fails, just the two dataplane checks are flipped together in one Register (sharing a single `ModifyIndex` that is ahead of the app check's `ModifyIndex`) while the unchanged app check stays out of the payload (its `ModifyIndex` is untouched) — giving both atomicity (no partial/inconsistent writes) and no redundant writes (only changed checks are sent).

**No change to health evaluation:** `computeOverallDataplaneHealth` (the whole-task aggregate that drives the dataplane/proxy checks) is untouched. Only how checks are written changed, not what status they get — the blast radius is the write path only.

Also:
- split `writeContainerHealth`/`handleHealthForDataplaneContainer`/`updateConsulHealthStatus` into `stageContainerHealthChecks` + `stageCheck` (in-memory staging) and `registerChecks` (the single write).
- log one line per changed container, only after the write succeeds.
- add unit tests for the atomic batched write, the app/dataplane failure asymmetry, and the setChecksCritical shutdown path.

### Test Setup:
Single ECS task with consul-dataplane, health-sync, mesh-init, and an nginx app container on Consul 1.22.0; consul-ecs image built from this branch's HEAD and pushed to ECR and verified the `ModifyIndex` registered service when its status toggles.

### How I've tested this PR:
1. Unit testcases (All Passed).
2. Integration test with consul using above setup.

Integration test result:

```
# RUNNING: validate_deployment
# Waits for the ECS service to stabilize and asserts test-service is registered in Consul with passing checks.
>>> validate_deployment: PASS

## RUNNING: test_service_and_proxy_registered
# Asserts both test-service and test-service-sidecar-proxy catalog entries are registered after a task starts by mesh-init.
>>> test_service_and_proxy_registered: PASS

## RUNNING: test_bug1_no_redundant_writes
# Delta guard: while health status is stable, no Catalog.Register is issued (proxy check ModifyIndex does not advance across multiple ticks).
>>> test_bug1_no_redundant_writes: PASS

## RUNNING: test_bug2_missing_container_health
# Asserts the proxy check is CRITICAL while the app container health is not yet reported (no premature passing during startup).
>>> test_bug2_missing_container_health: PASS

## RUNNING: test_app_unhealthy_marks_proxy_critical
# When the app container goes UNHEALTHY, health-sync propagates it to the proxy check (proxy goes critical), and recovers to passing once the app is healthy again.
>>> test_app_unhealthy_marks_proxy_critical: PASS

## RUNNING: test_status_change_triggers_write
# A genuine UNHEALTHY→HEALTHY transition produces exactly one Register write (ModifyIndex advances once) and
 then stays stable — the change is written, redundant writes are not.
>>> test_status_change_triggers_write: PASS

## RUNNING: test_atomic_batched_register
# Core of this PR: all checks that change in one tick are committed in a single atomic Consul Register (they share one 
ModifyIndex), unchanged ticks write nothing, and a dataplane-only failure flips just the two dataplane checks together while
the app check stays out of the payload (its ModifyIndex is untouched) — proving no partial/inconsistent writes (atomicity)
and no redundant writes (only changed checks are sent).
>>> test_atomic_batched_register: PASS

## RUNNING: test_graceful_shutdown_deregisters
# On graceful shutdown (SIGTERM), setChecksCritical marks all checks critical, then both test-service and test-service-sidecar-proxy are deregistered from the Consul catalog.
>>> test_graceful_shutdown_deregisters: PASS
```

### Consul does honor multiple checks as part of single catalog registration
It converts single health check into a slice supporting both single and multiple checks for catalog registration [See code ref](https://github.com/hashicorp/consul/blob/52d5a78d0a4f570d9f55cf454cbc01ec41ba3cd2/agent/consul/catalog_endpoint.go#L108).
Also, attached the integration test bw consul and consul-ecs logs below.

```
	// Move the old format single check into the slice, and fixup IDs.
	if args.Check != nil {
		args.Checks = append(args.Checks, args.Check)
		args.Check = nil
	}
	for _, check := range args.Checks {
		if check.Node == "" {
			check.Node = args.Node
		}
		checkPreApply(check)

		// Populate check type for cases when a check is registered in the catalog directly
		// and not via anti-entropy
		if check.Type == "" {
			chkType := check.CheckType()
			check.Type = chkType.Type()
		}
	}
```

Integration test b/w consul and consul-ecs logs:

New setup with consul health check api + service reachability check (with 2 services- test-service and client-service):
[test_atomic_batched_register_dumps3.log](https://github.com/user-attachments/files/29287738/test_atomic_batched_register_dumps3.log)
[test_atomic_batched_register.sh](https://github.com/user-attachments/files/29287739/test_atomic_batched_register.sh)

Old setup only with consul health check api:
[test_atomic_batched_register_dumps.log](https://github.com/user-attachments/files/29283071/test_atomic_batched_register_dumps.log)
[test_atomic_batched_register.sh](https://github.com/user-attachments/files/29283072/test_atomic_batched_register.sh)
