### PR TITLE
Prepare 0.10.0

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,6 +5,17 @@ container {
 	dependencies = true
 	alpine_secdb = true
 	secrets      = true
+
+	triage {
+		suppress {
+			vulnerabilities = [
+				"CVE-2025-30258", // Alpine Linux's Security Issue Tracker in gnupg@2.4.9-r0:
+				// 2.4.x is the stable version of gnupg and the latest is 2.4.9 which is not affected by the vulnerability
+				// according to NVD - CVE-2025-30258, but our scanner is still flagging it. Hence suppressing it for now.
+				// Impact: gnupg is used only to verify signatures and is not exploitable in this context.
+			]
+		}
+	}
 }
 
 binary {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Unreleased
+## 0.10.0 (July 9, 2026)
 SECURITY
 * Upgrade `golang.org/x/crypto`, `golang.org/x/net`, and `golang.org/x/sys` to address CVEs in transitive dependencies. [[GH-345](https://github.com/hashicorp/consul-ecs/pull/345)]
 * Update `go-discover` to `v1.3.0` in Dockerfile to mitigate CVEs in dependencies. [[GH-348](https://github.com/hashicorp/consul-ecs/pull/348)]
+* Update Dockerfile to use Alpine 3.24 to mitigate multiple vulnerable packages including curl, libcrypt and others identified by security scan ([CVE-2026-41989] and related CVEs)
 
 FEATURES
 * Add `consecutive5xx`, `enforcingConsecutiveGatewayFailure`, and `maxEjectionPercent` fields to the outlier detection configuration schema, enabling gateway failure detection and fine-grained ejection percentage control for passive health checks. [[GH-321](https://github.com/hashicorp/consul-ecs/pull/321)]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 FROM golang:1.26.4-alpine AS go-discover
 RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@v1.3.0
 
-FROM docker.mirror.hashicorp.services/alpine:3.23 AS release-default
+FROM docker.mirror.hashicorp.services/alpine:3.24 AS release-default
 
 ARG BIN_NAME=consul-ecs
 ARG PRODUCT_VERSION

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
## Changes proposed in this PR:
- Upgraded alpine base image to 3.24 to fix CVEs related to libcrypt and curl
- Suppressed vulnerability CVE-2025-30258 related to gnupg
- Removed pre-release marker for final release
- Added changelog for release

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
