### PR TITLE
Migrate FIPS builds from FIPS 140-2 to FIPS 140-3

### DIFF
--- a/.github/containers/ubuntu/fips-build-Dockerfile
+++ b/.github/containers/ubuntu/fips-build-Dockerfile
@@ -18,12 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils \
     zip
 
-# Conditionally install cross-compiler for arm64 only
-RUN if [ "$GOARCH" = "arm64" ]; then \
-      apt-get update && \
-      apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu; \
-    fi
-
 # Install Go
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /opt -zxv
 
@@ -42,12 +36,10 @@ WORKDIR /build
 # Copy source code into container
 COPY . /build
 
-# Build the FIPS-enabled binary for the target arch
+# Build the FIPS 140-3 binary for the target arch using the pure-Go in-tree Go
+# Cryptographic Module. GOFIPS140=v1.0.0 pins the CMVP-validated module (Certificate #5247).
+# CGO_ENABLED=0 means no cgo and no cross-compiler is needed for arm64.
 RUN cd /build && \
     /opt/go/bin/go version && \
     /opt/go/bin/go env && \
-    if [ "$GOARCH" = "arm64" ]; then \
-      env GOOS=linux GOARCH=arm64 CGO_ENABLED=1 GOEXPERIMENT=boringcrypto CC=aarch64-linux-gnu-gcc /opt/go/bin/go build -tags="$GO_TAGS" -ldflags="$LDFLAGS" -o /bin/$BIN_NAME .; \
-    else \
-      env GOOS=linux GOARCH=amd64 CGO_ENABLED=1 GOEXPERIMENT=boringcrypto /opt/go/bin/go build -tags="$GO_TAGS" -ldflags="$LDFLAGS" -o /bin/$BIN_NAME .; \
-    fi
+    env GOOS=linux GOARCH=$GOARCH CGO_ENABLED=0 GOFIPS140=v1.0.0 /opt/go/bin/go build -tags="$GO_TAGS" -ldflags="$LDFLAGS" -o /bin/$BIN_NAME .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,23 +68,18 @@ jobs:
           - {goos: "linux", goarch: "arm64"}
           - {goos: "linux", goarch: "386"}
           - {goos: "linux", goarch: "amd64"}
-          - {goos: "linux", goarch: "arm64", gotags: "fips", env: "CGO_ENABLED=1 GOEXPERIMENT=boringcrypto CC=aarch64-linux-gnu-gcc", fips: "+fips1402"}
-          - {goos: "linux", goarch: "amd64", gotags: "fips", env: "CGO_ENABLED=1 GOEXPERIMENT=boringcrypto", fips: "+fips1402"}
+          - {goos: "linux", goarch: "arm64", gotags: "fips", env: "GOFIPS140=v1.0.0", fips: "+fips1403"}
+          - {goos: "linux", goarch: "amd64", gotags: "fips", env: "GOFIPS140=v1.0.0", fips: "+fips1403"}
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} ${{ matrix.fips }} build
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup go
-        if: ${{ !(matrix.gotags == 'fips') }}
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - name: Set up QEMU for cross-arch builds (only for Docker)
-        if: ${{ matrix.gotags == 'fips' }}
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # V3.6.0
       - name: Build (runner)
-        if: ${{ !(matrix.gotags == 'fips') }}
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -100,34 +95,6 @@ jobs:
             bin=$(find dist -name consul-ecs)
             $bin version
           fi
-      - name: Build FIPS (Docker)
-        # NOTE: We use an older Ubuntu image for FIPS builds to ensure the resulting CGO-linked binary
-        # is compatible with a wide range of Linux hosts, especially for arm64. Newer Ubuntu versions
-        # may use a newer glibc, which can break mesh-init or remote execution scenarios where the binary
-        # is copied to a host with an older glibc. See: https://groups.google.com/g/pat-users/c/dawmYvN4DBc
-        if: ${{ matrix.gotags == 'fips' }}
-        run: |
-          set -e
-          # No global cross-compiler install here; handled in Dockerfile
-          mkdir -p dist/linux/${{ matrix.goarch }} out
-          # Build the FIPS binary using Ubuntu-based Dockerfile for glibc compatibility
-          docker buildx build \
-            --platform linux/${{ matrix.goarch }} \
-            --build-arg GO_VERSION=${{ needs.get-go-version.outputs.go-version }} \
-            --build-arg GO_TAGS=fips \
-            --build-arg LDFLAGS="${{ needs.get-product-version.outputs.ldflags }}" \
-            --build-arg BIN_NAME=consul-ecs \
-            --build-arg GOARCH=${{ matrix.goarch }} \
-            -f .github/containers/ubuntu/fips-build-Dockerfile \
-            -t consul-ecs-fips-${{ matrix.goarch }}:build .
-          # Extract the binary from the image for packaging (match Dockerfile path)
-          id=$(docker create consul-ecs-fips-${{ matrix.goarch }}:build)
-          docker cp $id:/bin/consul-ecs ./consul-ecs
-          docker rm $id
-          mkdir -p dist/linux/${{ matrix.goarch }}
-          mv consul-ecs dist/linux/${{ matrix.goarch }}/consul-ecs
-          cp LICENSE dist/LICENSE.txt
-          zip -j out/consul-ecs_${{ needs.get-product-version.outputs.product-version }}+fips1402_linux_${{ matrix.goarch }}.zip dist/linux/${{ matrix.goarch }}/consul-ecs dist/LICENSE.txt
       - name: Upload artifact (binary)
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
@@ -184,7 +151,7 @@ jobs:
           - { arch: "amd64" }
     env:
       repo: ${{ github.event.repository.name }}
-      version: ${{ needs.get-product-version.outputs.product-version }}+fips1402
+      version: ${{ needs.get-product-version.outputs.product-version }}+fips1403
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/fips-test.yml
+++ b/.github/workflows/fips-test.yml
@@ -1,0 +1,141 @@
+name: fips-test
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    branches:
+      - main
+
+# cancel existing runs of the same workflow on the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
+  # Consul CE version used to back the unit tests. FIPS here refers to the
+  # consul-ecs binary under test; the Consul agent it talks to need not be FIPS.
+  CONSUL_CE_VERSION: "2.0.1"
+  # Pinned CMVP-validated Go Cryptographic Module (Certificate #5247).
+  GOFIPS140_VERSION: "v1.0.0"
+
+jobs:
+  get-go-version:
+    uses: ./.github/workflows/reusable-get-go-version.yml
+
+  # Native-module lane: recompile and run the full unit suite against the in-tree
+  # Go Cryptographic Module in FIPS Mode (permissive). Replaces the old
+  # GOEXPERIMENT=boringcrypto premise; pure Go means no cgo/cross-compiler.
+  fips-unit-test:
+    needs:
+      - get-go-version
+    name: fips unit test (native module, fips140=on)
+    runs-on: ubuntu-22.04
+    env:
+      CGO_ENABLED: "0"
+      GOFIPS140: v1.0.0
+      GODEBUG: fips140=on
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - name: Install Consul
+        shell: bash
+        run: |
+          CONSUL_VERSION="${{ env.CONSUL_CE_VERSION }}"
+          curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
+          unzip -o "consul_${CONSUL_VERSION}_linux_amd64.zip" consul -d /usr/local/bin
+          rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
+          consul version
+      - name: Test (fips tag, native module)
+        run: |
+          PACKAGE_NAMES=$(go list ./... | grep -v 'mocks\|hack\|testing' | tr '\n' ' ')
+          echo "Testing $(echo $PACKAGE_NAMES | wc -w) packages under FIPS 140-3"
+          go test -tags=fips $PACKAGE_NAMES
+
+  # Strict Approved-Only lane: any use of a non-approved algorithm errors instead
+  # of silently degrading. Scoped to deterministic crypto-relevant packages; the
+  # full suite is not run here because some tests perform external TLS I/O with
+  # non-approved curves (e.g. X25519), which is not shipped behavior.
+  fips-strict:
+    needs:
+      - get-go-version
+    name: fips strict (fips140=only)
+    runs-on: ubuntu-22.04
+    env:
+      CGO_ENABLED: "0"
+      GOFIPS140: v1.0.0
+      GODEBUG: fips140=only
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - name: Test (strict, approved-only)
+        run: |
+          go test -tags=fips ./version/... ./internal/...
+
+  # Module-in-use assertion: prove the built artifact records the pinned module
+  # and bakes fips140=on, and that the version metadata reads +fips1403. Pure Go
+  # lets us build arm64 with no cross-compiler; arm64 is build/verify-only here
+  # since the runner is amd64.
+  fips-verify-module:
+    needs:
+      - get-go-version
+    name: fips verify module (${{ matrix.goarch }})
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        goarch: ["amd64", "arm64"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - name: Build FIPS binary
+        env:
+          GOOS: linux
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+          GOFIPS140: v1.0.0
+        run: |
+          go build -tags=fips -o consul-ecs-fips .
+      - name: Assert pinned module and baked GODEBUG
+        run: |
+          set -euo pipefail
+          info=$(go version -m consul-ecs-fips)
+          echo "$info" | grep -F "GOFIPS140=${GOFIPS140_VERSION}" || \
+            { echo "FAIL: binary does not record GOFIPS140=${GOFIPS140_VERSION}"; exit 1; }
+          echo "$info" | grep -F "DefaultGODEBUG=fips140=on" || \
+            { echo "FAIL: binary does not bake DefaultGODEBUG=fips140=on"; exit 1; }
+          echo "PASS: module pin and fips140=on recorded in binary"
+      - name: Assert +fips1403 version metadata
+        if: ${{ matrix.goarch == 'amd64' }}
+        run: |
+          set -euo pipefail
+          out=$(./consul-ecs-fips version)
+          echo "version output: $out"
+          echo "$out" | grep -F "+fips1403" || \
+            { echo "FAIL: version does not carry +fips1403"; exit 1; }
+          echo "PASS: version reports +fips1403"
+
+  # Aggregator for branch protection: fans in all FIPS jobs.
+  fips-test-success:
+    needs:
+      - fips-unit-test
+      - fips-strict
+      - fips-verify-module
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - name: evaluate upstream job results
+        run: |
+          if printf '${{ toJSON(needs) }}' | grep -E -i '"result": "(failure|cancelled)"'; then
+            printf "FIPS tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
+            exit 1
+          fi

--- a/.release/consul-ecs-artifacts.hcl
+++ b/.release/consul-ecs-artifacts.hcl
@@ -4,8 +4,8 @@
 schema = 1
 artifacts {
   zip = [
-    "consul-ecs_${version}+fips1402_linux_amd64.zip",
-    "consul-ecs_${version}+fips1402_linux_arm64.zip",
+    "consul-ecs_${version}+fips1403_linux_amd64.zip",
+    "consul-ecs_${version}+fips1403_linux_arm64.zip",
     "consul-ecs_${version}_linux_386.zip",
     "consul-ecs_${version}_linux_amd64.zip",
     "consul-ecs_${version}_linux_arm.zip",
@@ -20,9 +20,9 @@ artifacts {
     "consul-ecs_release-default_linux_arm64_${version}_${commit_sha}.docker.tar",
     "consul-ecs_release-default_linux_arm_${version}_${commit_sha}.docker.dev.tar",
     "consul-ecs_release-default_linux_arm_${version}_${commit_sha}.docker.tar",
-    "consul-ecs_release-fips-default_linux_amd64_${version}+fips1402_${commit_sha}.docker.dev.tar",
-    "consul-ecs_release-fips-default_linux_amd64_${version}+fips1402_${commit_sha}.docker.tar",
-    "consul-ecs_release-fips-default_linux_arm64_${version}+fips1402_${commit_sha}.docker.dev.tar",
-    "consul-ecs_release-fips-default_linux_arm64_${version}+fips1402_${commit_sha}.docker.tar",
+    "consul-ecs_release-fips-default_linux_amd64_${version}+fips1403_${commit_sha}.docker.dev.tar",
+    "consul-ecs_release-fips-default_linux_amd64_${version}+fips1403_${commit_sha}.docker.tar",
+    "consul-ecs_release-fips-default_linux_arm64_${version}+fips1403_${commit_sha}.docker.dev.tar",
+    "consul-ecs_release-fips-default_linux_arm64_${version}+fips1403_${commit_sha}.docker.tar",
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+IMPROVEMENTS
+* FIPS: Migrate FIPS builds from FIPS 140-2 (BoringCrypto via `GOEXPERIMENT=boringcrypto`/cgo) to FIPS 140-3 using the in-tree Go Cryptographic Module. FIPS builds now use `CGO_ENABLED=0 GOFIPS140=v1.0.0` (CMVP Certificate #5247) with `GODEBUG=fips140=on` baked into the binary, dropping cgo and the arm64 cross-compiler. The build metadata suffix changes from `+fips1402` to `+fips1403`.
+
 ## 0.10.0 (July 9, 2026)
 SECURITY
 * Upgrade `golang.org/x/crypto`, `golang.org/x/net`, and `golang.org/x/sys` to address CVEs in transitive dependencies. [[GH-345](https://github.com/hashicorp/consul-ecs/pull/345)]

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,11 @@ dev: dist
 	GOARCH=$(ARCH) GOOS=$(OS) go build -ldflags "$(LD_FLAGS)" -o $(BIN)
 .PHONY: dev
 
+# FIPS 140-3 build: pure-Go in-tree Go Cryptographic Module (no cgo, no boringcrypto).
+# GOFIPS140=v1.0.0 pins the CMVP-validated module (Certificate #5247).
+# Runtime activation is baked into the binary via //go:debug fips140=on (see fips140.go).
 dev-fips: dist
-	GOARCH=$(ARCH) GOOS=$(OS) CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -tags=fips  -ldflags "$(LD_FLAGS)" -o $(BIN)
+	GOARCH=$(ARCH) GOOS=$(OS) CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -tags=fips -ldflags "$(LD_FLAGS)" -o $(BIN)
 .PHONY: dev-fips
 
 # Docker Stuff.

--- a/fips140.go
+++ b/fips140.go
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build fips
+
+//go:debug fips140=on
+
+package main
+
+// This file only exists for FIPS builds. The //go:debug fips140=on directive
+// bakes FIPS Mode activation into the binary so operators do not need to set
+// GODEBUG=fips140=on at run time. The Go Cryptographic Module runs its
+// pre-operational and conditional self-tests on initialization and aborts the
+// process on failure (fail-closed).

--- a/version/fips_build.go
+++ b/version/fips_build.go
@@ -5,12 +5,18 @@
 
 package version
 
-// This validates during compilation that we are being built with a FIPS enabled go toolchain
-import (
-	_ "crypto/tls/fipsonly"
-)
+// consul-ecs FIPS builds link against the in-tree Go Cryptographic Module
+// (FIPS 140-3), selected at build time with GOFIPS140 and activated at run time
+// with GODEBUG=fips140=on (baked into the binary via //go:debug fips140=on in
+// fips140.go). In FIPS Mode the module constrains the security-relevant
+// operations (including restricting TLS to FIPS-approved settings) and runs its
+// pre-operational and conditional self-tests, aborting the process on failure.
+//
+// Note: unlike the former FIPS 140-2 boringcrypto build, crypto/tls/fipsonly is
+// intentionally not imported here — that package only exists under
+// GOEXPERIMENT=boringcrypto. TLS restriction is provided by the native module.
 
-// IsFIPS returns true if consul-ecs is operating in FIPS-140-2 mode.
+// IsFIPS returns true if consul-ecs is operating in FIPS-140-3 mode.
 func IsFIPS() bool {
 	return true
 }

--- a/version/fips_test.go
+++ b/version/fips_test.go
@@ -1,0 +1,32 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build fips
+
+package version
+
+import (
+	"crypto/fips140"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFIPSModuleActive asserts that a fips-tagged binary is actually running the
+// in-tree Go Cryptographic Module (FIPS 140-3). This closes the "we don't verify
+// the module" gap: it fails if the binary was not built/activated with the native
+// module (GOFIPS140 + GODEBUG=fips140=on).
+func TestFIPSModuleActive(t *testing.T) {
+	require.True(t, fips140.Enabled(), "expected FIPS 140-3 module to be active (build with GOFIPS140 and GODEBUG=fips140=on)")
+	require.True(t, IsFIPS(), "expected IsFIPS() to report true for a fips build")
+}
+
+// TestFIPSVersionSuffix asserts the human version carries the FIPS 140-3 build
+// metadata suffix.
+func TestFIPSVersionSuffix(t *testing.T) {
+	GitCommit = ""
+	VersionPrerelease = ""
+	require.True(t, strings.HasSuffix(GetHumanVersion(), "+fips1403"),
+		"expected +fips1403 suffix, got %q", GetHumanVersion())
+}

--- a/version/non_fips_build.go
+++ b/version/non_fips_build.go
@@ -5,7 +5,7 @@
 
 package version
 
-// IsFIPS returns true if consul-ecs is operating in FIPS-140-2 mode.
+// IsFIPS returns true if consul-ecs is operating in FIPS-140-3 mode.
 func IsFIPS() bool {
 	return false
 }

--- a/version/non_fips_build.go
+++ b/version/non_fips_build.go
@@ -5,7 +5,7 @@
 
 package version
 
-// IsFIPS returns true if consul-ecs is operating in FIPS-140-3 mode.
+// IsFIPS returns false if consul-ecs is operating in non FIPS-140-3 mode.
 func IsFIPS() bool {
 	return false
 }

--- a/version/version.go
+++ b/version/version.go
@@ -34,7 +34,7 @@ func GetHumanVersion() string {
 	}
 
 	if IsFIPS() {
-		version += "+fips1402"
+		version += "+fips1403"
 	}
 
 	if GitCommit != "" {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -10,6 +10,12 @@ import (
 )
 
 func TestVersion(t *testing.T) {
+	// FIPS builds append a build-metadata suffix to the version. The suffix is
+	// inserted after any prerelease marker and before the git commit.
+	fipsSuffix := ""
+	if IsFIPS() {
+		fipsSuffix = "+fips1403"
+	}
 	cases := map[string]struct {
 		commit     string
 		prerelease string
@@ -17,20 +23,20 @@ func TestVersion(t *testing.T) {
 		expVersion string
 	}{
 		"no commit and no prerelease": {
-			expVersion: "v" + Version,
+			expVersion: "v" + Version + fipsSuffix,
 		},
 		"commit but no prerelease": {
 			commit:     "asdf",
-			expVersion: "v" + Version + " (asdf)",
+			expVersion: "v" + Version + fipsSuffix + " (asdf)",
 		},
 		"prerelease but no commit": {
 			prerelease: "beta1",
-			expVersion: "v" + Version + "-beta1",
+			expVersion: "v" + Version + "-beta1" + fipsSuffix,
 		},
 		"commit and prerelease": {
 			commit:     "asdf",
 			prerelease: "beta1",
-			expVersion: "v" + Version + "-beta1 (asdf)",
+			expVersion: "v" + Version + "-beta1" + fipsSuffix + " (asdf)",
 		},
 	}
 	for name, c := range cases {


### PR DESCRIPTION
## Changes proposed in this PR:
- Swap the FIPS crypto backend from BoringCrypto (`GOEXPERIMENT=boringcrypto`, cgo) to the in-tree **Go Cryptographic Module (FIPS 140-3)**, selected with `GOFIPS140=v1.0.0` (CMVP Certificate #5247) and activated via `GODEBUG=fips140=on` baked into the binary (`//go:debug` in new `fips140.go`). Per RFC 0001 (Group A), this is a **parity effort** — same operator contract (`-fips` artifact, `fips` build tag), just a validated-module upgrade.
- Drop `crypto/tls/fipsonly` from `version/fips_build.go` (it only compiles under `GOEXPERIMENT=boringcrypto`; TLS restriction is enforced at runtime by `fips140=on`). Update FIPS wording to 140-3.
- Rename build metadata / artifacts / images `fips1402` → `fips1403` (`version/version.go`, `.github/workflows/build.yml`, `.release/consul-ecs-artifacts.hcl`).
- Simplify the build: `CGO_ENABLED=0`, drop the arm64 cross-compiler and Docker/QEMU FIPS path — FIPS now builds on the runner as pure Go (`Makefile`, `build.yml`, `fips-build-Dockerfile`).
- Add FIPS test coverage: `version/fips_test.go` (module-active + `+fips1403` assertions), make `TestVersion` FIPS-aware, and a new `.github/workflows/fips-test.yml` lane.

## How I've tested this PR:
Locally verified in all three modes:
- Non-FIPS: `go build ./...`, `go test ./version/...`
- FIPS permissive: `CGO_ENABLED=0 GOFIPS140=v1.0.0 GODEBUG=fips140=on go test -tags=fips ./version/...`
- FIPS strict: `CGO_ENABLED=0 GOFIPS140=v1.0.0 GODEBUG=fips140=only go test -tags=fips ./version/... ./internal/...`

Confirmed the built binary records the pin and activation: `go version -m` shows `GOFIPS140=v1.0.0` and `DefaultGODEBUG=fips140=on`, and `consul-ecs version` reports `v0.10.0-dev+fips1403`.

## How I expect reviewers to test this PR:
- Run the new `fips-test` workflow (native-module unit lane, strict `fips140=only` lane, and the module-in-use verification job for amd64/arm64).
- Build a FIPS artifact and confirm `go version -m <binary>` records `GOFIPS140=v1.0.0` + `DefaultGODEBUG=fips140=on`, and that the version string carries `+fips1403`.

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

  Migration of the FIPS-enabled builds to a FIPS 140-3 validated cryptographic module, tracked by RFC 0001, as FIPS 140-2 certificates move to the CMVP historical list.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Revert is limited to reverting this PR; `fips1402` artifacts for in-support legacy releases are unaffected. No data migration is involved.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Upgrades the FIPS cryptographic module from 140-2 (BoringCrypto) to a 140-3 validated module (Go Cryptographic Module v1.0.0, CMVP #5247) with module-owned, fail-closed self-tests. TLS restriction moves from the compile-time `crypto/tls/fipsonly` import to runtime enforcement via `GODEBUG=fips140=on`.