### PR TITLE
updated consul version to 2.0.1 for acceptance tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ env:
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
   # Latest CE version, also present in the test matrix below — used by unit-tests-coverage.
   # ENT variants need CONSUL_LICENSE and cannot be used in the coverage job.
-  CONSUL_CE_VERSION: "2.0.2"
+  CONSUL_CE_VERSION: "2.0.1"
 
 jobs:
   get-go-version:
@@ -54,8 +54,8 @@ jobs:
         consul-version:
           - 1.22.7
           - 1.22.8+ent
-          - 2.0.2
-          - 2.0.2+ent
+          - 2.0.1
+          - 2.0.1+ent
     env:
       TEST_RESULTS_DIR: /tmp/test-results
       GOTESTSUM_VERSION: 1.8.2


### PR DESCRIPTION
## Changes proposed in this PR:
- updated consul version back to 2.0.1 for acceptance tests so that it can be used as default version in terraform-aws-consul-ecs along with dataplane 2.0.1
-

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
